### PR TITLE
chore: update socket.io client from 4.5.4 to 4.8.3

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/css/tailwind.css">
 
     <!-- Socket.IO Client -->
-    <script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
+    <script src="https://cdn.socket.io/4.8.3/socket.io.min.js"></script>
     
     <style>
         @keyframes pulse-glow {


### PR DESCRIPTION
## Summary

- Bumps the socket.io client CDN URL from `4.5.4` → `4.8.3` (latest stable 4.x release)
- No server-side changes needed — flask-socketio 5.x and socket.io 4.x use the same Engine.IO v4 protocol, making this a drop-in upgrade

## Changes

| File | Change |
|------|--------|
| `web/index_modern.html` | CDN URL updated from `cdn.socket.io/4.5.4/` to `cdn.socket.io/4.8.3/` |

## Compatibility

socket.io 4.8.3 is fully backwards-compatible with 4.5.4 — no breaking changes in the 4.x client API.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)