### PR TITLE
Fix vulnerability scan progress updates

### DIFF
--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -447,6 +447,37 @@ function initializeSocket() {
         handleScanProgress(data);
     });
 
+    socket.on('scan_update', function(payload) {
+        if (!payload) {
+            return;
+        }
+        const eventType = payload.type || payload.event || '';
+        const eventData = payload.data || {};
+
+        switch (eventType) {
+            case 'scan_started':
+                handleScanStarted(eventData);
+                break;
+            case 'scan_progress':
+                handleScanProgress(eventData);
+                break;
+            case 'scan_completed':
+                handleScanCompleted(eventData);
+                break;
+            case 'scan_error':
+                handleScanError(eventData);
+                break;
+            case 'host_updated':
+                handleScanHostUpdate(eventData);
+                break;
+            default:
+                if (eventType) {
+                    addConsoleMessage(`Scan update: ${eventType}`, 'info');
+                }
+                break;
+        }
+    });
+
     socket.on('scan_host_update', function(data) {
         handleScanHostUpdate(data);
     });
@@ -1427,8 +1458,13 @@ function handleScanStarted(data) {
 }
 
 function handleScanProgress(data) {
-    currentScanState.scannedHosts = data.completed || 0;
-    currentScanState.currentTarget = data.current_target || '';
+    const scannedHosts = Number.isFinite(data.scanned) ? data.scanned : data.completed;
+    const totalHosts = Number.isFinite(data.total_hosts) ? data.total_hosts : data.total;
+    const currentTarget = data.current_target || data.current_ip || data.current_host || '';
+
+    currentScanState.scannedHosts = scannedHosts || 0;
+    currentScanState.totalHosts = totalHosts || currentScanState.totalHosts || 0;
+    currentScanState.currentTarget = currentTarget;
     
     updateScanProgress();
 }


### PR DESCRIPTION
### Motivation
- The frontend scan progress bar and UI were not reflecting backend vulnerability-scan progress reliably because the backend emits consolidated `scan_update` events and uses different field names (`scanned`, `total_hosts`, `current_ip`) than the UI expected.

### Description
- Wire a new `socket.on('scan_update', ...)` listener that dispatches backend scan events to the existing handlers such as `handleScanStarted`, `handleScanProgress`, `handleScanCompleted`, `handleScanError`, and `handleScanHostUpdate` in `web/scripts/ragnar_modern.js`.
- Normalize and broaden `handleScanProgress` to accept both legacy and new payload fields by honoring `scanned`, `total_hosts`, `current_ip` (and falling back to `completed`, `total`, `current_target`), and updating `currentScanState` accordingly so the progress bar and target label update correctly.
- Keep existing handlers (`handleScanStarted`, `handleScanHostUpdate`, `handleScanCompleted`, `handleScanError`) and reuse them for the new `scan_update` dispatch to avoid duplicating UI logic.

### Testing
- No automated tests were executed for this change (none were requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69865f6898e88324af024479d17dfcae)