### PR TITLE
Epd2in13b v4 driver

### DIFF
--- a/install_ragnar.sh
+++ b/install_ragnar.sh
@@ -1692,7 +1692,7 @@ main() {
             log "INFO" "Attempting to auto-detect E-Paper display"
             
             EPD_VERSION=""
-            EPD_VERSIONS=("epd2in13_V4" "epd2in13_V3" "epd2in13_V2" "epd2in7_V2" "epd2in7" "epd2in13" "epd2in9_V2" "epd3in7" "epd4in26")
+            EPD_VERSIONS=("epd2in13b_V4", "epd2in13_V4" "epd2in13_V3" "epd2in13_V2" "epd2in7_V2" "epd2in7" "epd2in13" "epd2in9_V2" "epd3in7" "epd4in26")
             
             for version in "${EPD_VERSIONS[@]}"; do
                 echo -e "${BLUE}Testing ${version}...${NC}"
@@ -1767,26 +1767,27 @@ except:
             echo "2.  epd2in13_V2  (2.13\" V2 122x250)"
             echo "3.  epd2in13_V3  (2.13\" V3 122x250)"
             echo "4.  epd2in13_V4  (2.13\" V4 122x250)"
-            echo "5.  epd2in7_V2   (2.7\"  V2 176x264)"
-            echo "6.  epd2in7      (2.7\"  V1 176x264)"
-            echo "7.  epd2in9_V2   (2.9\"  128x296)"
-            echo "8.  epd3in7      (3.7\"  280x480)"
-            echo "9.  epd4in26     (4.26\" 800x480)"
+            echo "5.  epd2in13b_V4  (2.13\" V4 122x250)"
+            echo "6.  epd2in7_V2   (2.7\"  V2 176x264)"
+            echo "7.  epd2in7      (2.7\"  V1 176x264)"
+            echo "8.  epd2in9_V2   (2.9\"  128x296)"
+            echo "9.  epd3in7      (3.7\"  280x480)"
+            echo "10.  epd4in26     (4.26\" 800x480)"
             echo ""
             echo -e "${CYAN}  TFT LCD displays:${NC}"
-            echo "10. GC9A01       (1.28\" Round 240x240)"
+            echo "11. GC9A01       (1.28\" Round 240x240)"
             echo ""
             echo -e "${CYAN}  OLED displays:${NC}"
-            echo "11. SSD1306      (0.96\" OLED 128x64)"
+            echo "12. SSD1306      (0.96\" OLED 128x64)"
             echo ""
             echo -e "${CYAN}  Character LCD:${NC}"
-            echo "12. LCD1602      (16x2 I2C Character LCD)"
+            echo "13. LCD1602      (16x2 I2C Character LCD)"
             echo ""
             echo -e "${CYAN}  LED Matrix displays:${NC}"
-            echo "13. MAX7219  (8 panels 64×8 LED matrix)"
-            echo "14. MAX7219  (4 panels 32×8 LED matrix)"
+            echo "14. MAX7219  (8 panels 64×8 LED matrix)"
+            echo "15. MAX7219  (4 panels 32×8 LED matrix)"
             echo ""
-            echo "15. No display (headless install)"
+            echo "16. No display (headless install)"
 
             while true; do
                 read -p "Enter your choice (1-15): " epd_choice
@@ -1795,17 +1796,18 @@ except:
                     2) EPD_VERSION="epd2in13_V2"; break;;
                     3) EPD_VERSION="epd2in13_V3"; break;;
                     4) EPD_VERSION="epd2in13_V4"; break;;
-                    5) EPD_VERSION="epd2in7_V2"; break;;
-                    6) EPD_VERSION="epd2in7"; break;;
-                    7) EPD_VERSION="epd2in9_V2"; break;;
-                    8) EPD_VERSION="epd3in7"; break;;
-                    9) EPD_VERSION="epd4in26"; break;;
-                    10) EPD_VERSION="gc9a01"; break;;
-                    11) EPD_VERSION="ssd1306"; break;;
-                    12) EPD_VERSION="lcd1602"; break;;
-                    13) EPD_VERSION="max7219_8panel"; break;;
-                    14) EPD_VERSION="max7219_4panel"; break;;
-                    15)
+                    5) EPD_VERSION="epd2in13b_V4"; break;;
+                    6) EPD_VERSION="epd2in7_V2"; break;;
+                    7) EPD_VERSION="epd2in7"; break;;
+                    8) EPD_VERSION="epd2in9_V2"; break;;
+                    9) EPD_VERSION="epd3in7"; break;;
+                    10) EPD_VERSION="epd4in26"; break;;
+                    11) EPD_VERSION="gc9a01"; break;;
+                    12) EPD_VERSION="ssd1306"; break;;
+                    13) EPD_VERSION="lcd1602"; break;;
+                    14) EPD_VERSION="max7219_8panel"; break;;
+                    15) EPD_VERSION="max7219_4panel"; break;;
+                    16)
                         select_headless_variant
                         EPD_VERSION=""
                         break

--- a/resources/waveshare_epd/epd2in13b_V4
+++ b/resources/waveshare_epd/epd2in13b_V4
@@ -1,0 +1,258 @@
+# *****************************************************************************
+# * | File        :	  epd2in13b_V4.py
+# * | Author      :   Waveshare team | ChrisPHL
+# * | Function    :   Electronic paper driver
+# * | Info        :   Mixed from https://github.com/waveshareteam/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13b_V4.py and https://github.com/PierreGode/Ragnar/blob/main/resources/waveshare_epd/epd2in13_V4.py
+# *----------------
+# * | This version:   V1.0
+# * | Date        :   2022-04-21
+# # | Info        :   python demo
+# -----------------------------------------------------------------------------
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documnetation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to  whom the Software is
+# furished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS OR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+from . import epdconfig
+
+# Display resolution
+EPD_WIDTH       = 122
+EPD_HEIGHT      = 250
+
+logger = logging.getLogger(__name__)
+
+class EPD:
+    def __init__(self):
+        self.reset_pin = epdconfig.RST_PIN
+        self.dc_pin = epdconfig.DC_PIN
+        self.busy_pin = epdconfig.BUSY_PIN
+        self.cs_pin = epdconfig.CS_PIN
+        self.width = EPD_WIDTH
+        self.height = EPD_HEIGHT
+
+    # hardware reset
+    def reset(self):
+        epdconfig.digital_write(self.reset_pin, 1)
+        epdconfig.delay_ms(20)
+        epdconfig.digital_write(self.reset_pin, 0)
+        epdconfig.delay_ms(2)
+        epdconfig.digital_write(self.reset_pin, 1)
+        epdconfig.delay_ms(20)
+
+    # send 1 byte command
+    def send_command(self, command):
+        epdconfig.digital_write(self.dc_pin, 0)
+        epdconfig.digital_write(self.cs_pin, 0)
+        epdconfig.spi_writebyte([command])
+        epdconfig.digital_write(self.cs_pin, 1)
+
+    # send 1 byte data
+    def send_data(self, data):
+        epdconfig.digital_write(self.dc_pin, 1)
+        epdconfig.digital_write(self.cs_pin, 0)
+        epdconfig.spi_writebyte([data])
+        epdconfig.digital_write(self.cs_pin, 1)
+
+    # send a lot of data
+    def send_data2(self, data):
+        epdconfig.digital_write(self.dc_pin, 1)
+        epdconfig.digital_write(self.cs_pin, 0)
+        epdconfig.spi_writebyte2(data)
+        epdconfig.digital_write(self.cs_pin, 1)
+
+    # judge e-Paper whether is busy
+    def busy(self):
+        logger.debug("e-Paper busy")
+        while(epdconfig.digital_read(self.busy_pin) != 0):
+            epdconfig.delay_ms(10)
+        logger.debug("e-Paper busy release")
+
+    # set the display window
+    def set_windows(self, xstart, ystart, xend, yend):
+        self.send_command(0x44) # SET_RAM_X_ADDRESS_START_END_POSITION
+        self.send_data((xstart>>3) & 0xff)
+        self.send_data((xend>>3) & 0xff)
+
+        self.send_command(0x45) # SET_RAM_Y_ADDRESS_START_END_POSITION
+        self.send_data(ystart & 0xff)
+        self.send_data((ystart >> 8) & 0xff)
+        self.send_data(yend & 0xff)
+        self.send_data((yend >> 8) & 0xff)
+
+    # set the display cursor(origin)
+    def set_cursor(self, xstart, ystart):
+        self.send_command(0x4E) # SET_RAM_X_ADDRESS_COUNTER
+        self.send_data(xstart & 0xff)
+
+        self.send_command(0x4F) # SET_RAM_Y_ADDRESS_COUNTER
+        self.send_data(ystart & 0xff)
+        self.send_data((ystart >> 8) & 0xff)
+
+    # initialize
+    def init(self):
+        if (epdconfig.module_init() != 0):
+            return -1
+
+        self.reset()
+
+        self.busy()
+        self.send_command(0x12)  # SWRESET
+        self.busy()
+
+        self.send_command(0x01) # Driver output control
+        self.send_data(0xf9)
+        self.send_data(0x00)
+        self.send_data(0x00)
+
+        self.send_command(0x11) # data entry mode
+        self.send_data(0x03)
+
+        self.set_windows(0, 0, self.width - 1, self.height - 1)
+        self.set_cursor(0, 0)
+
+        self.send_command(0x3C) # BorderWavefrom
+        self.send_data(0x05)
+
+        self.send_command(0x18) # Read built-in temperature sensor
+        self.send_data(0x80)
+
+        self.send_command(0x21) # Display update control
+        self.send_data(0x80)
+        self.send_data(0x80)
+
+        self.busy()
+
+        return 0
+
+    # turn on display
+    def ondisplay(self):
+        self.send_command(0x20)
+        self.busy()
+
+    # image converted to bytearray
+    def getbuffer(self, image):
+        img = image
+        imwidth, imheight = img.size
+        if(imwidth == self.width and imheight == self.height):
+            img = img.convert('1')
+        elif(imwidth == self.height and imheight == self.width):
+            # image has correct dimensions, but needs to be rotated
+            img = img.rotate(90, expand=True).convert('1')
+        else:
+            logger.warning("Wrong image dimensions: must be " + str(self.width) + "x" + str(self.height))
+            # return a blank buffer
+            return [0x00] * (int(self.width/8) * self.height)
+
+        buf = bytearray(img.tobytes('raw'))
+        return buf
+
+    # display image
+    def display(self, imageblack, imagered=None):
+        self.send_command(0x24)
+        self.send_data2(imagered)
+
+        if not None==imagered:
+            self.send_command(0x26)
+            self.send_data2(imageblack)
+
+        self.ondisplay()
+
+    # display white image
+    def clear(self):
+        if self.width%8 == 0:
+            linewidth = int(self.width/8)
+        else:
+            linewidth = int(self.width/8) + 1
+
+        buf = [0xff] * (int(linewidth * self.height))
+        self.send_command(0x24)
+        self.send_data2(buf)
+
+        self.send_command(0x26)
+        self.send_data2(buf)
+
+        self.ondisplay()
+
+    # Compatible with older version functions
+    def Clear(self):
+        self.clear()
+
+    # sleep
+    def sleep(self):
+        self.send_command(0x10) # DEEP_SLEEP
+        self.send_data(0x01) # check code
+        epdconfig.delay_ms(2000)
+        epdconfig.module_exit()
+
+    ################################################################################
+    # Compatibility wrapper functions                                              #
+    ################################################################################
+    def ReadBusy(self):
+        self.busy()
+
+    def SetWindow(self, x_start, y_start, x_end, y_end):
+        self.set_windows(x_start, y_start, x_end, y_end)
+
+    def SetCursor(self, x, y):
+        self.set_cursor(x, y)
+
+    def TurnOnDisplay(self):
+        self.ondisplay()
+
+    def TurnOnDisplay_Fast(self):
+        self.TurnOnDisplay()
+
+    '''
+    function : Turn On Display Part
+    parameter:
+    '''
+    def TurnOnDisplayPart(self):
+        self.send_command(0x22) # Display Update Control
+        self.send_data(0xff)    # fast:0x0c, quality:0x0f, 0xcf
+        self.send_command(0x20) # Activate Display Update Sequence
+        self.ReadBusy()
+
+    '''
+    function : Sends the image buffer in RAM to e-Paper and partial refresh
+    parameter:
+        image : Image data
+    '''
+    def displayPartial(self, image):
+        epdconfig.digital_write(self.reset_pin, 0)
+        epdconfig.delay_ms(1)
+        epdconfig.digital_write(self.reset_pin, 1)
+
+        self.send_command(0x3C) # BorderWavefrom
+        self.send_data(0x80)
+
+        self.send_command(0x01) # Driver output control
+        self.send_data(0xF9)
+        self.send_data(0x00)
+        self.send_data(0x00)
+
+        self.send_command(0x11) # data entry mode
+        self.send_data(0x03)
+
+        self.SetWindow(0, 0, self.width - 1, self.height - 1)
+        self.SetCursor(0, 0)
+
+        self.send_command(0x24) # WRITE_RAM
+        self.send_data2(image)
+        self.TurnOnDisplayPart()
+
+### END OF FILE ###

--- a/shared.py
+++ b/shared.py
@@ -115,6 +115,7 @@ DISPLAY_PROFILES = {
     "epd2in13_V2": {"ref_width": DESIGN_REF_WIDTH, "ref_height": DESIGN_REF_HEIGHT, "default_flip": False},
     "epd2in13_V3": {"ref_width": DESIGN_REF_WIDTH, "ref_height": DESIGN_REF_HEIGHT, "default_flip": True},
     "epd2in13_V4": {"ref_width": DESIGN_REF_WIDTH, "ref_height": DESIGN_REF_HEIGHT, "default_flip": False},
+    "epd2in13b_V4": {"ref_width": DESIGN_REF_WIDTH, "ref_height": DESIGN_REF_HEIGHT, "default_flip": False},
     # Waveshare 4.26" 800x480 e-paper (landscape) — use DESIGN_REF so the
     # scale-factor system uniformly scales the 122×250 layout up.  The
     # vertical factor (480/250 = 1.92) dominates; we use that for the


### PR DESCRIPTION
I got a Waveshare 'epd2in13b_V4' display which is capable of displaying black/white/red color. This one does not work using the 'epd2in13_V4' (without 'b') driver.  So I tried to implement the Ragnar API wrapper into the [original waveshare driver](https://github.com/waveshareteam/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in13b_V4.py).
This branch is the result... Hope it works for others too.