### PR TITLE
Power warning: lower EXT5V thresholds to match real Pi 5 readings

### DIFF
--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -6383,10 +6383,10 @@ def _get_power_health():
             message = f"Pi is undervolted right now ({ext5v:.2f} V at input)" if ext5v else "Pi is undervolted right now"
         else:
             message = "Pi is currently throttling"
-    elif ext5v is not None and ext5v < 4.85:
+    elif ext5v is not None and ext5v < 4.70:
         status = 'critical'
-        message = f"Input voltage low ({ext5v:.2f} V) — USB devices may fail to enumerate"
-    elif ext5v is not None and ext5v < 4.95:
+        message = f"Input voltage low ({ext5v:.2f} V) — close to undervoltage trip, USB devices may fail to enumerate"
+    elif ext5v is not None and ext5v < 4.80:
         status = 'warning'
         message = f"Input voltage marginal ({ext5v:.2f} V) — consider a higher-output USB-PD powerbank"
     elif ever_undervolted or ever_throttled:


### PR DESCRIPTION
A Pi 5 fed by a known-good 100 W USB-PD wall supply reads EXT5V_V around 4.90 V — the PMIC measures after the input protection circuit, so even a clean source sits ~100-150 mV below the nominal 5 V. The 4.85 / 4.95 V thresholds were firing on healthy hardware.

The Pi's own undervoltage trip is at 4.63 V, so genuinely-degraded power doesn't start until ~4.70 V. New thresholds:
- critical: EXT5V < 4.70 V
- warning:  EXT5V < 4.80 V

Throttle-bit and sticky-history checks are unchanged — those are the Pi's own measurements and are independent of where I draw the EXT5V line.