### PR TITLE
Expose level and points on modern dashboard

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -232,7 +232,7 @@
         <!-- Dashboard Tab -->
         <div id="dashboard-tab" class="tab-content">
             <!-- Stats Grid -->
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4 mb-8">
                 <!-- Targets Card -->
                 <div class="glass rounded-xl p-6 hover:scale-105 transition-transform">
                     <div class="flex items-center justify-between">
@@ -288,6 +288,38 @@
                         <div class="w-12 h-12 bg-yellow-500 bg-opacity-20 rounded-full flex items-center justify-center">
                             <svg class="w-6 h-6 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"></path>
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Level Card -->
+                <div class="glass rounded-xl p-6 hover:scale-105 transition-transform">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <p class="text-gray-400 text-sm">Level</p>
+                            <p id="level-count" class="text-3xl font-bold text-purple-400">0</p>
+                        </div>
+                        <div class="w-12 h-12 bg-purple-500 bg-opacity-20 rounded-full flex items-center justify-center">
+                            <svg class="w-6 h-6 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0v7"></path>
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Points Card -->
+                <div class="glass rounded-xl p-6 hover:scale-105 transition-transform">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <p class="text-gray-400 text-sm">Points</p>
+                            <p id="points-count" class="text-3xl font-bold text-amber-400">0</p>
+                        </div>
+                        <div class="w-12 h-12 bg-amber-500 bg-opacity-20 rounded-full flex items-center justify-center">
+                            <svg class="w-6 h-6 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-3.314 0-6 1.343-6 3s2.686 3 6 3 6-1.343 6-3-2.686-3-6-3z" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 11v2c0 1.657 2.686 3 6 3s6-1.343 6-3v-2" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 15v2c0 1.657 2.686 3 6 3s6-1.343 6-3v-2" />
                             </svg>
                         </div>
                     </div>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -1263,6 +1263,9 @@ function updateDashboardStatus(data) {
                 updateElement('port-count', stats.port_count || 0);
                 updateElement('vuln-count', stats.vulnerability_count || 0);
                 updateElement('cred-count', stats.credential_count || 0);
+                updateElement('level-count', stats.level || stats.levelnbr || 0);
+                const dashboardPoints = stats.points ?? stats.coins ?? 0;
+                updateElement('points-count', dashboardPoints);
             })
             .catch(() => {
                 // Fallback to WebSocket data if API fails
@@ -1270,6 +1273,9 @@ function updateDashboardStatus(data) {
                 updateElement('port-count', data.port_count || 0);
                 updateElement('vuln-count', data.vulnerability_count || 0);
                 updateElement('cred-count', data.credential_count || 0);
+                updateElement('level-count', data.level || data.levelnbr || 0);
+                const fallbackPoints = data.points ?? data.coins ?? 0;
+                updateElement('points-count', fallbackPoints);
             });
     } else {
         // Use WebSocket data if it has non-zero values
@@ -1277,6 +1283,9 @@ function updateDashboardStatus(data) {
         updateElement('port-count', data.port_count || 0);
         updateElement('vuln-count', data.vulnerability_count || 0);
         updateElement('cred-count', data.credential_count || 0);
+        updateElement('level-count', data.level || data.levelnbr || 0);
+        const realtimePoints = data.points ?? data.coins ?? 0;
+        updateElement('points-count', realtimePoints);
     }
     
     // Update status - use the actual e-paper display text

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -304,9 +304,15 @@ def sync_all_counts():
                     logger.debug("Updated livestatus file with synchronized counts")
             except Exception as e:
                 logger.warning(f"Could not update livestatus with all sync counts: {e}")
-        
+
+        try:
+            shared_data.update_stats()
+            logger.debug(f"Updated gamification stats - Level: {shared_data.levelnbr}, Points: {shared_data.coinnbr}")
+        except Exception as e:
+            logger.warning(f"Could not update gamification stats: {e}")
+
         logger.debug(f"Completed sync_all_counts() - Targets: {shared_data.targetnbr}, Ports: {shared_data.portnbr}, Vulns: {shared_data.vulnnbr}, Creds: {shared_data.crednbr}")
-        
+
     except Exception as e:
         logger.error(f"Error synchronizing all counts: {e}")
 
@@ -656,6 +662,9 @@ def get_status():
             'vulnerability_count': safe_int(shared_data.vulnnbr),
             'credential_count': safe_int(shared_data.crednbr),
             'data_count': safe_int(shared_data.datanbr),
+            'level': safe_int(shared_data.levelnbr),
+            'points': safe_int(shared_data.coinnbr),
+            'coins': safe_int(shared_data.coinnbr),
             'wifi_connected': safe_bool(shared_data.wifi_connected),
             'bluetooth_active': safe_bool(shared_data.bluetooth_active),
             'pan_connected': safe_bool(shared_data.pan_connected),
@@ -2317,6 +2326,11 @@ def handle_activity_request():
 
 def get_current_status():
     """Get current status data"""
+    try:
+        shared_data.update_stats()
+    except Exception as e:
+        logger.debug(f"Unable to refresh gamification stats: {e}")
+
     return {
         'ragnar_status': safe_str(shared_data.ragnarstatustext),
         'ragnar_status2': safe_str(shared_data.ragnarstatustext2),
@@ -2327,6 +2341,9 @@ def get_current_status():
         'vulnerability_count': safe_int(shared_data.vulnnbr),
         'credential_count': safe_int(shared_data.crednbr),
         'data_count': safe_int(shared_data.datanbr),
+        'level': safe_int(shared_data.levelnbr),
+        'points': safe_int(shared_data.coinnbr),
+        'coins': safe_int(shared_data.coinnbr),
         'wifi_connected': safe_bool(shared_data.wifi_connected),
         'bluetooth_active': safe_bool(shared_data.bluetooth_active),
         'pan_connected': safe_bool(shared_data.pan_connected),
@@ -3621,7 +3638,10 @@ def get_dashboard_stats():
             'target_count': safe_int(shared_data.targetnbr),
             'port_count': safe_int(shared_data.portnbr),
             'vulnerability_count': safe_int(shared_data.vulnnbr),
-            'credential_count': safe_int(shared_data.crednbr)
+            'credential_count': safe_int(shared_data.crednbr),
+            'level': safe_int(shared_data.levelnbr),
+            'points': safe_int(shared_data.coinnbr),
+            'coins': safe_int(shared_data.coinnbr)
         }
         
         return jsonify(stats)


### PR DESCRIPTION
## Summary
- surface the shared level and point totals through the modern status and dashboard APIs
- keep the shared stats refreshed during sync operations and websocket updates
- display live level and point cards on the modern dashboard alongside the other counts

## Testing
- python -m compileall webapp_modern.py web/scripts/ragnar_modern.js web/index_modern.html

------
https://chatgpt.com/codex/tasks/task_e_6907ea24185883249289842d6f5d4b3c