### PR TITLE
Fix live status counts when Alive values are strings

### DIFF
--- a/actions/scanning.py
+++ b/actions/scanning.py
@@ -455,7 +455,12 @@ class NetworkScanner:
             Calculates the total number of open ports for alive hosts.
             """
             try:
-                alive_df = self.df[self.df['Alive'] == 1].copy()
+                # The Alive column is persisted as strings ("1"/"0").
+                # Convert to string and compare against "1" to ensure
+                # compatibility with legacy data written by earlier
+                # components.
+                alive_mask = self.df['Alive'].astype(str).str.strip() == '1'
+                alive_df = self.df[alive_mask].copy()
                 alive_df.loc[:, 'Ports'] = alive_df['Ports'].fillna('')
                 alive_df.loc[:, 'Port Count'] = alive_df['Ports'].apply(lambda x: len(x.split(';')) if x else 0)
                 self.total_open_ports = alive_df['Port Count'].sum()
@@ -468,8 +473,9 @@ class NetworkScanner:
             """
             try:
                 # self.all_known_hosts_count = self.df.shape[0] 
-                self.all_known_hosts_count = self.df[self.df['MAC Address'] != 'STANDALONE'].shape[0] 
-                self.alive_hosts_count = self.df[self.df['Alive'] == 1].shape[0]
+                self.all_known_hosts_count = self.df[self.df['MAC Address'] != 'STANDALONE'].shape[0]
+                alive_mask = self.df['Alive'].astype(str).str.strip() == '1'
+                self.alive_hosts_count = self.df[alive_mask].shape[0]
             except Exception as e:
                 self.logger.error(f"Error in calculate_hosts_counts: {e}")
 

--- a/display.py
+++ b/display.py
@@ -132,7 +132,10 @@ class Display:
                     if os.path.exists(self.shared_data.netkbfile):
                         with open(self.shared_data.netkbfile, 'r') as file:
                             netkb_df = pd.read_csv(file)
-                            alive_macs = set(netkb_df[(netkb_df["Alive"] == 1) & (netkb_df["MAC Address"] != "STANDALONE")]["MAC Address"])
+                            alive_mask = netkb_df["Alive"].astype(str).str.strip() == '1'
+                            alive_macs = set(
+                                netkb_df[(alive_mask) & (netkb_df["MAC Address"] != "STANDALONE")]["MAC Address"]
+                            )
                     else:
                         alive_macs = set()
 


### PR DESCRIPTION
## Summary
- ensure live status calculations treat the Alive column as string-based flags
- update the e-paper vulnerability counter to honour Alive hosts marked with string values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905eae2529483248da56f68da0502cf