### PR TITLE
Add ZAP daemon watchdog support

### DIFF
--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -57,6 +57,7 @@ from lynis_parser import parse_lynis_dat
 from actions.lynis_pentest_ssh import LynisPentestSSH
 from actions.connector_utils import CredentialChecker
 from db_manager import get_db, DatabaseManager
+from zap_daemon import ZapDaemonManager
 
 # Initialize logger
 logger = Logger(name="webapp_modern.py", level=logging.DEBUG)
@@ -112,6 +113,43 @@ PWN_SWITCH_STALE_SECONDS = 60  # Consider switch stuck after 60 seconds
 RELEASE_GATE_DEFAULT_MESSAGE = (
     "A controlled release is rolling out. Proceeding with a manual update may cause instability."
 )
+ZAP_MONITOR_INTERVAL_SECONDS = 30
+
+zap_daemon_manager = None
+zap_daemon_thread = None
+
+
+def start_zap_daemon_monitor() -> None:
+    """Start a background monitor to keep the ZAP daemon running."""
+    global zap_daemon_manager, zap_daemon_thread
+
+    enabled = os.getenv("RAGNAR_ZAP_DAEMON_ENABLED", "1").lower() not in {"0", "false", "no"}
+    if not enabled:
+        logger.info("ZAP daemon monitor disabled via RAGNAR_ZAP_DAEMON_ENABLED.")
+        return
+
+    zap_host = os.getenv("RAGNAR_ZAP_HOST", "127.0.0.1")
+    try:
+        zap_port = int(os.getenv("RAGNAR_ZAP_PORT", "8090"))
+    except ValueError:
+        zap_port = 8090
+    zap_api_key = os.getenv("RAGNAR_ZAP_API_KEY")
+
+    zap_daemon_manager = ZapDaemonManager(
+        logger=logger,
+        host=zap_host,
+        port=zap_port,
+        api_key=zap_api_key,
+        monitor_interval=ZAP_MONITOR_INTERVAL_SECONDS,
+    )
+
+    zap_daemon_thread = threading.Thread(
+        target=zap_daemon_manager.monitor_loop,
+        name="ZapDaemonMonitor",
+        daemon=True,
+    )
+    zap_daemon_thread.start()
+    logger.info(f"ZAP daemon monitor started (host={zap_host}, port={zap_port}).")
 
 
 def _normalize_value(value, default='Unknown'):
@@ -11471,6 +11509,9 @@ def handle_exit(signum, frame):
     """Handle exit signals with proper cleanup"""
     logger.info("Shutting down web server...")
     shared_data.webapp_should_exit = True
+
+    if zap_daemon_manager:
+        zap_daemon_manager.stop()
     
     # Stop all background tasks first
     try:
@@ -11529,6 +11570,9 @@ def run_server(host='0.0.0.0', port=8000):
 
         # Prime synchronized data before clients connect
         sync_all_counts()
+
+        # Start ZAP daemon watchdog (optional)
+        start_zap_daemon_monitor()
 
         # Start background status broadcaster
         socketio.start_background_task(broadcast_status_updates)

--- a/zap_daemon.py
+++ b/zap_daemon.py
@@ -1,0 +1,136 @@
+# zap_daemon.py
+
+import os
+import shutil
+import socket
+import subprocess
+import threading
+import time
+from typing import Optional
+
+
+class ZapDaemonManager:
+    def __init__(
+        self,
+        logger,
+        host: str = "127.0.0.1",
+        port: int = 8090,
+        api_key: Optional[str] = None,
+        max_start_retries: int = 3,
+        startup_timeout: float = 15.0,
+        retry_delay: float = 3.0,
+        monitor_interval: float = 30.0,
+    ) -> None:
+        self.logger = logger
+        self.host = host
+        self.port = port
+        self.api_key = api_key
+        self.max_start_retries = max_start_retries
+        self.startup_timeout = startup_timeout
+        self.retry_delay = retry_delay
+        self.monitor_interval = monitor_interval
+        self._missing_binary = False
+        self._stop_event = threading.Event()
+
+    def resolve_zap_path(self) -> Optional[str]:
+        env_paths = [
+            os.getenv("RAGNAR_ZAP_PATH"),
+            os.getenv("ZAP_PATH"),
+            os.getenv("ZAPROXY_PATH"),
+            os.getenv("ZAP_SH"),
+        ]
+        for candidate in env_paths:
+            if candidate and os.path.exists(candidate):
+                return candidate
+
+        for binary in ("zap.sh", "zap", "zaproxy"):
+            resolved = shutil.which(binary)
+            if resolved:
+                return resolved
+
+        for candidate in ("/usr/share/zaproxy/zap.sh", "/opt/zap/zap.sh"):
+            if os.path.exists(candidate):
+                return candidate
+
+        return None
+
+    def _is_port_open(self) -> bool:
+        try:
+            with socket.create_connection((self.host, self.port), timeout=2):
+                return True
+        except OSError:
+            return False
+
+    def _wait_for_ready(self, timeout: float) -> bool:
+        start = time.time()
+        while time.time() - start < timeout:
+            if self._is_port_open():
+                return True
+            time.sleep(0.5)
+        return False
+
+    def start_daemon(self) -> bool:
+        if self._is_port_open():
+            return True
+
+        zap_path = self.resolve_zap_path()
+        if not zap_path:
+            if not self._missing_binary:
+                self.logger.warning(
+                    "ZAP daemon binary not found. Set RAGNAR_ZAP_PATH or install ZAP."
+                )
+                self._missing_binary = True
+            return False
+
+        self._missing_binary = False
+        args = [
+            zap_path,
+            "-daemon",
+            "-host",
+            self.host,
+            "-port",
+            str(self.port),
+        ]
+
+        if self.api_key:
+            args.extend(["-config", f"api.key={self.api_key}"])
+        else:
+            args.extend(["-config", "api.disablekey=true"])
+
+        for attempt in range(1, self.max_start_retries + 1):
+            try:
+                self.logger.info(f"Starting ZAP daemon (attempt {attempt})...")
+                subprocess.Popen(
+                    args,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+            except Exception as exc:
+                self.logger.error(f"Failed to launch ZAP daemon: {exc}")
+            else:
+                if self._wait_for_ready(self.startup_timeout):
+                    self.logger.info("ZAP daemon is running.")
+                    return True
+
+            self.logger.warning("ZAP daemon not ready yet; retrying...")
+            time.sleep(self.retry_delay)
+
+        self.logger.error("ZAP daemon failed to start after retries.")
+        return False
+
+    def ensure_daemon(self) -> bool:
+        if self._is_port_open():
+            return True
+        return self.start_daemon()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def monitor_loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self.ensure_daemon()
+            except Exception as exc:
+                self.logger.error(f"ZAP daemon monitor error: {exc}")
+            self._stop_event.wait(self.monitor_interval)


### PR DESCRIPTION
### Motivation

- Ensure the ZAP (OWASP ZAP) daemon is started and remains available for web vulnerability scanning after users reported "Failed to start ZAP Deamon" issues.

### Description

- Add a new `ZapDaemonManager` in `zap_daemon.py` that locates the ZAP binary, starts the daemon with retries, waits for readiness, and provides a monitoring loop to ensure the daemon stays running.
- Wire the manager into the web server lifecycle by importing `ZapDaemonManager` in `webapp_modern.py` and starting the monitor from `run_server()` via `start_zap_daemon_monitor()`.
- Provide a clean shutdown hook in `handle_exit()` that stops the monitor by calling `zap_daemon_manager.stop()`.
- Configuration is environment-driven with `RAGNAR_ZAP_DAEMON_ENABLED`, `RAGNAR_ZAP_HOST`, `RAGNAR_ZAP_PORT`, and `RAGNAR_ZAP_API_KEY`, and a default monitor interval constant `ZAP_MONITOR_INTERVAL_SECONDS`.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698662cf1778832488c9dee20d3e6ebe)