### PR TITLE
Re-exec installer under bash when invoked with sh

### DIFF
--- a/install_ragnar.sh
+++ b/install_ragnar.sh
@@ -5,6 +5,10 @@
 # Author: infinition
 # Version: 1.0 - 071124 - 0954
 
+if [ -z "$BASH_VERSION" ]; then
+    exec /bin/bash "$0" "$@"
+fi
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -1284,4 +1288,3 @@ main() {
 }
 
 main
-


### PR DESCRIPTION
### Motivation
- The install script contains bash-specific syntax (for example `[[` and function definitions) which fails when the script is invoked with `sh`, so ensure it runs under `bash` to avoid syntax errors.

### Description
- Add a guard at the top of `install_ragnar.sh` that checks `BASH_VERSION` and `exec /bin/bash "$0" "$@"` when the script is started under a non-bash shell.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977df33866083249725247f820fe9ba)