### PR TITLE
feat: display human-readable temperature sensor names

### DIFF
--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -11458,6 +11458,38 @@ function updateNetworkStats(data) {
     networkStats.innerHTML = html;
 }
 
+function formatSensorName(sensor) {
+    const known = {
+        'cpu_thermal': 'CPU',
+        'cpu-thermal': 'CPU',
+        'cpu_temp': 'CPU',
+        'gpu_thermal': 'GPU',
+        'gpu-thermal': 'GPU',
+        'soc_thermal': 'SoC',
+        'soc-thermal': 'SoC',
+        'acpitz': 'System (ACPI)',
+        'coretemp': 'CPU Core',
+        'k10temp': 'CPU (AMD)',
+        'nvme_composite': 'NVMe SSD',
+        'nvme': 'NVMe SSD',
+        'wifi': 'Wi-Fi',
+        'pch': 'Chipset',
+        'bat': 'Battery',
+    };
+
+    const lower = sensor.toLowerCase().replace(/[_\-\s]+\d*$/, '').replace(/[_\-\s]+/g, '_');
+    for (const [key, label] of Object.entries(known)) {
+        if (lower === key || lower.startsWith(key)) return label;
+    }
+
+    // Fallback: capitalise words, remove trailing numbers/underscores
+    return sensor
+        .replace(/[_\-]+/g, ' ')
+        .replace(/\s*\d+\s*$/, '')
+        .trim()
+        .replace(/\b\w/g, c => c.toUpperCase()) || sensor;
+}
+
 function updateTemperatureDisplay(temperatures) {
     const tempSection = document.getElementById('temperature-section');
     const tempDisplay = document.getElementById('temperature-display');
@@ -11477,7 +11509,7 @@ function updateTemperatureDisplay(temperatures) {
         
         html += `
             <div class="bg-slate-800 rounded p-3">
-                <h4 class="font-medium mb-1 text-sm">${sensor}</h4>
+                <h4 class="font-medium mb-1 text-sm">${formatSensorName(sensor)}</h4>
                 <div class="text-xl font-bold ${tempColor}">${temp.toFixed(1)}°C</div>
             </div>
         `;


### PR DESCRIPTION
## Problem

The Temperature Sensors card in the System Monitoring tab showed raw OS sensor identifiers like `cpu_thermal_`, `acpitz_0`, or `k10temp_0` — names that are meaningful to the kernel but confusing to end users.

## Solution

Added a `formatSensorName()` function that maps known sensor identifiers to friendly labels before rendering, with a generic capitalisation fallback for unknown sensors.

### Mapping table

| Raw name | Displayed as |
|----------|-------------|
| `cpu_thermal_`, `cpu_thermal_0` | **CPU** |
| `cpu-thermal` | **CPU** |
| `gpu_thermal_0` | **GPU** |
| `soc_thermal_0` | **SoC** |
| `acpitz_0` | **System (ACPI)** |
| `coretemp_0` | **CPU Core** |
| `k10temp_0` | **CPU (AMD)** |
| `nvme_composite_0` | **NVMe SSD** |
| `pch_*` | **Chipset** |
| `wifi_*` | **Wi-Fi** |
| `bat_*` | **Battery** |
| anything else | Capitalised, underscores removed |

## Changes

| File | Change |
|------|--------|
| `web/scripts/ragnar_modern.js` | Added `formatSensorName()` lookup function; `updateTemperatureDisplay()` now calls it instead of rendering raw sensor keys |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)