### PR TITLE
fix: move search icons to right side to prevent placeholder/text overlap

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -870,11 +870,11 @@
                 <!-- Filters -->
                 <div class="flex flex-col sm:flex-row gap-3 mb-4">
                     <div class="relative flex-1">
-                        <svg class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg class="w-4 h-4 text-gray-400 pointer-events-none" style="position:absolute;right:0.75rem;top:50%;transform:translateY(-50%);" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 1 0 5 11a6 6 0 0 0 12 0z"></path>
                         </svg>
                         <input id="cred-ip-search" type="text" placeholder="Filter by IP..." oninput="onCredSearch(this.value)"
-                            class="w-full bg-slate-800 border border-slate-600 rounded-lg pl-3 pr-10 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-Ragnar-500">
+                            class="w-full bg-slate-800 border border-slate-600 rounded-lg py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-Ragnar-500" style="padding-left:0.75rem;padding-right:2.5rem;">
                     </div>
                     <div class="flex flex-wrap gap-2">
                         <button onclick="filterCredsByService('all')" data-svc="all" class="cred-svc-btn bg-Ragnar-600 text-white px-3 py-2 rounded-lg text-sm transition-colors">All</button>
@@ -1631,11 +1631,11 @@
                 <div class="flex flex-col sm:flex-row gap-3 mb-6">
                     <!-- IP search -->
                     <div class="relative flex-1">
-                        <svg class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg class="w-4 h-4 text-gray-400 pointer-events-none" style="position:absolute;right:0.75rem;top:50%;transform:translateY(-50%);" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 1 0 5 11a6 6 0 0 0 12 0z"></path>
                         </svg>
                         <input id="attack-ip-search" type="text" placeholder="Filter by IP address..." oninput="onAttackIPSearch(this.value)"
-                            class="w-full bg-slate-800 border border-slate-600 rounded-lg pl-3 pr-10 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-Ragnar-500">
+                            class="w-full bg-slate-800 border border-slate-600 rounded-lg py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-Ragnar-500" style="padding-left:0.75rem;padding-right:2.5rem;">
                     </div>
                     <!-- Network / SSID dropdown -->
                     <div class="flex items-center gap-2">


### PR DESCRIPTION
## Problem

The 'Filter by IP...' placeholder text and typed characters overlap the search icon in both the **Credentials** tab and **Attack Log** tab. Three previous commits tried increasing left padding (`pl-9` → `pl-10`) but the issue persists on the Pi's Chromium browser.

## Root cause

Left-side absolute-positioned icons + left padding are unreliable across browsers and zoom levels. The icon sits at `left-3` (12px) and extends to ~28px, but the input text starts before the `pl-10` (40px) mark on certain Chromium rendering configurations.

## Fix

Move the search icon to the **right side** of the input — text then starts flush at the left with zero overlap possible:

```diff
- <svg class="absolute left-3 ...
+ <svg class="absolute right-3 ...

- class="... pl-10 pr-3 ..."
+ class="... pl-3 pr-10 ..."
```

Applied to:
- Credentials tab (`cred-ip-search`) 
- Attack Log tab (`attack-ip-search`)