### PR TITLE
fix: show filter-aware empty state in Vulnerabilities by Host

### DIFF
--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -12048,13 +12048,19 @@ function displayGroupedVulnerabilities(data) {
     document.getElementById('high-vuln-count').textContent = highTotal;
     
     if (!data.grouped_vulnerabilities || data.grouped_vulnerabilities.length === 0) {
+        const emptyMessages = {
+            open:     { title: 'No Open Vulnerabilities',      sub: 'No unresolved vulnerabilities match the current filter.' },
+            resolved: { title: 'No Resolved Vulnerabilities',  sub: 'None of the discovered vulnerabilities have been marked as resolved yet.' },
+            all:      { title: 'No Vulnerabilities Found',     sub: 'All discovered hosts appear to be secure!' },
+        };
+        const msg = emptyMessages[threatIntelStatusFilter] || emptyMessages.all;
         container.innerHTML = `
             <div class="glass rounded-lg p-6 text-center">
                 <svg class="w-16 h-16 mx-auto mb-4 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                 </svg>
-                <h3 class="text-xl font-semibold text-white mb-2">No Vulnerabilities Found</h3>
-                <p class="text-slate-400">All discovered hosts appear to be secure!</p>
+                <h3 class="text-xl font-semibold text-white mb-2">${msg.title}</h3>
+                <p class="text-slate-400">${msg.sub}</p>
             </div>
         `;
         return;


### PR DESCRIPTION
## Problem

In the **Vulnerabilities by Host** tab, selecting the **Resolved** or **Open** filter with no matching results always showed:

> ✅ No Vulnerabilities Found  
> All discovered hosts appear to be secure!

This is misleading — it implies the system is fully secure even when there are active open vulnerabilities, just none matching the selected filter.

## Fix

The empty-state message now adapts to the active filter:

| Filter | Title | Subtitle |
|--------|-------|----------|
| **Open** | No Open Vulnerabilities | No unresolved vulnerabilities match the current filter. |
| **Resolved** | No Resolved Vulnerabilities | None of the discovered vulnerabilities have been marked as resolved yet. |
| **All** | No Vulnerabilities Found | All discovered hosts appear to be secure! |

## Changes

| File | Change |
|------|--------|
| `web/scripts/ragnar_modern.js` | Empty-state block in `updateVulnerabilityDisplay()` now reads `threatIntelStatusFilter` and picks the appropriate title/subtitle |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)