### PR TITLE
Create combined Discoveries page for credentials and loot

### DIFF
--- a/web/config.html
+++ b/web/config.html
@@ -24,11 +24,8 @@
         <button type="button" onclick="window.location.href='/netkb.html'" title="NetKB">
             <img src="/web/images/netkb_icon.png" alt="Icon_netkb" style="height: 50px;">
         </button>
-        <button type="button" onclick="window.location.href='/credentials.html'" title="Credentials">
-            <img src="/web/images/cred_icon.png" alt="Icon_cred" style="height: 50px;">
-        </button>
-        <button type="button" onclick="window.location.href='/loot.html'" title="Loot">
-            <img src="/web/images/loot_icon.png" alt="Icon_loot" style="height: 50px;">
+        <button type="button" onclick="window.location.href='/discoveries.html'" title="Discoveries">
+            <img src="/web/images/loot_icon.png" alt="Icon_discoveries" style="height: 50px;">
         </button>
     </div>
     <div class="console-toolbar">

--- a/web/credentials.html
+++ b/web/credentials.html
@@ -24,11 +24,8 @@
         <button type="button" onclick="window.location.href='/netkb.html'" title="NetKB">
             <img src="/web/images/netkb_icon.png" alt="Icon_netkb" style="height: 50px;">
         </button>
-        <button type="button" onclick="window.location.href='/credentials.html'" title="Credentials">
-            <img src="/web/images/cred_icon.png" alt="Icon_cred" style="height: 50px;">
-        </button>
-        <button type="button" onclick="window.location.href='/loot.html'" title="Loot">
-            <img src="/web/images/loot_icon.png" alt="Icon_loot" style="height: 50px;">
+        <button type="button" onclick="window.location.href='/discoveries.html'" title="Discoveries">
+            <img src="/web/images/loot_icon.png" alt="Icon_discoveries" style="height: 50px;">
         </button>
     </div>
     <div class="console-toolbar">

--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -126,6 +126,57 @@ strong {
     margin-left: 5px;
     font-size: 14px;
 }
+
+.discoveries-toolbar {
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+}
+
+.toolbar-group {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.toolbar-label {
+    color: #e0e0e0;
+    font-weight: bold;
+}
+
+.discoveries-container {
+    flex: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    padding: 20px;
+    color: white;
+    background-color: #333;
+    overflow: auto;
+}
+
+.discoveries-section {
+    flex: 1 1 320px;
+    min-height: 0;
+    background-color: #2a2a2a;
+    padding: 20px;
+    border-radius: 12px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+    overflow: auto;
+}
+
+.discoveries-title {
+    margin-top: 0;
+    color: #ee9025;
+}
+
+#file-list ul {
+    padding-left: 0;
+}
+
+#file-list li {
+    list-style: none;
+}
 #cred-title {
     color: white;
 }

--- a/web/discoveries.html
+++ b/web/discoveries.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ragnar Cyberviking - Discoveries</title>
+    <link rel="icon" href="web/images/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="web/css/styles.css">
+    <link rel="manifest" href="manifest.json">
+    <link rel="apple-touch-icon" href="images/apple-touch-icon.png">
+    <script src="web/scripts/discoveries.js" defer></script>
+</head>
+<body>
+    <div class="toolbar" id="mainToolbar">
+        <button type="button" onclick="window.location.href='/index.html'" title="Playground">
+            <img src="/web/images/console_icon.png" alt="Ragnar" style="height: 50px;">
+        </button>
+        <button type="button" onclick="window.location.href='/config.html'" title="Config">
+            <img src="/web/images/config_icon.png" alt="Icon_config" style="height: 50px;">
+        </button>
+        <button type="button" onclick="window.location.href='/network.html'" title="Network">
+            <img src="/web/images/network_icon.png" alt="Icon_network" style="height: 50px;">
+        </button>
+        <button type="button" onclick="window.location.href='/netkb.html'" title="NetKB">
+            <img src="/web/images/netkb_icon.png" alt="Icon_netkb" style="height: 50px;">
+        </button>
+        <button type="button" onclick="window.location.href='/discoveries.html'" title="Discoveries">
+            <img src="/web/images/loot_icon.png" alt="Icon_discoveries" style="height: 50px;">
+        </button>
+    </div>
+    <div class="console-toolbar discoveries-toolbar">
+        <div class="toolbar-group">
+            <span class="toolbar-label">Credentials</span>
+            <button type="button" class="toolbar-button" onclick="adjustCredentialsFontSize(-1)" title="-">
+                <img src="/web/images/less.png" alt="Icon_less" style="height: 40px;">
+            </button>
+            <button type="button" class="toolbar-button" onclick="adjustCredentialsFontSize(1)" title="+">
+                <img src="/web/images/plus.png" alt="Icon_plus" style="height: 40px;">
+            </button>
+        </div>
+        <button id="toggle-toolbar" type="button" class="toolbar-button" onclick="toggleDiscoveriesToolbar()" data-open="false">
+            <img id="toggle-icon" src="/web/images/hide.png" alt="Toggle Toolbar" style="height: 50px;">
+        </button>
+        <div class="toolbar-group">
+            <span class="toolbar-label">Loot</span>
+            <button type="button" class="toolbar-button" onclick="adjustLootFontSize(-1)" title="-">
+                <img src="/web/images/less.png" alt="Icon_less" style="height: 40px;">
+            </button>
+            <button type="button" class="toolbar-button" onclick="adjustLootFontSize(1)" title="+">
+                <img src="/web/images/plus.png" alt="Icon_plus" style="height: 40px;">
+            </button>
+        </div>
+    </div>
+    <div class="discoveries-container">
+        <section class="discoveries-section">
+            <h1 class="discoveries-title">Credentials</h1>
+            <div id="credentials-table"></div>
+        </section>
+        <section class="discoveries-section">
+            <h1 class="discoveries-title">Loot</h1>
+            <div id="file-list"></div>
+        </section>
+    </div>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -28,11 +28,8 @@
         <button type="button" onclick="window.location.href='/netkb.html'" title="NetKB">
             <img src="/web/images/netkb_icon.png" alt="Icon_netkb" style="height: 50px;">
         </button>
-        <button type="button" onclick="window.location.href='/credentials.html'" title="Credentials">
-            <img src="/web/images/cred_icon.png" alt="Icon_cred" style="height: 50px;">
-        </button>
-        <button type="button" onclick="window.location.href='/loot.html'" title="Loot">
-            <img src="/web/images/loot_icon.png" alt="Icon_loot" style="height: 50px;">
+        <button type="button" onclick="window.location.href='/discoveries.html'" title="Discoveries">
+            <img src="/web/images/loot_icon.png" alt="Icon_discoveries" style="height: 50px;">
         </button>
     </div>
     <div class="console-toolbar">

--- a/web/loot.html
+++ b/web/loot.html
@@ -66,11 +66,8 @@
         <button type="button" onclick="window.location.href='/netkb.html'" title="NetKB">
             <img src="/web/images/netkb_icon.png" alt="Icon_netkb" style="height: 50px;">
         </button>
-        <button type="button" onclick="window.location.href='/credentials.html'" title="Credentials">
-            <img src="/web/images/cred_icon.png" alt="Icon_cred" style="height: 50px;">
-        </button>
-        <button type="button" onclick="window.location.href='/loot.html'" title="Loot">
-            <img src="/web/images/loot_icon.png" alt="Icon_loot" style="height: 50px;">
+        <button type="button" onclick="window.location.href='/discoveries.html'" title="Discoveries">
+            <img src="/web/images/loot_icon.png" alt="Icon_discoveries" style="height: 50px;">
         </button>
     </div>
     <div class="console-toolbar">

--- a/web/netkb.html
+++ b/web/netkb.html
@@ -25,11 +25,8 @@
         <button type="button" onclick="window.location.href='/netkb.html'" title="NetKB">
             <img src="/web/images/netkb_icon.png" alt="Icon_netkb" style="height: 50px;">
         </button>
-        <button type="button" onclick="window.location.href='/credentials.html'" title="Credentials">
-            <img src="/web/images/cred_icon.png" alt="Icon_cred" style="height: 50px;">
-        </button>
-        <button type="button" onclick="window.location.href='/loot.html'" title="Loot">
-            <img src="/web/images/loot_icon.png" alt="Icon_loot" style="height: 50px;">
+        <button type="button" onclick="window.location.href='/discoveries.html'" title="Discoveries">
+            <img src="/web/images/loot_icon.png" alt="Icon_discoveries" style="height: 50px;">
         </button>
     </div>
     <div class="console-toolbar">

--- a/web/network.html
+++ b/web/network.html
@@ -25,11 +25,8 @@
         <button type="button" onclick="window.location.href='/netkb.html'" title="NetKB">
             <img src="/web/images/netkb_icon.png" alt="Icon_netkb" style="height: 50px;">
         </button>
-        <button type="button" onclick="window.location.href='/credentials.html'" title="Credentials">
-            <img src="/web/images/cred_icon.png" alt="Icon_cred" style="height: 50px;">
-        </button>
-        <button type="button" onclick="window.location.href='/loot.html'" title="Loot">
-            <img src="/web/images/loot_icon.png" alt="Icon_loot" style="height: 50px;">
+        <button type="button" onclick="window.location.href='/discoveries.html'" title="Discoveries">
+            <img src="/web/images/loot_icon.png" alt="Icon_discoveries" style="height: 50px;">
         </button>
     </div>
     <div class="console-toolbar">

--- a/web/ragnar.html
+++ b/web/ragnar.html
@@ -106,11 +106,8 @@
         <button type="button" onclick="window.location.href='/netkb.html'" title="NetKB">
             <img src="/web/images/netkb_icon.png" alt="Icon_netkb" style="height: 50px;">
         </button>
-        <button type="button" onclick="window.location.href='/credentials.html'" title="Credentials">
-            <img src="/web/images/cred_icon.png" alt="Icon_cred" style="height: 50px;">
-        </button>
-        <button type="button" onclick="window.location.href='/loot.html'" title="Loot">
-            <img src="/web/images/loot_icon.png" alt="Icon_loot" style="height: 50px;">
+        <button type="button" onclick="window.location.href='/discoveries.html'" title="Discoveries">
+            <img src="/web/images/loot_icon.png" alt="Icon_discoveries" style="height: 50px;">
         </button>
     </div>
     <div class="image-container">

--- a/web/scripts/discoveries.js
+++ b/web/scripts/discoveries.js
@@ -1,0 +1,90 @@
+let credentialsFontSize = 12;
+let lootFontSize = 14;
+
+if (/Mobi|Android/i.test(navigator.userAgent)) {
+    credentialsFontSize = 7;
+    lootFontSize = 7;
+}
+
+function fetchCredentials() {
+    fetch('/list_credentials')
+        .then(response => response.text())
+        .then(data => {
+            document.getElementById('credentials-table').innerHTML = data;
+            document.getElementById('credentials-table').style.fontSize = `${credentialsFontSize}px`;
+        })
+        .catch(error => {
+            console.error('Error loading credentials:', error);
+        });
+}
+
+function fetchLoot() {
+    fetch('/list_files')
+        .then(response => response.json())
+        .then(data => {
+            document.getElementById('file-list').innerHTML = generateFileListHTML(data, '/', 0);
+            document.getElementById('file-list').style.fontSize = `${lootFontSize}px`;
+        })
+        .catch(error => {
+            console.error('Error loading loot:', error);
+        });
+}
+
+function generateFileListHTML(files, path, indent) {
+    let html = '<ul>';
+    files.forEach(file => {
+        if (file.is_directory) {
+            const icon = path === '/' ? 'web/images/mainfolder.png' : 'web/images/subfolder.png';
+            html += `
+                <li style="margin-left: ${indent * 5}px;">
+                    <img src="${icon}" alt="Folder Icon" style="height: 20px;">
+                    <strong>${file.name}</strong>
+                    <ul>
+                        ${generateFileListHTML(file.children || [], `${path}/${file.name}`, indent + 1)}
+                    </ul>
+                </li>`;
+        } else {
+            const icon = 'web/images/file.png';
+            html += `
+                <li style="margin-left: ${indent * 5}px;">
+                    <img src="${icon}" alt="File Icon" style="height: 20px;">
+                    <a href="/download_file?path=${encodeURIComponent(file.path)}">${file.name}</a>
+                </li>`;
+        }
+    });
+    html += '</ul>';
+    return html;
+}
+
+function adjustCredentialsFontSize(change) {
+    credentialsFontSize += change;
+    document.getElementById('credentials-table').style.fontSize = `${credentialsFontSize}px`;
+}
+
+function adjustLootFontSize(change) {
+    lootFontSize += change;
+    document.getElementById('file-list').style.fontSize = `${lootFontSize}px`;
+}
+
+function toggleDiscoveriesToolbar() {
+    const mainToolbar = document.querySelector('.toolbar');
+    const toggleButton = document.getElementById('toggle-toolbar');
+    const toggleIcon = document.getElementById('toggle-icon');
+
+    if (mainToolbar.classList.contains('hidden')) {
+        mainToolbar.classList.remove('hidden');
+        toggleIcon.src = '/web/images/hide.png';
+        toggleButton.setAttribute('data-open', 'false');
+    } else {
+        mainToolbar.classList.add('hidden');
+        toggleIcon.src = '/web/images/reveal.png';
+        toggleButton.setAttribute('data-open', 'true');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    fetchCredentials();
+    fetchLoot();
+    setInterval(fetchCredentials, 10000);
+    setInterval(fetchLoot, 10000);
+});


### PR DESCRIPTION
## Summary
- create a Discoveries page that brings the credentials table and loot browser into a single view
- add supporting styling and JavaScript to manage both sections and toolbar controls together
- update navigation buttons across the interface to point to the Discoveries tab instead of separate credentials and loot pages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69090d3a46948324a3f30871aca6bf9a