### PR TITLE
Fix modern threat intel tab rendering and surface top threats

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -552,7 +552,7 @@
         </div>
 
         <!-- Threat Intelligence Tab -->
-        <div id="threat-intel" class="tab-content hidden">
+        <div id="threat-intel-tab" class="tab-content hidden">
             <div class="mb-6">
                 <h1 class="text-3xl font-bold text-white mb-2">🛡️ Threat Intelligence</h1>
                 <p class="text-slate-400">Global threat intelligence fusion and real-time threat analysis</p>
@@ -615,6 +615,17 @@
                         </div>
                     </div>
                 </div>
+            </div>
+
+            <!-- Top Threats -->
+            <div class="glass rounded-lg p-6 mb-8">
+                <div class="flex items-center justify-between mb-4">
+                    <h3 class="text-lg font-semibold text-white">Top Threats</h3>
+                    <span class="text-sm text-slate-400" id="top-threats-updated">Last updated: N/A</span>
+                </div>
+                <ul id="top-threats-list" class="space-y-3 text-slate-300">
+                    <li class="text-slate-400">No threats detected. You're all clear!</li>
+                </ul>
             </div>
 
             <!-- Control Panel -->
@@ -703,7 +714,7 @@
                             <tbody id="enriched-findings-table">
                                 <tr>
                                     <td colspan="6" class="text-center py-8 text-slate-400">
-                                        No enriched findings available. Run network scans to generate threat intelligence data.
+                                        No threats detected. Run network scans to generate threat intelligence data.
                                     </td>
                                 </tr>
                             </tbody>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -3117,6 +3117,8 @@ function updateThreatIntelStats(data) {
     updateSourceStatus('nvd-status', sources.nvd_cve || false);
     updateSourceStatus('otx-status', sources.alienvault_otx || false);
     updateSourceStatus('mitre-status', sources.mitre_attack || false);
+
+    updateTopThreatsList(data.top_threats || [], data.last_update || data.last_intelligence_update || null);
 }
 
 // Update source status indicator
@@ -3130,12 +3132,12 @@ function updateSourceStatus(elementId, isActive) {
 // Update enriched findings table
 function updateEnrichedFindingsTable(findings) {
     const tableBody = document.getElementById('enriched-findings-table');
-    
+
     if (!findings || findings.length === 0) {
         tableBody.innerHTML = `
             <tr>
                 <td colspan="6" class="text-center py-8 text-slate-400">
-                    No enriched findings available. Run network scans to generate threat intelligence data.
+                    No threats detected. Run network scans to generate threat intelligence data.
                 </td>
             </tr>
         `;
@@ -3162,6 +3164,45 @@ function updateEnrichedFindingsTable(findings) {
                 </button>
             </td>
         </tr>
+    `).join('');
+}
+
+// Update top threats list
+function updateTopThreatsList(threats, lastUpdated) {
+    const listElement = document.getElementById('top-threats-list');
+    const updatedElement = document.getElementById('top-threats-updated');
+
+    if (!listElement) {
+        return;
+    }
+
+    if (updatedElement) {
+        updatedElement.textContent = `Last updated: ${lastUpdated ? formatTimestamp(lastUpdated) : 'N/A'}`;
+    }
+
+    if (!threats || threats.length === 0) {
+        listElement.innerHTML = `
+            <li class="text-slate-400">
+                No threats detected. You're all clear!
+            </li>
+        `;
+        return;
+    }
+
+    listElement.innerHTML = threats.slice(0, 5).map(threat => `
+        <li class="bg-slate-800/60 rounded-lg p-4 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div class="space-y-1">
+                <p class="text-white font-semibold">${escapeHtml(threat.target || 'Unknown Target')}</p>
+                <p class="text-slate-400 text-sm">${escapeHtml(threat.summary || 'No summary available')}</p>
+                <div class="text-xs text-slate-500 space-x-3">
+                    <span>Last Seen: ${formatTimestamp(threat.last_seen)}</span>
+                    ${threat.attribution ? `<span>Attributed to: ${escapeHtml(threat.attribution)}</span>` : ''}
+                </div>
+            </div>
+            <span class="self-start sm:self-center px-2 py-1 rounded text-xs font-semibold ${getRiskScoreClass(threat.risk_score)}">
+                ${threat.risk_score}/100
+            </span>
+        </li>
     `).join('');
 }
 


### PR DESCRIPTION
## Summary
- fix the modern threat intelligence tab visibility and add a top threats panel with empty states
- normalize threat intelligence API responses for the modern UI and expose summarized metrics
- update the enriched findings table messaging to clearly report when no threats are detected

## Testing
- pytest test_threat_intelligence.py

------
https://chatgpt.com/codex/tasks/task_e_6908fa3d0e6c8324a0bb7f6b1aa2026f