### PR TITLE
fix: resolve permanent 'Loading...' in Data Management card (Config tab)

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -3735,7 +3735,7 @@
                         <div class="glass rounded-lg p-4">
                             <div class="flex items-center justify-between mb-3">
                                 <h4 class="font-medium">Data Management</h4>
-                                <span id="vuln-count" class="text-sm px-2 py-1 rounded bg-gray-700 text-gray-300">Loading...</span>
+                                <span id="config-vuln-count" class="text-sm px-2 py-1 rounded bg-gray-700 text-gray-300">Loading...</span>
                             </div>
                             <div class="text-sm text-gray-400 mb-3">
                                 Reset vulnerability and intelligence data

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -5920,6 +5920,7 @@ async function resetVulnerabilities() {
             
             // Update vulnerability count display
             updateElement('vuln-count', '0');
+            updateElement('config-vuln-count', '0');
             updateElement('vulnerability-count', '0');
             
             // Refresh current tab if we're on network or discovered tabs
@@ -5973,6 +5974,7 @@ async function updateVulnerabilityCount() {
         const stats = await fetchAPI('/api/stats');
         const count = stats.vulnerability_count || 0;
         updateElement('vuln-count', count.toString());
+        updateElement('config-vuln-count', count.toString());
     } catch (error) {
         console.error('Error updating vulnerability count:', error);
         updateElement('vuln-count', '?');


### PR DESCRIPTION
## Problem

The **Data Management** card in the Config tab always showed `Loading...` next to the vulnerability count — it never updated to the actual number.

## Root Cause

There were two HTML elements with the same `id="vuln-count"`:
- Line 420: `<p id="vuln-count">` — the vulnerability badge in the dashboard stats area
- Line 3738: `<span id="vuln-count">Loading...</span>` — the count badge in the Config tab's Data Management card

`document.getElementById()` always returns the **first** matching element, so every call to `updateElement('vuln-count', ...)` updated the dashboard badge only. The Config tab span was never written to and stayed permanently on `Loading...`.

## Fix

- Renamed the Config tab element ID from `vuln-count` to `config-vuln-count`
- Updated `updateVulnerabilityCount()` to also write to `config-vuln-count`
- Updated `resetVulnerabilities()` to also reset `config-vuln-count` to `0`

## Changes

| File | Change |
|------|--------|
| `web/index_modern.html` | Renamed duplicate `id="vuln-count"` → `id="config-vuln-count"` in Data Management card |
| `web/scripts/ragnar_modern.js` | `updateVulnerabilityCount()` and `resetVulnerabilities()` now update both `vuln-count` and `config-vuln-count` |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)