### PR TITLE
Improve live target tracking on modern dashboard

### DIFF
--- a/shared.py
+++ b/shared.py
@@ -419,6 +419,14 @@ class SharedData:
         self.networkkbnbr = 0
         self.attacksnbr = 0
         self.show_first_image = True
+        self.network_hosts_snapshot = {}
+        self.total_targetnbr = 0
+        self.inactive_targetnbr = 0
+        self.new_targets = 0
+        self.lost_targets = 0
+        self.new_target_ips = []
+        self.lost_target_ips = []
+        self.last_sync_timestamp = 0.0
 
     def delete_webconsolelog(self):
             """Delete the web console log file."""

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -242,7 +242,28 @@
                     <div class="flex items-center justify-between">
                         <div>
                             <p class="text-gray-400 text-sm">Targets</p>
-                            <p id="target-count" class="text-3xl font-bold text-Ragnar-400">0</p>
+                            <div class="flex items-baseline space-x-2">
+                                <p id="target-count" class="text-3xl font-bold text-Ragnar-400">0</p>
+                                <span class="text-sm text-gray-400">active</span>
+                            </div>
+                            <div class="mt-3 grid grid-cols-2 gap-2 text-xs text-gray-300">
+                                <div class="flex items-center space-x-1">
+                                    <span class="text-gray-400">Total</span>
+                                    <span id="target-total-count" class="font-semibold text-gray-100">0</span>
+                                </div>
+                                <div class="flex items-center space-x-1">
+                                    <span class="text-gray-400">Offline</span>
+                                    <span id="target-inactive-count" class="font-semibold text-red-300">0</span>
+                                </div>
+                                <div class="flex items-center space-x-1">
+                                    <span class="text-gray-400">New</span>
+                                    <span id="target-new-count" class="font-semibold text-green-300" title="No recent additions">0</span>
+                                </div>
+                                <div class="flex items-center space-x-1">
+                                    <span class="text-gray-400">Lost</span>
+                                    <span id="target-lost-count" class="font-semibold text-orange-300" title="No recent drops">0</span>
+                                </div>
+                            </div>
                         </div>
                         <div class="w-12 h-12 bg-Ragnar-500 bg-opacity-20 rounded-full flex items-center justify-center">
                             <svg class="w-6 h-6 text-Ragnar-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -329,7 +350,28 @@
                     </div>
                 </div>
             </div>
-            
+
+            <div class="glass rounded-xl p-4 mb-8 flex flex-col sm:flex-row sm:items-center sm:justify-between text-xs text-gray-300">
+                <div class="flex items-center space-x-2">
+                    <span class="uppercase tracking-wider text-gray-400">Last Sync</span>
+                    <span id="last-sync-display" class="font-semibold text-gray-100">Sync pending…</span>
+                </div>
+                <div class="mt-2 sm:mt-0 flex flex-wrap gap-2 text-[11px] text-gray-400">
+                    <span class="flex items-center space-x-1">
+                        <span class="w-1.5 h-1.5 rounded-full bg-green-400"></span>
+                        <span id="active-target-summary">Active targets stable</span>
+                    </span>
+                    <span class="flex items-center space-x-1">
+                        <span class="w-1.5 h-1.5 rounded-full bg-blue-400"></span>
+                        <span id="new-target-summary">0 new</span>
+                    </span>
+                    <span class="flex items-center space-x-1">
+                        <span class="w-1.5 h-1.5 rounded-full bg-red-400"></span>
+                        <span id="lost-target-summary">0 lost</span>
+                    </span>
+                </div>
+            </div>
+
             <!-- Status Section -->
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
                 <!-- Current Status -->


### PR DESCRIPTION
## Summary
- normalize scan data to deduplicate ports, track active hosts, and record new or lost targets during synchronization
- extend the dashboard stats API with active/total counts and last-sync metadata for richer status updates
- refresh the modern dashboard UI and JavaScript to surface accurate counts, recent activity, and last sync timing

## Testing
- python -m compileall shared.py webapp_modern.py web/scripts/ragnar_modern.js

------
https://chatgpt.com/codex/tasks/task_e_6909063c25d88324b62f853fe52bd3a7