### PR TITLE
Revamp advanced vuln scans UI: scan cards, inline findings, and expand/collapse

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -3021,40 +3021,43 @@
                     </div>
                 </div>
 
-                <!-- Active Scans & Findings -->
-                <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
-                    <!-- Active Scans -->
-                    <div class="glass-card p-3 sm:p-4">
-                        <div class="flex items-center justify-between mb-4">
-                            <h3 class="font-semibold flex items-center text-sm sm:text-base">
-                                <svg id="adv-vuln-scans-spinner" class="w-4 h-4 sm:w-5 sm:h-5 mr-2 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
-                                </svg>
-                                Scans
-                            </h3>
-                            <button onclick="deleteAllAdvScans()" class="text-xs text-gray-400 hover:text-red-400 flex items-center gap-1">
-                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
-                                </svg>
-                                <span class="hidden sm:inline">Clear All</span>
-                            </button>
-                        </div>
-                        <div id="adv-vuln-active-scans" class="space-y-2 max-h-48 sm:max-h-60 overflow-y-auto scrollbar-thin">
-                            <p class="text-gray-400 text-center py-4 text-sm">No active scans</p>
-                        </div>
-                    </div>
-
-                    <!-- Recent Findings -->
-                    <div class="glass-card p-3 sm:p-4">
-                        <h3 class="font-semibold mb-4 flex items-center text-sm sm:text-base">
-                            <svg class="w-4 h-4 sm:w-5 sm:h-5 mr-2 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+                <!-- Scan Cards -->
+                <div class="glass-card p-3 sm:p-4">
+                    <div class="flex items-center justify-between mb-4">
+                        <h3 class="font-semibold flex items-center text-sm sm:text-base">
+                            <svg id="adv-vuln-scans-spinner" class="w-4 h-4 sm:w-5 sm:h-5 mr-2 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
                             </svg>
-                            Recent Findings
+                            Scans
                         </h3>
-                        <div id="adv-vuln-findings" class="space-y-2 max-h-48 sm:max-h-60 overflow-y-auto scrollbar-thin">
-                            <p class="text-gray-400 text-center py-4 text-sm">No findings yet</p>
-                        </div>
+                        <button onclick="deleteAllAdvScans()" class="text-xs text-gray-400 hover:text-red-400 flex items-center gap-1">
+                            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+                            </svg>
+                            <span class="hidden sm:inline">Clear All</span>
+                        </button>
+                    </div>
+                    <div id="adv-vuln-active-scans" class="space-y-3">
+                        <p class="text-gray-400 text-center py-4 text-sm">No active scans</p>
+                    </div>
+                    <button id="adv-vuln-scans-toggle" onclick="toggleAdvVulnScansExpanded()" class="hidden mt-3 w-full text-xs text-gray-300 hover:text-white flex items-center justify-center gap-2">
+                        <span>Show all scans</span>
+                        <svg id="adv-vuln-scans-toggle-icon" class="w-4 h-4 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                        </svg>
+                    </button>
+                </div>
+
+                <!-- Scan Details -->
+                <div id="adv-vuln-scan-details" class="glass-card p-3 sm:p-4 mt-4">
+                    <h3 class="font-semibold mb-3 flex items-center text-sm sm:text-base">
+                        <svg class="w-4 h-4 sm:w-5 sm:h-5 mr-2 text-cyan-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M12 6a9 9 0 100 18 9 9 0 000-18z"></path>
+                        </svg>
+                        Scan Findings
+                    </h3>
+                    <div id="adv-vuln-scan-details-content" class="text-sm text-gray-400">
+                        Select a scan above to view all findings and detailed information.
                     </div>
                 </div>
 
@@ -3144,34 +3147,6 @@
                     <div class="mt-3 text-xs text-gray-500 flex justify-between items-center">
                         <span id="findings-count-text">Showing 0 findings</span>
                         <span id="findings-filter-text" class="text-cyan-400 hidden">Filtered</span>
-                    </div>
-                </div>
-
-                <!-- Finding Detail Modal -->
-                <div id="finding-detail-modal" class="fixed inset-0 bg-black bg-opacity-80 hidden items-center justify-center z-50 p-2 sm:p-4">
-                    <div class="glass rounded-xl p-4 sm:p-6 max-w-2xl w-full max-h-[95vh] sm:max-h-[90vh] overflow-y-auto">
-                        <div class="flex items-center justify-between mb-4">
-                            <h3 class="text-xl font-bold" id="finding-modal-title">Finding Details</h3>
-                            <button onclick="closeFindingDetailModal()" class="text-gray-400 hover:text-white">
-                                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-                                </svg>
-                            </button>
-                        </div>
-                        <div id="finding-modal-content" class="space-y-4">
-                            <!-- Content populated by JS -->
-                        </div>
-                        <div class="mt-6 flex justify-between items-center gap-3">
-                            <button onclick="copyCurrentFinding()" class="flex items-center gap-2 bg-green-700 hover:bg-green-600 text-white px-4 py-2 rounded-lg transition-colors text-sm">
-                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"></path>
-                                </svg>
-                                Copy Finding
-                            </button>
-                            <button onclick="closeFindingDetailModal()" class="bg-slate-600 hover:bg-slate-500 text-white px-4 py-2 rounded-lg transition-colors">
-                                Close
-                            </button>
-                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
### Motivation
- Replace the single bundled findings view with per-scan cards so each scan is represented as its own UI card showing target, method, counts and timing. 
- Limit the scan card list to three visible items by default with a toggle to reveal all scans for clearer overview and less visual noise. 
- Provide an inline scan details panel that shows all findings for the selected scan (including severity badges, CVEs, evidence, remediation, duration and timestamp) and remove the modal-popup flow. 

### Description
- UI: added a scan-cards area and an inline `#adv-vuln-scan-details` container in `web/index_modern.html`, and removed the old finding detail modal UI so details render inline. 
- Data/Rendering: reworked `updateActiveScans` in `web/scripts/ragnar_modern.js` to render up to 3 cards by default, support an expand/collapse toggle, show scan metadata (target, method, status, duration, performed timestamp) and per-severity badges/counts. 
- Mapping & state: added client-side state and helpers (`advVulnShowAllScans`, `advVulnSelectedScanId`, `advVulnScansCache`, `advVulnScanFindingsMap`) and new functions (`toggleAdvVulnScansExpanded`, `updateScansToggleButton`, `buildAdvVulnScanFindingsMap`, `selectAdvVulnScan`, `renderAdvVulnScanDetails`, formatting helpers) to map findings to scans and render full per-scan findings inline. 
- Behavior changes: `loadAdvancedVulnData` now loads findings first so scan cards can display accurate severity breakdowns, and `showFindingDetail` was changed to select the parent scan and highlight the finding instead of opening a modal; copying via the previous global "currentDisplayedFinding" modal flow was removed. 

### Testing
- UI smoke test attempt with Playwright to capture the updated page was performed but failed due to the headless Chromium process crashing with a SIGSEGV, so no screenshot could be produced. 
- A local static HTTP server was started to serve the modified page for manual inspection; no automated unit tests were executed. 
- Recommend running the app in a browser or CI-capable headless environment (and re-running the Playwright screenshot) to visually verify card rendering, toggle behavior, selection/highlighting and that per-scan findings display as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987934558a88324b275dcc4de6801fe)