### PR TITLE
Fix vulnerable host counter ids on dashboard and threat intel

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -286,7 +286,7 @@
                         <div>
                             <p class="text-gray-400 text-sm">Vulnerabilities</p>
                             <p id="vuln-count" class="text-3xl font-bold text-red-400">123</p>
-                            <p class="text-gray-500 text-xs mt-1">Vulnerable Hosts <span id="vulnerable-hosts-count" class="text-red-300 font-semibold">1</span></p>
+                            <p class="text-gray-500 text-xs mt-1">Vulnerable Hosts <span id="dashboard-vulnerable-hosts-count" class="text-red-300 font-semibold">1</span></p>
                         </div>
                         <div class="w-12 h-12 bg-red-500 bg-opacity-20 rounded-full flex items-center justify-center">
                             <svg class="w-6 h-6 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -645,7 +645,7 @@
                     <div class="flex items-center justify-between">
                         <div>
                             <p class="text-slate-400 text-sm">Vulnerable Hosts</p>
-                            <p class="text-2xl font-bold text-blue-400" id="vulnerable-hosts-count">0</p>
+                            <p class="text-2xl font-bold text-blue-400" id="threat-intel-vulnerable-hosts-count">0</p>
                         </div>
                         <div class="bg-blue-500/20 p-3 rounded-lg">
                             <svg class="w-6 h-6 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -731,7 +731,7 @@ function updateDashboardStats(stats) {
 
     updateElement('port-count', portCount);
     updateElement('vuln-count', vulnCount);
-    updateElement('vulnerable-hosts-count', vulnerableHostsCount);
+    updateElement('dashboard-vulnerable-hosts-count', vulnerableHostsCount);
     updateElement('cred-count', credCount);
     updateElement('level-count', level);
     updateElement('points-count', points);
@@ -4757,7 +4757,10 @@ function displayGroupedVulnerabilities(data) {
     const container = document.getElementById('grouped-vulnerabilities-container');
     
     // Update summary cards
-    document.getElementById('vulnerable-hosts-count').textContent = data.total_hosts || 0;
+    const threatIntelVulnerableHosts = document.getElementById('threat-intel-vulnerable-hosts-count');
+    if (threatIntelVulnerableHosts) {
+        threatIntelVulnerableHosts.textContent = data.total_hosts || 0;
+    }
     document.getElementById('total-vulnerabilities-count').textContent = data.total_vulnerabilities || 0;
     
     // Calculate severity totals


### PR DESCRIPTION
## Summary
- give the dashboard and threat intelligence vulnerable host counters unique identifiers
- update the client script to populate both counters with the reported totals

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690ba9cafdf08324af5e57d2f43f8d60