### PR TITLE
gps from piglet

### DIFF
--- a/gps_manager.py
+++ b/gps_manager.py
@@ -235,6 +235,11 @@ class GPSManager:
         self._gsv_by_talker = {}
         self.connected = False
         self.error = None
+        # Tracks whether the current position came from an external source
+        # (e.g. a USB-connected Piglet companion reporting its own GPS).
+        # Set by update_external_fix(); cleared once a local receiver
+        # produces a real fix.
+        self._external_source = None
 
     def start(self):
         """Start GPS reading thread."""
@@ -335,9 +340,15 @@ class GPSManager:
     def get_status(self):
         """Return full GPS status dict."""
         with self._lock:
+            if self._external_source:
+                source = self._external_source
+            elif self._use_gpsd:
+                source = 'gpsd'
+            else:
+                source = 'serial'
             return {
                 'connected': self.connected,
-                'source': 'gpsd' if self._use_gpsd else 'serial',
+                'source': source,
                 'port': self.port,
                 'has_fix': self.has_fix(),
                 'fix_quality': self.fix_quality,
@@ -354,6 +365,70 @@ class GPSManager:
                 'last_sentence': self.last_sentence,
                 'error': self.error
             }
+
+    def update_external_fix(self, lat, lon, alt=None, speed_kmh=None,
+                            satellites=None, hdop=None, source='companion'):
+        """Inject a position from an external source (e.g. a USB-connected
+        Piglet/HuginnESP companion that has its own GPS receiver).
+
+        Lets Ragnar operate as if it had GPS even when no local receiver is
+        attached, so BT/cell scans, the gps_track table, and the status UI
+        all see a position. A local receiver always wins: if NMEA from the
+        directly-attached GPS arrived within the last 5 s we ignore the
+        external update.
+        """
+        if lat is None or lon is None:
+            return False
+        try:
+            lat = float(lat)
+            lon = float(lon)
+        except (TypeError, ValueError):
+            return False
+        # Reject the "no fix yet" sentinel many modules emit (0.0, 0.0 is
+        # in the Gulf of Guinea — practically never a real wardriving fix).
+        if lat == 0.0 and lon == 0.0:
+            return False
+        now = time.time()
+        # Prefer a fresh local fix over an external one. Only skip when the
+        # current state actually came from a local receiver (NMEA/gpsd) —
+        # otherwise back-to-back external updates would block each other.
+        if (self._external_source is None
+                and (self._serial is not None or self._gpsd_sock is not None)
+                and self.last_update
+                and (now - self.last_update) < 5
+                and self.fix_quality > 0):
+            return False
+        with self._lock:
+            self.latitude = lat
+            self.longitude = lon
+            if alt is not None:
+                try:
+                    self.altitude = float(alt)
+                except (TypeError, ValueError):
+                    pass
+            if speed_kmh is not None:
+                try:
+                    self.speed_kmh = float(speed_kmh)
+                except (TypeError, ValueError):
+                    pass
+            if satellites is not None:
+                try:
+                    self.satellites = int(satellites)
+                except (TypeError, ValueError):
+                    pass
+            if hdop is not None:
+                try:
+                    self.hdop = float(hdop)
+                except (TypeError, ValueError):
+                    pass
+            if self.fix_quality <= 0:
+                self.fix_quality = 1
+            self.last_update = now
+            self.last_sentence = now
+            self.connected = True
+            self.error = None
+            self._external_source = source
+        return True
 
     def _read_loop_gpsd(self):
         """Background thread: read JSON objects from gpsd and parse position."""
@@ -427,6 +502,7 @@ class GPSManager:
                 self.fix_quality = 2 if status == 2 else 1
                 self.hdop = obj.get('hdop') or self.hdop
                 self.last_update = now
+                self._external_source = None
             else:
                 self.fix_quality = 0
             self.last_sentence = now
@@ -544,6 +620,7 @@ class GPSManager:
                     pass
                 self.last_update = now
                 self.last_sentence = now
+                self._external_source = None
             return
 
         # RMC — position + speed + course
@@ -567,6 +644,7 @@ class GPSManager:
                         pass
                     self.last_update = now
                     self.last_sentence = now
+                    self._external_source = None
             else:
                 with self._lock:
                     self.last_sentence = now

--- a/wardriving.py
+++ b/wardriving.py
@@ -3436,6 +3436,27 @@ class WardrivingEngine:
 
                 mac = data.get('mac', data.get('bssid', '')).upper()
                 if not mac or len(mac) < 12:
+                    # GPS-only telemetry from the companion. Some Piglet
+                    # builds emit standalone fixes like:
+                    #   {"type":"GPS","lat":..,"lon":..,"alt":..,"sats":..}
+                    # No MAC → not a network/BT row, but the position is
+                    # still useful for Ragnar's own scans + gps_track log.
+                    if self._gps is not None:
+                        try:
+                            elat = data.get('lat', data.get('latitude'))
+                            elon = data.get('lon', data.get('longitude'))
+                            ealt = data.get('alt', data.get('altitude'))
+                            esats = data.get('sats', data.get('satellites'))
+                            espeed = data.get('speed_kmh', data.get('speed'))
+                            ehdop = data.get('hdop')
+                            if elat is not None and elon is not None:
+                                self._gps.update_external_fix(
+                                    elat, elon, ealt,
+                                    speed_kmh=espeed, satellites=esats, hdop=ehdop,
+                                    source=self._companion_name or 'companion'
+                                )
+                        except Exception:
+                            pass
                     return
                 ssid = data.get('ssid', data.get('name', ''))
                 rssi = int(data.get('rssi', data.get('signal', -80)))
@@ -3470,6 +3491,12 @@ class WardrivingEngine:
                     )
                     if is_new:
                         self.serial_networks += 1
+                # Adopt the companion's GPS fix when Ragnar has no local
+                # receiver (or the local one is stale). Falls back silently
+                # if the companion reports the 0.0/0.0 sentinel.
+                if lat is not None and lon is not None and self._gps is not None:
+                    self._gps.update_external_fix(lat, lon, alt,
+                                                   source=self._companion_name or 'companion')
                 return
             except (json.JSONDecodeError, ValueError):
                 pass
@@ -3646,6 +3673,15 @@ class WardrivingEngine:
             lat = gps_lat
             lon = gps_lon
             alt = gps_alt
+
+        # If the companion actually has a fix (non-zero lat/lon parsed from
+        # its WiGLE row), adopt it as Ragnar's position. Lets us wardrive
+        # GPS-tagged even with no GPS receiver on the Pi itself.
+        if (lat is not None and lon is not None
+                and not (lat == 0.0 and lon == 0.0)
+                and self._gps is not None):
+            self._gps.update_external_fix(lat, lon, alt,
+                                          source=self._companion_name or 'companion')
 
         record_type = (_field('type') or 'WIFI').upper()
 


### PR DESCRIPTION
This pull request adds support for using external GPS fixes—such as those from a connected companion device—when no local GPS receiver is available or when the local fix is stale. The changes ensure that the system can seamlessly adopt and report positions from external sources, improving robustness in scenarios where the onboard GPS is unavailable or unreliable.

**External GPS Fix Integration:**

* Added the `_external_source` attribute to the `GPSManager` class to track when a position comes from an external source, and updated the `get_status` method to report the correct source (`serial`, `gpsd`, or external). [[1]](diffhunk://#diff-ecf8269cfc17cda0874b9bc1637ff64b656570a2fe6e75fb7c807609da158996R238-R242) [[2]](diffhunk://#diff-ecf8269cfc17cda0874b9bc1637ff64b656570a2fe6e75fb7c807609da158996R343-R351)
* Implemented the `update_external_fix` method in `GPSManager` to allow injection of external GPS positions, with logic to prefer recent local fixes and to reject invalid/sentinel values.
* Modified NMEA and gpsd parsing methods to clear `_external_source` when a valid local fix is received, ensuring the system switches back to local data when available. [[1]](diffhunk://#diff-ecf8269cfc17cda0874b9bc1637ff64b656570a2fe6e75fb7c807609da158996R505) [[2]](diffhunk://#diff-ecf8269cfc17cda0874b9bc1637ff64b656570a2fe6e75fb7c807609da158996R623) [[3]](diffhunk://#diff-ecf8269cfc17cda0874b9bc1637ff64b656570a2fe6e75fb7c807609da158996R647)

**Companion Device Data Handling:**

* Updated `wardriving.py` to detect and process GPS-only telemetry from companion devices, calling `update_external_fix` when appropriate, including when parsing standalone GPS fixes or WiGLE rows. [[1]](diffhunk://#diff-22fe1f64957729edb89cd0dc3b053ec11ce1ba58ed700fabf3e6e64fb9718052R3439-R3459) [[2]](diffhunk://#diff-22fe1f64957729edb89cd0dc3b053ec11ce1ba58ed700fabf3e6e64fb9718052R3494-R3499) [[3]](diffhunk://#diff-22fe1f64957729edb89cd0dc3b053ec11ce1ba58ed700fabf3e6e64fb9718052R3677-R3685)