### PR TITLE
Fix ZAP context scope for in-scope scans

### DIFF
--- a/advanced_vuln_scanner.py
+++ b/advanced_vuln_scanner.py
@@ -1471,11 +1471,27 @@ class AdvancedVulnScanner:
                 'regex': url_pattern
             })
 
+            # Ensure the context is in scope so inScopeOnly scans work
+            self._zap_set_context_in_scope(context_name, True)
+
             logger.info(f"Added {target} to ZAP scope (context: {context_name})")
             return True
 
         except Exception as e:
             logger.error(f"Error adding target to ZAP scope: {e}")
+            return False
+
+    def _zap_set_context_in_scope(self, context_name: str, in_scope: bool = True) -> bool:
+        """Set a ZAP context as in-scope for scanning."""
+        try:
+            self._zap_api_call('JSON/context/action/setContextInScope', {
+                'contextName': context_name,
+                'booleanInScope': str(bool(in_scope)).lower()
+            })
+            logger.info(f"Set context '{context_name}' in-scope={in_scope}")
+            return True
+        except Exception as e:
+            logger.warning(f"Failed to set context '{context_name}' in-scope={in_scope}: {e}")
             return False
 
     def _run_zap_spider(self, scan_id: str, target: str, options: Dict):
@@ -2052,6 +2068,7 @@ class AdvancedVulnScanner:
                     'contextName': 'default',
                     'regex': include_regex
                 })
+                self._zap_set_context_in_scope('default', True)
                 logger.info(f"Added {include_regex} to auth context 'default'")
             except Exception as e:
                 logger.warning(f"Could not add target to auth context: {e}")


### PR DESCRIPTION
### Motivation
- ZAP contexts created for targets were not explicitly marked in-scope which could cause `inScopeOnly` scans to exclude the target and return zero findings or appear stalled. 
- The change ensures contexts are properly marked in-scope so spider/active scans that honor scope behave correctly for both unauthenticated and authenticated scans.

### Description
- Added a helper ` _zap_set_context_in_scope` that calls ZAP's `JSON/context/action/setContextInScope` to mark a context in- or out-of-scope. 
- Call ` _zap_set_context_in_scope` from ` _zap_add_to_scope` immediately after creating and including the target in the new context so the new context is in-scope. 
- Ensure the `'default'` auth context is also marked in-scope during the full-scan spider phase by calling ` _zap_set_context_in_scope('default', True)`. 
- Added logging around context in-scope operations and warnings on failure; changes are confined to `advanced_vuln_scanner.py`.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69865b3c8adc8324803afd821b68cc4e)