### PR TITLE
fix: add timeout to epd4in26 ReadBusy to prevent startup hang

### DIFF
--- a/resources/waveshare_epd/epd4in26.py
+++ b/resources/waveshare_epd/epd4in26.py
@@ -28,6 +28,7 @@
 #
 
 import logging
+import time
 from . import epdconfig
 
 # Display resolution
@@ -72,9 +73,13 @@ class EPD:
         epdconfig.spi_writebyte2(data)
         epdconfig.digital_write(self.cs_pin, 1)
 
-    def ReadBusy(self):
+    def ReadBusy(self, timeout=30):
         logger.debug("e-Paper busy")
-        while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: idle, 1: busy
+        deadline = time.time() + timeout
+        while(epdconfig.digital_read(self.busy_pin) == 0):      # 0: busy, 1: idle/ready
+            if time.time() > deadline:
+                logger.warning(f"ReadBusy timeout after {timeout}s — display may not be connected or responding")
+                break
             epdconfig.delay_ms(10)
         logger.debug("e-Paper busy release")
 


### PR DESCRIPTION
ReadBusy() polled the BUSY pin indefinitely (while pin==0). If the 4.26" display is slow to respond or disconnected, this caused the entire service to hang at init_full_update() and the web UI would never start.

Added a 30-second timeout so ReadBusy logs a warning and breaks out if the display does not respond in time, allowing the service to continue. Also corrected the misleading comment (0=busy, 1=idle/ready).

https://claude.ai/code/session_01MuFqRE975nXSst5CC1WK1x