### PR TITLE
Wardriving card: power-health warning banner

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -3691,6 +3691,15 @@
         <!-- Wardriving Tab -->
         <div id="wardriving-tab" class="tab-content hidden">
             <div class="glass rounded-xl p-4 sm:p-6">
+                <div id="wd-power-warning" class="hidden mb-4 px-4 py-3 rounded-lg border flex items-start gap-3">
+                    <svg class="w-5 h-5 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M5 19h14a2 2 0 001.84-2.75L13.74 4a2 2 0 00-3.48 0L3.16 16.25A2 2 0 005 19z"/>
+                    </svg>
+                    <div class="text-sm">
+                        <div id="wd-power-warning-title" class="font-semibold">Power supply issue</div>
+                        <div id="wd-power-warning-msg" class="text-xs opacity-90 mt-0.5"></div>
+                    </div>
+                </div>
                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
                     <div class="flex items-center space-x-3">
                         <h2 class="text-lg sm:text-2xl font-bold">Wardriving</h2>
@@ -4911,7 +4920,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260520b"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260520c"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -14712,7 +14712,25 @@ async function refreshWardrivingStatus() {
 function updateWardrivingUI(status) {
     const badge = document.getElementById('wd-status-badge');
 
-    // Sync running state and toggle button
+    const powerEl = document.getElementById('wd-power-warning');
+    if (powerEl) {
+        const p = status.power;
+        if (p && p.status && p.status !== 'ok' && p.message) {
+            powerEl.classList.remove('hidden');
+            const isCritical = p.status === 'critical';
+            powerEl.className = 'mb-4 px-4 py-3 rounded-lg border flex items-start gap-3 ' +
+                (isCritical
+                    ? 'bg-red-900/30 border-red-500/50 text-red-200'
+                    : 'bg-yellow-900/30 border-yellow-500/50 text-yellow-200');
+            const titleEl = document.getElementById('wd-power-warning-title');
+            const msgEl = document.getElementById('wd-power-warning-msg');
+            if (titleEl) titleEl.textContent = isCritical ? 'Power supply critical' : 'Power supply marginal';
+            if (msgEl) msgEl.textContent = p.message;
+        } else {
+            powerEl.classList.add('hidden');
+        }
+    }
+
     _wardrivingRunning = !!status.running;
     updateWardrivingToggleButton();
 

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -6332,6 +6332,83 @@ def _get_wardriving_engine():
         _wardriving_engine = WardrivingEngine(shared_data)
     return _wardriving_engine
 
+_power_health_cache = {'ts': 0, 'value': None}
+
+def _get_power_health():
+    """Read Pi power state via vcgencmd. Cached for 5 s. Returns None on
+    non-Pi hosts where vcgencmd is unavailable."""
+    import subprocess, re as _re, time as _time
+    now = _time.time()
+    if now - _power_health_cache['ts'] < 5 and _power_health_cache['value'] is not None:
+        return _power_health_cache['value']
+
+    try:
+        thr_out = subprocess.run(
+            ['vcgencmd', 'get_throttled'],
+            capture_output=True, text=True, timeout=2
+        )
+        if thr_out.returncode != 0:
+            return None
+        m = _re.search(r'throttled=0x([0-9a-fA-F]+)', thr_out.stdout)
+        if not m:
+            return None
+        thr = int(m.group(1), 16)
+    except (FileNotFoundError, subprocess.TimeoutExpired, Exception):
+        return None
+
+    ext5v = None
+    try:
+        v_out = subprocess.run(
+            ['vcgencmd', 'pmic_read_adc', 'EXT5V_V'],
+            capture_output=True, text=True, timeout=2
+        )
+        m = _re.search(r'volt\(\d+\)=([\d.]+)V', v_out.stdout)
+        if m:
+            ext5v = float(m.group(1))
+    except Exception:
+        pass
+
+    currently_undervolted = bool(thr & 0x1)
+    currently_capped      = bool(thr & 0x2)
+    currently_throttled   = bool(thr & 0x4)
+    ever_undervolted      = bool(thr & 0x10000)
+    ever_capped           = bool(thr & 0x20000)
+    ever_throttled        = bool(thr & 0x40000)
+
+    status = 'ok'
+    message = None
+    if currently_undervolted or currently_throttled:
+        status = 'critical'
+        if currently_undervolted:
+            message = f"Pi is undervolted right now ({ext5v:.2f} V at input)" if ext5v else "Pi is undervolted right now"
+        else:
+            message = "Pi is currently throttling"
+    elif ext5v is not None and ext5v < 4.85:
+        status = 'critical'
+        message = f"Input voltage low ({ext5v:.2f} V) — USB devices may fail to enumerate"
+    elif ext5v is not None and ext5v < 4.95:
+        status = 'warning'
+        message = f"Input voltage marginal ({ext5v:.2f} V) — consider a higher-output USB-PD powerbank"
+    elif ever_undervolted or ever_throttled:
+        status = 'warning'
+        message = "Undervoltage / throttling has occurred since boot — power supply may be inadequate under load"
+
+    value = {
+        'available': True,
+        'status': status,
+        'message': message,
+        'ext5v_volts': ext5v,
+        'throttled_hex': f"0x{thr:x}",
+        'currently_undervolted': currently_undervolted,
+        'currently_throttled': currently_throttled,
+        'ever_undervolted': ever_undervolted,
+        'ever_throttled': ever_throttled,
+    }
+    _power_health_cache['ts'] = now
+    _power_health_cache['value'] = value
+    return value
+
+
 @app.route('/api/wardriving/status')
 def wardriving_status():
     """Get wardriving engine status."""
@@ -6341,6 +6418,9 @@ def wardriving_status():
         engine = _get_wardriving_engine()
         status = engine.get_status()
         status['enabled'] = True
+        ph = _get_power_health()
+        if ph is not None:
+            status['power'] = ph
         return jsonify(status)
     except Exception as e:
         logger.error(f"Wardriving status error: {e}")


### PR DESCRIPTION
Reads Pi power state via vcgencmd (get_throttled + pmic_read_adc EXT5V_V), classifies as ok / warning / critical, and surfaces a banner above the wardriving card when degraded. Critical = currently undervolted, currently throttled, or input voltage below 4.85 V. Warning = input 4.85–4.95 V, or any sticky throttle/undervolt bit since boot. Cached server-side for 5 s.

Closes the diagnostic gap where get_throttled=0x0 makes the Pi look fine but EXT5V at 4.9 V is silently preventing high-current USB peripherals from enumerating — symptom we saw with the NETGEAR A6210 missing from interfaces on a marginal powerbank.

On non-Pi hosts vcgencmd isn't present; the helper returns None and the banner stays hidden.