### PR TITLE
Ensure netkb CSV headers persist core columns

### DIFF
--- a/actions/scanning.py
+++ b/actions/scanning.py
@@ -373,12 +373,20 @@ class NetworkScanner:
             try:
                 netkb_entries = {}
                 existing_action_columns = []
+                existing_headers = ["MAC Address", "IPs", "Hostnames", "Alive", "Ports", "Failed_Pings"]
 
                 # Read existing CSV file
                 if os.path.exists(netkbfile):
                     with open(netkbfile, 'r') as file:
                         reader = csv.DictReader(file)
-                        existing_headers = reader.fieldnames
+                        file_headers = reader.fieldnames or []
+
+                        # Merge any existing headers with the defaults so we always
+                        # have the core columns even if the CSV was empty or malformed.
+                        for header in file_headers:
+                            if header and header not in existing_headers:
+                                existing_headers.append(header)
+
                         existing_action_columns = [header for header in existing_headers if header not in ["MAC Address", "IPs", "Hostnames", "Alive", "Ports", "Failed_Pings"]]
                         for row in reader:
                             mac = row["MAC Address"]


### PR DESCRIPTION
## Summary
- default the netkb CSV headers to include the core columns before updating entries
- merge any existing custom headers on disk to avoid losing action-specific columns
- prevent empty or malformed CSV files from blocking hostname and port persistence

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690db26f71788324bb71c1ab5692fb1f)