### PR TITLE
fix: green toggle indicator for on/off state

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -215,6 +215,8 @@
                 width: 100%;
             }
         }
+        /* Toggle switch: show green when ON, regardless of Tailwind purge state */
+        label > input[type="checkbox"]:checked + div { background-color: #16a34a !important; }
     </style>
 </head>
 


### PR DESCRIPTION
Small UI change — makes it easier to tell if a toggle is on or off.

The toggle track now turns green when enabled, and stays gray when disabled. Previously the only indicator was the thumb position (left/right).