### PR TITLE
Improve Nmap vulnerability ingestion

### DIFF
--- a/shared.py
+++ b/shared.py
@@ -174,6 +174,7 @@ class SharedData:
             "nmap_scan_aggressivity": "-T4",
             "portstart": 1,
             "portend": 1000,
+            "default_vulnerability_ports": [22, 80, 443],
             
             "__title_timewaits__": "Time Wait Settings",
             "timewait_smb": 0,


### PR DESCRIPTION
## Summary
- normalize the list of ports passed to the Nmap vulnerability scan, add default fallbacks, and feed structured findings into network intelligence
- persist Nmap vulnerability summaries back into the NetKB and expose configurable default vulnerability ports in the shared configuration

## Testing
- python -m pytest test_threat_intelligence.py

------
https://chatgpt.com/codex/tasks/task_e_690941ff95c88324bab85cb34302b710