### PR TITLE
Filter duplicate networks for HuginnESP WiFi count

### DIFF
--- a/wardriving.py
+++ b/wardriving.py
@@ -375,6 +375,7 @@ class WardrivingSession:
                               now, now, rssi, lat, lon, interface, band, is_camera))
                         self.unique_bssids.add(bssid)
                         self.network_count = len(self.unique_bssids)
+                        return True
 
                     # Per-interface observation row — records what THIS adapter
                     # actually saw, independent of which adapter "owns" the
@@ -406,6 +407,7 @@ class WardrivingSession:
 
             except Exception as e:
                 logger.error(f"DB upsert error: {e}")
+        return False
 
     def log_gps_track(self, lat, lon, alt, speed, satellites, hdop):
         """Log a GPS trackpoint."""
@@ -3169,13 +3171,14 @@ class WardrivingEngine:
                     freq = 0
                     if channel:
                         freq = (2407 + channel * 5) if channel <= 14 else (5000 + channel * 5)
-                    self.session.upsert_network(
+                    is_new = self.session.upsert_network(
                         bssid=mac, ssid=ssid, security=auth,
                         channel=channel, frequency=freq, rssi=rssi,
                         lat=lat, lon=lon, alt=alt, speed=None, hdop=None,
                         interface='esp32-serial'
                     )
-                    self.serial_networks += 1
+                    if is_new:
+                        self.serial_networks += 1
                 return
             except (json.JSONDecodeError, ValueError):
                 pass
@@ -3323,13 +3326,14 @@ class WardrivingEngine:
                 signal_dbm=rssi, lat=lat, lon=lon
             )
         else:
-            self.session.upsert_network(
+            is_new = self.session.upsert_network(
                 bssid=mac, ssid=ssid, security=auth,
                 channel=channel, frequency=freq, rssi=rssi,
                 lat=lat, lon=lon, alt=alt, speed=None, hdop=None,
                 interface='esp32-serial'
             )
-            self.serial_networks += 1
+            if is_new:
+                self.serial_networks += 1
 
     def _flush_serial_entry(self, gps_lat, gps_lon, gps_alt):
         """Flush a buffered HuginnESP multi-line entry to the session."""
@@ -3357,10 +3361,11 @@ class WardrivingEngine:
         if channel:
             freq = (2407 + channel * 5) if channel <= 14 else (5000 + channel * 5)
 
-        self.session.upsert_network(
+        is_new = self.session.upsert_network(
             bssid=bssid, ssid=ssid, security=security,
             channel=channel, frequency=freq, rssi=rssi,
             lat=gps_lat, lon=gps_lon, alt=gps_alt, speed=None, hdop=None,
             interface='esp32-serial'
         )
-        self.serial_networks += 1
+        if is_new:
+            self.serial_networks += 1


### PR DESCRIPTION
## Summary

- `upsert_network` now returns `True` when a new BSSID is inserted, `False` when updating an existing one
- `serial_networks` counter (WiFi count shown in the Huginn card) only increments on genuinely new networks — not on repeated scans of the same BSSID
- BLE was already deduplicated by MAC via the database query, so no change needed there

## Before / After

| Field | Before | After |
|---|---|---|
| WiFi | Total observations (inflated by re-scans) | Unique BSSIDs only |
| BLE | Already unique | Unchanged |
| Unique | Deduplicated WiFi (redundant label) | Same value, now consistent with WiFi |

## Test plan

- [ ] Connect HuginnESP and let it scan for a while — WiFi count should plateau once all local networks are seen, not keep climbing
- [ ] Restart and verify the counter resets to 0 and climbs back to the unique network count
- [ ] Confirm BLE count is unchanged

https://claude.ai/code/session_019stSxaLRGnhdDJvZxYEYKv

---
_Generated by [Claude Code](https://claude.ai/code/session_019stSxaLRGnhdDJvZxYEYKv)_