### PR TITLE
network

### DIFF
--- a/actions/scanning.py
+++ b/actions/scanning.py
@@ -243,12 +243,19 @@ class NetworkScanner:
 
     def run_arp_scan(self, network=None):
         """Execute arp-scan to get MAC addresses and vendor information for local network hosts."""
-        # Try both --localnet and explicit subnet scanning for comprehensive MAC discovery
-        subnet = str(network) if network else '192.168.1.0/24'
+        if network is None:
+            network = self.get_network()
         commands = [
             ['sudo', 'arp-scan', f'--interface={self.arp_scan_interface}', '--localnet'],
-            ['sudo', 'arp-scan', f'--interface={self.arp_scan_interface}', subnet]
         ]
+        if network is not None:
+            commands.append(
+                ['sudo', 'arp-scan',
+                 f'--interface={self.arp_scan_interface}', str(network)])
+        else:
+            self.logger.warning(
+                "run_arp_scan: no explicit subnet and detection failed; "
+                "falling back to --localnet only")
         
         all_hosts = {}
         
@@ -441,11 +448,17 @@ class NetworkScanner:
         known_ips = set(arp_hosts.keys())
 
         if not target_cidrs:
-            target_cidrs = ['192.168.1.0/24']
+            detected = self.get_network()
+            if detected is not None:
+                target_cidrs = [str(detected)]
+            else:
+                self.logger.error(
+                    "_ping_sweep_missing_hosts: no target CIDR and network "
+                    "detection failed — skipping ping sweep")
+                return ping_discovered
 
-        # CRITICAL TARGET: Always ensure 192.168.1.192 is checked explicitly unless overridden
         if priority_targets is None:
-            priority_targets = ['192.168.1.192']
+            priority_targets = []
 
         self.logger.info(f"🔍 Starting ping sweep - ARP found {len(arp_hosts)} hosts, checking {254} additional IPs")
 
@@ -586,7 +599,10 @@ class NetworkScanner:
                 if network:
                     target_cidrs.append(str(network))
                 else:
-                    target_cidrs.append('192.168.1.0/24')
+                    self.logger.error(
+                        "Initial ping sweep aborted: no target CIDR and "
+                        "network detection failed")
+                    return {}
 
             self.logger.info(f"🚀 Initial ping sweep requested across {', '.join(target_cidrs)}")
             arp_hosts = self.run_arp_scan(network=network) if include_arp_scan else {}
@@ -940,10 +956,11 @@ class NetworkScanner:
                                 return network
                 except Exception as e:
                     self.logger.warning(f"Failed to detect any network: {e}")
-                self.logger.warning("netifaces not available, using default network range")
-                network = ipaddress.IPv4Network("192.168.1.0/24", strict=False)
-                self.logger.info(f"Network (default): {network}")
-                return network
+                self.logger.error(
+                    "Unable to detect local network — netifaces missing and "
+                    "'ip' command output could not be parsed. Caller must "
+                    "supply an explicit CIDR.")
+                return None
                 
             gws = netifaces.gateways()
             default_gateway = gws['default'][netifaces.AF_INET][1]

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -78,8 +78,8 @@
 - Failures (missing binary, timeout) logged with guidance to install `arp-scan` or widen sudo privileges.
 
 ### 5.3 Ping Sweep
-- Targets missing from ARP results across configured CIDRs (default `192.168.1.0/24`, user-addable via config or UI).
-- Priority list (default `192.168.1.192`, user-configurable) pinged with 3 attempts, 3 s timeout before general sweep (single ping, 2 s wait). Purpose: ensure crown-jewel host stays monitored even if stealthy.
+- Targets missing from ARP results across configured CIDRs. CIDR defaults to the result of `get_network()` (parses `ip route` / `ip addr show` / netifaces) — no static fallback subnet; if detection fails, the sweep is skipped with an error logged.
+- Priority list is empty by default. Callers can pass a custom list of crown-jewel IPs to `_ping_sweep_missing_hosts(priority_targets=...)` for guaranteed coverage with 3 attempts × 3 s timeout before the general sweep.
 - Missing MACs create temporary pseudo-MACs (`00:00:<ip octets>`) until reconciled in `update_netkb()` with real data; DB marks them `is_pseudo=1`.
 - Threaded execution honors `network_max_failed_pings`, `mac_scan_blacklist`, and `ip_scan_blacklist`. Workers limited to `host_scan_workers` (default 4).
 - Summary stats (hosts seen, time taken) logged for e-paper and AI ingestion.

--- a/spec.md
+++ b/spec.md
@@ -78,8 +78,8 @@
 - Failures (missing binary, timeout) logged with guidance to install `arp-scan` or widen sudo privileges.
 
 ### 5.3 Ping Sweep
-- Targets missing from ARP results across configured CIDRs (default `192.168.1.0/24`, user-addable via config or UI).
-- Priority list (default `192.168.1.192`, user-configurable) pinged with 3 attempts, 3 s timeout before general sweep (single ping, 2 s wait). Purpose: ensure crown-jewel host stays monitored even if stealthy.
+- Targets missing from ARP results across configured CIDRs. CIDR defaults to the result of `get_network()` (parses `ip route` / `ip addr show` / netifaces) — no static fallback subnet; if detection fails, the sweep is skipped with an error logged.
+- Priority list is empty by default. Callers can pass a custom list of crown-jewel IPs to `_ping_sweep_missing_hosts(priority_targets=...)` for guaranteed coverage with 3 attempts × 3 s timeout before the general sweep.
 - Missing MACs create temporary pseudo-MACs (`00:00:<ip octets>`) until reconciled in `update_netkb()` with real data; DB marks them `is_pseudo=1`.
 - Threaded execution honors `network_max_failed_pings`, `mac_scan_blacklist`, and `ip_scan_blacklist`. Workers limited to `host_scan_workers` (default 4).
 - Summary stats (hosts seen, time taken) logged for e-paper and AI ingestion.

--- a/tests/test_passive_host_discovery.py
+++ b/tests/test_passive_host_discovery.py
@@ -1,0 +1,370 @@
+"""Tests for passive host discovery via TrafficAnalyzer.
+
+Covers:
+- ARP reply parsing -> IP↔MAC mapping
+- LAN-network derivation and is_lan_ip
+- Listening-port detection from observed service ports
+- _passive_sync_to_db merge semantics:
+  * existing host gets new ports added (no replace)
+  * new LAN IP creates a host
+  * non-LAN traffic does not touch the DB
+  * host without MAC and few packets is below threshold
+"""
+
+import ipaddress
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from traffic_analyzer import TrafficAnalyzer
+
+
+@pytest.fixture
+def analyzer():
+    with patch.object(TrafficAnalyzer, '_detect_interface', return_value='lo'), \
+         patch.object(TrafficAnalyzer, '_detect_local_ips',
+                      return_value={'127.0.0.1', '192.168.1.10'}), \
+         patch.object(TrafficAnalyzer, '_detect_gateway_ips',
+                      return_value={'192.168.1.1'}):
+        a = TrafficAnalyzer(shared_data=None, interface='lo')
+    a.MAX_ALERTS_PER_MINUTE = 10_000
+    a._alert_dedup_window = 0
+    return a
+
+
+# ---------------------------------------------------------------------------
+# _is_lan_ip / LAN-network derivation
+# ---------------------------------------------------------------------------
+
+def test_lan_networks_include_gateway_and_local_subnet(analyzer):
+    nets = analyzer._lan_networks
+    assert any(ipaddress.IPv4Address('192.168.1.50') in n for n in nets)
+
+
+@pytest.mark.parametrize("ip,expected", [
+    ('192.168.1.50', True),       # same /24 as gateway + local
+    ('192.168.1.255', True),      # boundary still in subnet
+    ('192.168.2.50', False),      # other /24
+    ('10.0.0.5', False),          # different RFC1918 block
+    ('8.8.8.8', False),           # public
+    ('127.0.0.1', False),         # loopback
+    ('169.254.1.1', False),       # link-local
+    ('224.0.0.1', False),         # multicast
+    ('', False),
+    ('not-an-ip', False),
+])
+def test_is_lan_ip(analyzer, ip, expected):
+    assert analyzer._is_lan_ip(ip) is expected
+
+
+# ---------------------------------------------------------------------------
+# ARP parsing
+# ---------------------------------------------------------------------------
+
+def test_arp_reply_extracts_mac(analyzer):
+    line = ('2026-05-28 01:00:00.000000 ARP, Reply 192.168.1.50 '
+            'is-at aa:bb:cc:dd:ee:ff, length 28')
+    analyzer._parse_and_record_packet(line)
+
+    assert analyzer._mac_by_ip['192.168.1.50'] == 'aa:bb:cc:dd:ee:ff'
+    assert analyzer.host_stats['192.168.1.50'].mac == 'aa:bb:cc:dd:ee:ff'
+
+
+def test_arp_reply_outside_lan_ignored(analyzer):
+    line = ('2026-05-28 01:00:00.000000 ARP, Reply 10.0.0.50 '
+            'is-at aa:bb:cc:dd:ee:ff, length 28')
+    analyzer._parse_and_record_packet(line)
+
+    assert '10.0.0.50' not in analyzer._mac_by_ip
+
+
+def test_arp_request_does_not_record_mac(analyzer):
+    # "tell" lines don't include the requester's MAC in -q output.
+    line = ('2026-05-28 01:00:00.000000 ARP, Request who-has 192.168.1.1 '
+            'tell 192.168.1.50, length 28')
+    analyzer._parse_and_record_packet(line)
+    assert '192.168.1.50' not in analyzer._mac_by_ip
+
+
+# ---------------------------------------------------------------------------
+# Listening-port detection
+# ---------------------------------------------------------------------------
+
+def test_listening_port_recorded_when_well_known_dst(analyzer):
+    base_ts = '2026-05-28 01:00:00.000000'
+    line = f'{base_ts} IP 192.168.1.20.50000 > 192.168.1.50.443: tcp 0'
+    analyzer._parse_and_record_packet(line)
+
+    assert 443 in analyzer._listening_ports['192.168.1.50']
+
+
+def test_listening_port_recorded_for_high_value_high_port(analyzer):
+    base_ts = '2026-05-28 01:00:00.000000'
+    line = f'{base_ts} IP 192.168.1.20.50000 > 192.168.1.50.6379: tcp 0'
+    analyzer._parse_and_record_packet(line)
+
+    assert 6379 in analyzer._listening_ports['192.168.1.50']
+
+
+def test_listening_port_not_recorded_for_ephemeral(analyzer):
+    base_ts = '2026-05-28 01:00:00.000000'
+    # Random ephemeral; should NOT be considered a listening port.
+    line = f'{base_ts} IP 192.168.1.20.50000 > 192.168.1.50.40000: tcp 0'
+    analyzer._parse_and_record_packet(line)
+
+    assert 192_168_1_50 != 0  # sanity
+    listening = analyzer._listening_ports.get('192.168.1.50', set())
+    assert 40000 not in listening
+
+
+def test_listening_port_not_recorded_for_non_lan(analyzer):
+    base_ts = '2026-05-28 01:00:00.000000'
+    line = f'{base_ts} IP 192.168.1.20.50000 > 8.8.8.8.443: tcp 0'
+    analyzer._parse_and_record_packet(line)
+
+    assert '8.8.8.8' not in analyzer._listening_ports
+
+
+# ---------------------------------------------------------------------------
+# Pseudo-MAC helper
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("ip,expected", [
+    ('192.168.1.50', '00:00:c0:a8:01:32'),
+    ('10.0.0.1', '00:00:0a:00:00:01'),
+    ('255.255.255.255', '00:00:ff:ff:ff:ff'),
+    ('not.an.ip.addr', ''),
+    ('1.2.3', ''),
+])
+def test_ip_to_pseudo_mac(ip, expected):
+    assert TrafficAnalyzer._ip_to_pseudo_mac(ip) == expected
+
+
+# ---------------------------------------------------------------------------
+# _passive_sync_to_db
+# ---------------------------------------------------------------------------
+
+def _build_db(existing_by_ip=None):
+    db = MagicMock()
+    db.get_host_by_ip.side_effect = lambda ip: (existing_by_ip or {}).get(ip)
+    db.upsert_host.return_value = True
+    return db
+
+
+def test_passive_sync_creates_new_host_with_real_mac(analyzer):
+    db = _build_db()
+    analyzer.shared_data = MagicMock(db=db)
+
+    # Seed: ARP reply + a packet to a service port.
+    base_ts = '2026-05-28 01:00:00.000000'
+    analyzer._parse_and_record_packet(
+        f'{base_ts} ARP, Reply 192.168.1.50 is-at aa:bb:cc:dd:ee:ff, length 28')
+    analyzer._parse_and_record_packet(
+        f'{base_ts} IP 192.168.1.20.50000 > 192.168.1.50.443: tcp 0')
+
+    analyzer._passive_sync_to_db()
+
+    db.upsert_host.assert_called()
+    call = db.upsert_host.call_args
+    assert call.kwargs['mac'] == 'aa:bb:cc:dd:ee:ff'
+    assert call.kwargs['ip'] == '192.168.1.50'
+    assert '443' in (call.kwargs['ports'] or '')
+    services = call.kwargs.get('services') or {}
+    assert services.get('443') == 'https'
+
+
+def test_passive_sync_merges_ports_with_existing_host(analyzer):
+    existing = {
+        '192.168.1.50': {
+            'mac': 'aa:bb:cc:dd:ee:ff',
+            'ports': '80,22',
+            'services': '{"22": "ssh", "80": "http"}',
+        }
+    }
+    db = _build_db(existing)
+    analyzer.shared_data = MagicMock(db=db)
+
+    base_ts = '2026-05-28 01:00:00.000000'
+    # Observed listening on 443 and 6379 (new ports).
+    analyzer._parse_and_record_packet(
+        f'{base_ts} ARP, Reply 192.168.1.50 is-at aa:bb:cc:dd:ee:ff, length 28')
+    analyzer._parse_and_record_packet(
+        f'{base_ts} IP 192.168.1.20.50000 > 192.168.1.50.443: tcp 0')
+    analyzer._parse_and_record_packet(
+        f'{base_ts} IP 192.168.1.20.50001 > 192.168.1.50.6379: tcp 0')
+
+    analyzer._passive_sync_to_db()
+
+    call = db.upsert_host.call_args
+    ports = set(call.kwargs['ports'].split(','))
+    # All four ports (old + new) should be present.
+    assert ports == {'22', '80', '443', '6379'}
+    services = call.kwargs['services']
+    # Existing service descriptions are preserved.
+    assert services['22'] == 'ssh'
+    assert services['80'] == 'http'
+    # New ports got inferred labels.
+    assert services['443'] == 'https'
+    assert services['6379'] == 'redis'
+
+
+def test_passive_sync_skips_host_without_mac_below_threshold(analyzer):
+    db = _build_db()
+    analyzer.shared_data = MagicMock(db=db)
+
+    # Only ONE packet — below PASSIVE_MIN_PACKETS (5), no ARP.
+    line = '2026-05-28 01:00:00.000000 IP 192.168.1.20.50000 > 192.168.1.99.443: tcp 0'
+    analyzer._parse_and_record_packet(line)
+
+    analyzer._passive_sync_to_db()
+
+    # 192.168.1.99 should NOT be upserted (no MAC, <5 packets).
+    upserted_ips = [c.kwargs.get('ip') for c in db.upsert_host.call_args_list]
+    assert '192.168.1.99' not in upserted_ips
+
+
+def test_passive_sync_upserts_host_with_pseudo_mac_when_threshold_met(analyzer):
+    db = _build_db()
+    analyzer.shared_data = MagicMock(db=db)
+
+    base_ts = '2026-05-28 01:00:00.000000'
+    # Five packets to 192.168.1.77, no ARP — should use pseudo-MAC.
+    for i in range(5):
+        line = (f'{base_ts} IP 192.168.1.20.{50000 + i} '
+                f'> 192.168.1.77.443: tcp 0')
+        analyzer._parse_and_record_packet(line)
+
+    analyzer._passive_sync_to_db()
+
+    call = next((c for c in db.upsert_host.call_args_list
+                 if c.kwargs.get('ip') == '192.168.1.77'), None)
+    assert call is not None
+    assert call.kwargs['mac'] == '00:00:c0:a8:01:4d'
+
+
+def test_passive_sync_does_not_touch_non_lan_hosts(analyzer):
+    db = _build_db()
+    analyzer.shared_data = MagicMock(db=db)
+
+    base_ts = '2026-05-28 01:00:00.000000'
+    for i in range(10):
+        line = f'{base_ts} IP 192.168.1.20.{50000 + i} > 8.8.8.8.443: tcp 0'
+        analyzer._parse_and_record_packet(line)
+
+    analyzer._passive_sync_to_db()
+
+    upserted_ips = [c.kwargs.get('ip') for c in db.upsert_host.call_args_list]
+    assert '8.8.8.8' not in upserted_ips
+
+
+def test_passive_sync_skips_ragnar_own_ip(analyzer):
+    db = _build_db()
+    analyzer.shared_data = MagicMock(db=db)
+
+    # 192.168.1.10 is in _local_ips per the fixture.
+    base_ts = '2026-05-28 01:00:00.000000'
+    analyzer._parse_and_record_packet(
+        f'{base_ts} ARP, Reply 192.168.1.10 is-at 11:22:33:44:55:66, length 28')
+    for i in range(10):
+        line = (f'{base_ts} IP 192.168.1.10.{50000 + i} > '
+                f'192.168.1.50.443: tcp 0')
+        analyzer._parse_and_record_packet(line)
+
+    analyzer._passive_sync_to_db()
+
+    upserted_ips = [c.kwargs.get('ip') for c in db.upsert_host.call_args_list]
+    assert '192.168.1.10' not in upserted_ips
+
+
+def test_passive_sync_no_op_when_db_unavailable(analyzer):
+    analyzer.shared_data = None
+    base_ts = '2026-05-28 01:00:00.000000'
+    analyzer._parse_and_record_packet(
+        f'{base_ts} ARP, Reply 192.168.1.50 is-at aa:bb:cc:dd:ee:ff, length 28')
+    # Should not raise.
+    analyzer._passive_sync_to_db()
+
+
+def test_passive_sync_skips_when_existing_host_and_no_new_ports(analyzer):
+    """Existing host with all our observed ports — no DB write needed."""
+    existing = {
+        '192.168.1.50': {
+            'mac': 'aa:bb:cc:dd:ee:ff',
+            'ports': '443',
+            'services': '{"443": "https"}',
+        }
+    }
+    db = _build_db(existing)
+    analyzer.shared_data = MagicMock(db=db)
+
+    base_ts = '2026-05-28 01:00:00.000000'
+    analyzer._parse_and_record_packet(
+        f'{base_ts} ARP, Reply 192.168.1.50 is-at aa:bb:cc:dd:ee:ff, length 28')
+    analyzer._parse_and_record_packet(
+        f'{base_ts} IP 192.168.1.20.50000 > 192.168.1.50.443: tcp 0')
+
+    analyzer._passive_sync_to_db()
+
+    # upsert_host should be called but with ports=None to avoid clobbering.
+    call = db.upsert_host.call_args
+    assert call.kwargs.get('ports') is None
+    assert call.kwargs.get('services') is None
+
+
+# ---------------------------------------------------------------------------
+# Liveness from passive observation: resurrects 'degraded' hosts
+# ---------------------------------------------------------------------------
+
+def test_passive_sync_calls_update_ping_status_for_observed_hosts(analyzer):
+    """Every passively-synced host should also get a liveness ping update."""
+    db = _build_db()
+    analyzer.shared_data = MagicMock(db=db)
+
+    base_ts = '2026-05-28 01:00:00.000000'
+    analyzer._parse_and_record_packet(
+        f'{base_ts} ARP, Reply 192.168.1.50 is-at aa:bb:cc:dd:ee:ff, length 28')
+    analyzer._parse_and_record_packet(
+        f'{base_ts} IP 192.168.1.20.50000 > 192.168.1.50.443: tcp 0')
+
+    analyzer._passive_sync_to_db()
+
+    # update_ping_status should be called with the real MAC and success=True.
+    db.update_ping_status.assert_called()
+    call = db.update_ping_status.call_args
+    assert call.args[0] == 'aa:bb:cc:dd:ee:ff'
+    assert call.kwargs.get('success') is True
+
+
+def test_passive_sync_resurrects_degraded_host_with_pseudo_mac(analyzer):
+    """A host whose only known MAC is pseudo still gets liveness."""
+    db = _build_db()
+    analyzer.shared_data = MagicMock(db=db)
+
+    base_ts = '2026-05-28 01:00:00.000000'
+    for i in range(5):
+        line = (f'{base_ts} IP 192.168.1.20.{50000 + i} > '
+                f'192.168.1.77.443: tcp 0')
+        analyzer._parse_and_record_packet(line)
+
+    analyzer._passive_sync_to_db()
+
+    # Pseudo-MAC should still receive a liveness signal.
+    macs_pinged = [c.args[0] for c in db.update_ping_status.call_args_list]
+    assert '00:00:c0:a8:01:4d' in macs_pinged
+
+
+def test_passive_sync_update_ping_failure_does_not_crash(analyzer):
+    """If update_ping_status raises, sync continues."""
+    db = _build_db()
+    db.update_ping_status.side_effect = RuntimeError("DB locked")
+    analyzer.shared_data = MagicMock(db=db)
+
+    base_ts = '2026-05-28 01:00:00.000000'
+    analyzer._parse_and_record_packet(
+        f'{base_ts} ARP, Reply 192.168.1.50 is-at aa:bb:cc:dd:ee:ff, length 28')
+    analyzer._parse_and_record_packet(
+        f'{base_ts} IP 192.168.1.20.50000 > 192.168.1.50.443: tcp 0')
+
+    # Should not raise.
+    analyzer._passive_sync_to_db()
+    db.upsert_host.assert_called()

--- a/tests/test_portscan_false_positives.py
+++ b/tests/test_portscan_false_positives.py
@@ -1,0 +1,360 @@
+"""Regression tests for port-scan detection false positives & evasion.
+
+Covers:
+- DNS / DHCP server responses must NOT count as scan targets.
+- Flow-direction inference: response traffic doesn't count even without
+  the service-port heuristic.
+- High-value high ports (Docker, Redis, ES, MongoDB...) bypass the
+  response heuristic — closes nmap `-g 53` evasion.
+- Default gateway uses softer threshold (5x), not full exemption.
+- Horizontal sweep detection: one port across many hosts alerts.
+- Real low-port scans still alert (HIGH).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from traffic_analyzer import (
+    AlertCategory,
+    TrafficAlertLevel,
+    TrafficAnalyzer,
+)
+
+
+@pytest.fixture
+def analyzer():
+    with patch.object(TrafficAnalyzer, '_detect_interface', return_value='lo'), \
+         patch.object(TrafficAnalyzer, '_detect_local_ips',
+                      return_value={'127.0.0.1', '192.168.1.10'}), \
+         patch.object(TrafficAnalyzer, '_detect_gateway_ips',
+                      return_value=set()):
+        a = TrafficAnalyzer(shared_data=None, interface='lo')
+    a.MAX_ALERTS_PER_MINUTE = 10_000
+    a._alert_dedup_window = 0
+    return a
+
+
+def _portscan_alerts(analyzer):
+    return [a for a in analyzer.alerts
+            if a.category == AlertCategory.PORT_SCAN.value]
+
+
+# ---------------------------------------------------------------------------
+# _looks_like_response
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("my_port,peer_port,expected", [
+    (53, 57285, True),     # DNS response
+    (67, 68, False),       # DHCP server->client (port 68 < 1024, not "ephemeral")
+    (80, 49152, True),     # HTTP response
+    (443, 51000, True),    # HTTPS response
+    (54321, 53, False),    # DNS query (client initiating)
+    (49152, 443, False),   # HTTPS request
+    (22, 50000, False),    # 22 not in SERVICE_SOURCE_PORTS
+    (8080, 60000, True),   # HTTP-alt response
+    (0, 0, False),         # ARP / ICMP — no port info
+    (53, 6379, False),     # `nmap -g 53` against Redis — high-value bypass
+    (53, 27017, False),    # `nmap -g 53` against MongoDB — high-value bypass
+    (53, 9200, False),     # `nmap -g 53` against Elasticsearch — bypass
+])
+def test_looks_like_response(analyzer, my_port, peer_port, expected):
+    assert analyzer._looks_like_response(my_port, peer_port) is expected
+
+
+# ---------------------------------------------------------------------------
+# DNS responses must not pollute ports_targeted
+# ---------------------------------------------------------------------------
+
+def test_dns_responses_do_not_pollute_ports_targeted(analyzer):
+    """Router answers 60 DNS queries from a client. No port-scan alert."""
+    router = '192.168.1.1'
+    client = '192.168.1.195'
+    base_ts = '2026-05-28 00:46:45.000000'
+
+    # 60 DNS replies on different ephemeral client ports.
+    for i in range(60):
+        eph = 32768 + i
+        line = (f'{base_ts} IP {router}.53 > {client}.{eph}: '
+                f'UDP, length 44')
+        analyzer._parse_and_record_packet(line)
+
+    # Router should NOT have those ephemeral ports as "targeted".
+    router_stats = analyzer.host_stats[router]
+    assert len(router_stats.ports_targeted) == 0, (
+        f"Router shouldn't target ephemeral ports from DNS responses, "
+        f"got: {router_stats.ports_targeted}"
+    )
+    # And no port-scan alert.
+    assert _portscan_alerts(analyzer) == []
+
+
+def test_dhcp_server_responses_do_not_trigger_scan(analyzer):
+    """DHCP server (port 67) responding to clients shouldn't look like scan."""
+    server = '192.168.1.1'
+    base_ts = '2026-05-28 00:46:45.000000'
+
+    for i in range(60):
+        client = f'192.168.1.{100 + (i % 50)}'
+        eph = 32768 + i
+        line = (f'{base_ts} IP {server}.67 > {client}.{eph}: '
+                f'UDP, length 300')
+        analyzer._parse_and_record_packet(line)
+
+    assert len(analyzer.host_stats[server].ports_targeted) == 0
+    assert _portscan_alerts(analyzer) == []
+
+
+def test_dns_client_querying_one_resolver_is_not_a_scan(analyzer):
+    """Client makes 60 DNS queries to 8.8.8.8 — only port 53 is 'targeted'."""
+    client = '192.168.1.195'
+    resolver = '8.8.8.8'
+    base_ts = '2026-05-28 00:46:45.000000'
+
+    for i in range(60):
+        eph = 32768 + i
+        line = (f'{base_ts} IP {client}.{eph} > {resolver}.53: '
+                f'UDP, length 64')
+        analyzer._parse_and_record_packet(line)
+
+    # Client only targets one port (53).
+    assert analyzer.host_stats[client].ports_targeted == {53}
+    assert _portscan_alerts(analyzer) == []
+
+
+# ---------------------------------------------------------------------------
+# Real port scans still alert
+# ---------------------------------------------------------------------------
+
+def test_real_low_port_scan_alerts_high(analyzer):
+    """Attacker probes 25 well-known ports — HIGH severity port-scan alert."""
+    attacker = '203.0.113.10'
+    target = '192.168.1.50'
+    base_ts = '2026-05-28 01:00:00.000000'
+
+    for port in range(1, 26):  # ports 1..25 — all <1024
+        eph = 40000 + port
+        line = (f'{base_ts} IP {attacker}.{eph} > {target}.{port}: '
+                f'tcp 0')
+        analyzer._parse_and_record_packet(line)
+
+    alerts = _portscan_alerts(analyzer)
+    assert len(alerts) >= 1
+    assert alerts[0].level == TrafficAlertLevel.HIGH
+    assert alerts[0].src_ip == attacker
+    assert alerts[0].details['low_ports_count'] >= 20
+
+
+def test_heavy_ephemeral_targeting_alerts_medium(analyzer):
+    """Host initiates to 200 unique high ports — MEDIUM alert."""
+    src = '203.0.113.10'
+    target = '192.168.1.50'
+    base_ts = '2026-05-28 01:00:00.000000'
+
+    for i in range(200):
+        port = 30000 + i
+        eph = 40000 + i
+        line = (f'{base_ts} IP {src}.{eph} > {target}.{port}: '
+                f'tcp 0')
+        analyzer._parse_and_record_packet(line)
+
+    alerts = _portscan_alerts(analyzer)
+    assert len(alerts) >= 1
+    # 200 high ports with 0 low ports — MEDIUM, not HIGH.
+    assert alerts[0].level == TrafficAlertLevel.MEDIUM
+
+
+# ---------------------------------------------------------------------------
+# Gateway whitelist
+# ---------------------------------------------------------------------------
+
+def test_default_gateway_uses_softer_threshold(analyzer):
+    """Gateway gets 5x threshold — 30 low ports no longer alerts."""
+    gateway = '192.168.1.1'
+    analyzer._gateway_ips = {gateway}
+    target = '192.168.1.50'
+    base_ts = '2026-05-28 01:00:00.000000'
+
+    # 30 low ports: would alert HIGH for non-gateway, but gateway needs 100.
+    for port in range(1, 31):
+        eph = 40000 + port
+        line = (f'{base_ts} IP {gateway}.{eph} > {target}.{port}: tcp 0')
+        analyzer._parse_and_record_packet(line)
+
+    assert _portscan_alerts(analyzer) == []
+
+
+def test_compromised_gateway_with_heavy_scan_still_alerts(analyzer):
+    """Gateway with 100+ low-port targets crosses the softer threshold."""
+    gateway = '192.168.1.1'
+    analyzer._gateway_ips = {gateway}
+    target = '192.168.1.50'
+    base_ts = '2026-05-28 01:00:00.000000'
+
+    # 110 low ports — exceeds 20*5 = 100.
+    for port in range(1, 111):
+        eph = 40000 + port
+        line = (f'{base_ts} IP {gateway}.{eph} > {target}.{port}: tcp 0')
+        analyzer._parse_and_record_packet(line)
+
+    alerts = _portscan_alerts(analyzer)
+    assert len(alerts) >= 1
+    assert alerts[0].level == TrafficAlertLevel.HIGH
+    assert alerts[0].details['is_gateway'] is True
+
+
+# ---------------------------------------------------------------------------
+# High-value high ports (nmap -g 53 evasion)
+# ---------------------------------------------------------------------------
+
+def test_source_port_53_against_high_value_ports_still_counts(analyzer):
+    """`nmap -g 53` against Redis/Mongo/ES/Docker must NOT evade detection."""
+    attacker = '203.0.113.10'
+    target = '192.168.1.50'
+    base_ts = '2026-05-28 01:00:00.000000'
+
+    high_value_targets = [6379, 27017, 9200, 5432, 3306, 2375, 5984,
+                          8080, 8443, 11211, 1433, 5601, 9000, 9090,
+                          5985, 5986, 2379, 5672, 5900, 8086]
+
+    for port in high_value_targets:
+        line = (f'{base_ts} IP {attacker}.53 > {target}.{port}: tcp 0')
+        analyzer._parse_and_record_packet(line)
+
+    # All 20 high-value ports should appear in ports_targeted despite src=53.
+    targeted = analyzer.host_stats[attacker].ports_targeted
+    for port in high_value_targets:
+        assert port in targeted, (
+            f"port {port} (high-value) should be counted as targeted "
+            f"even with src_port=53; got {sorted(targeted)}"
+        )
+
+    # And the scan alert fires (weighted score >= threshold).
+    alerts = _portscan_alerts(analyzer)
+    assert len(alerts) >= 1
+    assert alerts[0].level == TrafficAlertLevel.HIGH
+    assert alerts[0].details['high_value_ports_count'] >= 20
+
+
+def test_dns_response_to_random_ephemeral_still_filtered(analyzer):
+    """Random ephemeral (not high-value) — DNS response heuristic still works."""
+    router = '192.168.1.1'
+    client = '192.168.1.195'
+    base_ts = '2026-05-28 00:46:45.000000'
+
+    # 50 DNS replies — none of these ports are in HIGH_VALUE_HIGH_PORTS.
+    for i in range(50):
+        eph = 32768 + i
+        line = (f'{base_ts} IP {router}.53 > {client}.{eph}: UDP, length 44')
+        analyzer._parse_and_record_packet(line)
+
+    assert len(analyzer.host_stats[router].ports_targeted) == 0
+
+
+# ---------------------------------------------------------------------------
+# Flow-direction inference
+# ---------------------------------------------------------------------------
+
+def test_response_packet_does_not_count_as_initiation(analyzer):
+    """If we see the request first, the response shouldn't be counted."""
+    client = '192.168.1.195'
+    server = '203.0.113.10'
+    base_ts = '2026-05-28 01:00:00.000000'
+
+    # Client initiates to an UNCOMMON port that's neither service nor
+    # high-value, so neither heuristic applies — only flow-direction does.
+    line_request = f'{base_ts} IP {client}.50000 > {server}.31415: tcp 64'
+    analyzer._parse_and_record_packet(line_request)
+    # Server responds — direction reverses.
+    line_response = f'{base_ts} IP {server}.31415 > {client}.50000: tcp 64'
+    analyzer._parse_and_record_packet(line_response)
+
+    # Client targeted port 31415. ✓
+    assert 31415 in analyzer.host_stats[client].ports_targeted
+    # Server did NOT "target" port 50000 — it was responding.
+    assert 50000 not in analyzer.host_stats[server].ports_targeted
+
+
+# ---------------------------------------------------------------------------
+# Horizontal sweep
+# ---------------------------------------------------------------------------
+
+def test_horizontal_sweep_one_port_many_hosts_alerts(analyzer):
+    """Scanner hits port 445 across 12 hosts — sweep alert fires."""
+    attacker = '203.0.113.10'
+    base_ts = '2026-05-28 01:00:00.000000'
+
+    for i in range(12):
+        target = f'192.168.1.{50 + i}'
+        line = (f'{base_ts} IP {attacker}.40000 > {target}.445: tcp 0')
+        analyzer._parse_and_record_packet(line)
+
+    sweep_alerts = [a for a in _portscan_alerts(analyzer)
+                    if 'sweep' in a.message.lower()]
+    assert len(sweep_alerts) >= 1
+    assert sweep_alerts[0].details['sweep_port'] == 445
+    assert sweep_alerts[0].details['hosts_targeted'] >= 10
+
+
+def test_sweep_only_counts_relevant_ports(analyzer):
+    """Random high port across many hosts should NOT trigger sweep."""
+    attacker = '203.0.113.10'
+    base_ts = '2026-05-28 01:00:00.000000'
+
+    # Port 31415 is neither <1024 nor in HIGH_VALUE_HIGH_PORTS — irrelevant.
+    for i in range(20):
+        target = f'192.168.1.{50 + i}'
+        line = (f'{base_ts} IP {attacker}.40000 > {target}.31415: tcp 0')
+        analyzer._parse_and_record_packet(line)
+
+    sweep_alerts = [a for a in _portscan_alerts(analyzer)
+                    if 'sweep' in a.message.lower()]
+    assert sweep_alerts == []
+
+
+def test_sweep_dedup_per_src_port_pair(analyzer):
+    """Repeated sweep observations should not spam alerts."""
+    analyzer._alert_dedup_window = 300  # restore real dedup
+    attacker = '203.0.113.10'
+    base_ts = '2026-05-28 01:00:00.000000'
+
+    # First wave: 12 hosts on port 22.
+    for i in range(12):
+        target = f'192.168.1.{50 + i}'
+        line = (f'{base_ts} IP {attacker}.40000 > {target}.22: tcp 0')
+        analyzer._parse_and_record_packet(line)
+
+    sweep_alerts_first = [a for a in _portscan_alerts(analyzer)
+                          if a.details.get('sweep_port') == 22]
+    assert len(sweep_alerts_first) == 1
+
+    # Second wave: more hosts on port 22 — should NOT fire again.
+    for i in range(12, 25):
+        target = f'192.168.1.{50 + i}'
+        line = (f'{base_ts} IP {attacker}.40000 > {target}.22: tcp 0')
+        analyzer._parse_and_record_packet(line)
+
+    sweep_alerts_total = [a for a in _portscan_alerts(analyzer)
+                          if a.details.get('sweep_port') == 22]
+    assert len(sweep_alerts_total) == 1
+
+
+# ---------------------------------------------------------------------------
+# ports_contacted UI semantics unchanged for non-zero ports
+# ---------------------------------------------------------------------------
+
+def test_ports_contacted_still_tracks_all_peer_ports(analyzer):
+    """UI view of `ports_contacted` should include both directions' ports."""
+    router = '192.168.1.1'
+    client = '192.168.1.195'
+    base_ts = '2026-05-28 00:46:45.000000'
+
+    line = f'{base_ts} IP {router}.53 > {client}.57285: UDP, length 44'
+    analyzer._parse_and_record_packet(line)
+
+    # Router's ports_contacted contains the client's ephemeral port (UI shows
+    # "ports involved with this host"). It just isn't counted as a scan target.
+    assert 57285 in analyzer.host_stats[router].ports_contacted
+    assert 57285 not in analyzer.host_stats[router].ports_targeted
+    # And the client's stats show port 53 as both contacted and targeted.
+    assert 53 in analyzer.host_stats[client].ports_contacted

--- a/tests/test_wifi_ssid_debounce.py
+++ b/tests/test_wifi_ssid_debounce.py
@@ -1,0 +1,136 @@
+"""Tests for SSID-change debounce in WiFiManager._set_current_ssid.
+
+A transient SSID misread (roaming, dual-band flap, brief disconnect) used
+to propagate immediately to shared_data.set_active_network(), which calls
+mark_all_hosts_degraded() and wipes every alive host to offline. The
+debounce requires the NEW SSID to persist for N seconds before switching.
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def manager():
+    """A minimal WiFiManager with side-effecting init paths stubbed."""
+    from wifi_manager import WiFiManager
+
+    shared = MagicMock()
+    shared.config = {
+        'wifi_ssid_change_debounce_seconds': 30,
+        'wifi_ap_ssid': 'Ragnar',
+        'wifi_ap_password': 'ragnarconnect',
+        'wifi_default_interface': 'auto',
+    }
+    shared.active_network_ssid = None
+    shared.currentdir = '/tmp'
+
+    with patch('wifi_manager.detect_wifi_interface', return_value='wlan0'), \
+         patch('wifi_manager.get_db', return_value=None), \
+         patch.object(WiFiManager, 'setup_ap_logger'), \
+         patch.object(WiFiManager, 'load_wifi_config'):
+        wm = WiFiManager(shared)
+    return wm
+
+
+# ---------------------------------------------------------------------------
+# Fresh establishment: propagate immediately
+# ---------------------------------------------------------------------------
+
+def test_first_ssid_after_boot_propagates_immediately(manager):
+    """No active network yet → switching is non-destructive, fire now."""
+    manager.shared_data.active_network_ssid = None
+
+    manager._set_current_ssid('HomeNet')
+
+    manager.shared_data.set_active_network.assert_called_once_with('HomeNet')
+
+
+def test_same_ssid_as_active_does_not_propagate(manager):
+    """If the new value equals the storage's active SSID — no-op."""
+    manager.shared_data.active_network_ssid = 'HomeNet'
+
+    manager._set_current_ssid('HomeNet')
+
+    manager.shared_data.set_active_network.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Debounced switch: new SSID must persist
+# ---------------------------------------------------------------------------
+
+def test_transient_ssid_misread_does_not_propagate(manager):
+    """Single flap to a different SSID inside the debounce window → no call."""
+    manager.shared_data.active_network_ssid = 'HomeNet'
+    manager.ssid_change_debounce_s = 30
+
+    manager._set_current_ssid('NeighborWifi')   # first observation
+    manager._set_current_ssid('NeighborWifi')   # immediate repeat
+    manager._set_current_ssid('NeighborWifi')   # still in window
+
+    manager.shared_data.set_active_network.assert_not_called()
+
+
+def test_consistent_ssid_after_window_propagates(manager):
+    """Same NEW SSID observed across the debounce window → propagate."""
+    manager.shared_data.active_network_ssid = 'HomeNet'
+    manager.ssid_change_debounce_s = 1  # 1 second for fast test
+
+    manager._set_current_ssid('CafeWifi')
+    assert manager.shared_data.set_active_network.call_count == 0
+
+    time.sleep(1.1)
+    manager._set_current_ssid('CafeWifi')
+
+    manager.shared_data.set_active_network.assert_called_once_with('CafeWifi')
+
+
+def test_ssid_change_reverting_aborts_pending(manager):
+    """A new SSID seen, then reverting back to original → pending cleared."""
+    manager.shared_data.active_network_ssid = 'HomeNet'
+    manager.ssid_change_debounce_s = 30
+
+    manager._set_current_ssid('NeighborWifi')   # start debounce
+    assert manager._pending_ssid_change == 'NeighborWifi'
+
+    manager._set_current_ssid('HomeNet')        # revert
+    assert manager._pending_ssid_change is None
+    manager.shared_data.set_active_network.assert_not_called()
+
+
+def test_pending_ssid_reset_when_target_changes(manager):
+    """Pending SSID-A then observing SSID-B resets the timer."""
+    manager.shared_data.active_network_ssid = 'HomeNet'
+    manager.ssid_change_debounce_s = 30
+
+    manager._set_current_ssid('SsidA')
+    first_seen_a = manager._pending_ssid_first_seen
+
+    time.sleep(0.01)
+    manager._set_current_ssid('SsidB')
+
+    assert manager._pending_ssid_change == 'SsidB'
+    assert manager._pending_ssid_first_seen > first_seen_a
+
+
+def test_propagation_failure_does_not_raise(manager):
+    """set_active_network raising should not break the manager."""
+    manager.shared_data.active_network_ssid = None
+    manager.shared_data.set_active_network.side_effect = RuntimeError('boom')
+
+    # Should NOT raise.
+    manager._set_current_ssid('HomeNet')
+
+
+def test_current_ssid_updates_even_during_debounce(manager):
+    """self.current_ssid should reflect the live observation immediately."""
+    manager.shared_data.active_network_ssid = 'HomeNet'
+    manager.ssid_change_debounce_s = 30
+
+    manager._set_current_ssid('OtherNet')
+
+    # current_ssid mirrors latest observation even though storage isn't switched.
+    assert manager.current_ssid == 'OtherNet'
+    manager.shared_data.set_active_network.assert_not_called()

--- a/traffic_analyzer.py
+++ b/traffic_analyzer.py
@@ -25,6 +25,7 @@ import signal
 import queue
 import logging
 import statistics
+import ipaddress
 from typing import Dict, List, Optional, Any, Callable, Tuple
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timedelta
@@ -123,6 +124,8 @@ class HostTrafficStats:
     bytes_out: int = 0
     protocols: Dict[str, int] = field(default_factory=dict)
     ports_contacted: set = field(default_factory=set)
+    ports_targeted: set = field(default_factory=set)
+    sweep_targets: Dict[int, set] = field(default_factory=dict)
     connections_active: int = 0
     first_seen: datetime = field(default_factory=datetime.now)
     last_seen: datetime = field(default_factory=datetime.now)
@@ -141,6 +144,7 @@ class HostTrafficStats:
             'bytes_out': self.bytes_out,
             'protocols': self.protocols,
             'ports_contacted': list(self.ports_contacted)[:100],  # Limit for API
+            'ports_targeted': list(self.ports_targeted)[:100],
             'connections_active': self.connections_active,
             'first_seen': self.first_seen.isoformat(),
             'last_seen': self.last_seen.isoformat(),
@@ -215,6 +219,59 @@ class TrafficAnalyzer:
         5355,  # LLMNR
     })
 
+    # Service source ports: when a packet's src_port is one of these, the
+    # dst_port is a client's ephemeral socket (response), not a scan target.
+    SERVICE_SOURCE_PORTS = frozenset({
+        53, 67, 68, 69, 80, 443, 88, 123,
+        137, 138, 139, 161, 162, 389, 636,
+        445, 25, 465, 587, 514, 546, 547,
+        993, 995, 1900, 5353, 5355, 8080, 8443,
+    })
+
+    # High-value reconnaissance targets >1024. These always count as
+    # "targeted" even if src_port looks like a service port — closes the
+    # `nmap -g 53` evasion against common DB/admin/orchestrator ports.
+    HIGH_VALUE_HIGH_PORTS = frozenset({
+        1433, 1521,             # MS-SQL, Oracle
+        2375, 2376,             # Docker (TLS)
+        2379, 2380,             # etcd
+        3306,                   # MySQL
+        3389,                   # RDP
+        5432,                   # Postgres
+        5601,                   # Kibana
+        5672, 15672,            # RabbitMQ + management
+        5900, 5901,             # VNC
+        5984,                   # CouchDB
+        5985, 5986,             # WinRM
+        6379,                   # Redis
+        7474, 7687,             # Neo4j
+        8000, 8008, 8086,       # Common admin / InfluxDB
+        8080, 8443, 8888,       # HTTP-alt / admin
+        9000, 9090, 9091,       # Grafana, Prometheus
+        9042,                   # Cassandra
+        9092,                   # Kafka
+        9200, 9300,             # Elasticsearch
+        11211,                  # memcached
+        27017, 27018,           # MongoDB
+    })
+
+    PORTSCAN_LOW_PORT_THRESHOLD = 20
+    PORTSCAN_TOTAL_THRESHOLD = 150
+    PORTSCAN_EPHEMERAL_FLOOR = 1024
+    PORTSCAN_GATEWAY_MULTIPLIER = 5      # softer threshold for default gateway
+
+    # Horizontal sweep: same port across many distinct destination hosts.
+    SWEEP_HOST_THRESHOLD = 10            # distinct dst IPs on one port
+    SWEEP_MAX_TRACKED_PORTS = 200        # cap memory per source host
+    SWEEP_MAX_TRACKED_IPS = 500          # cap memory per port
+
+    # Passive host discovery: periodically flush observed LAN hosts into the
+    # hosts DB so traffic-only hosts (firewalled, never scanned) get tracked.
+    PASSIVE_SYNC_INTERVAL = 30.0         # seconds between DB flushes
+    PASSIVE_MIN_PACKETS = 5              # min packets to upsert if no MAC yet
+    PASSIVE_MAX_LISTEN_PORTS = 100       # cap per host
+    PASSIVE_LAN_PREFIX = 24              # /24 around each known local/gateway IP
+
     # Rate limiting
     MAX_ALERTS_PER_MINUTE = 10
     STATS_RETENTION_HOURS = 24
@@ -233,6 +290,21 @@ class TrafficAnalyzer:
         
         # Local IP addresses to exclude from alerts (Ragnar's own IPs)
         self._local_ips: set = self._detect_local_ips()
+
+        # Default gateway IPs: exempt from port-scan heuristic.
+        self._gateway_ips: set = self._detect_gateway_ips()
+
+        # LAN networks for passive host discovery (derived from local+gateway IPs).
+        self._lan_networks: List[ipaddress.IPv4Network] = self._derive_lan_networks()
+
+        # Passive discovery state:
+        # _mac_by_ip: IP -> MAC (from ARP replies)
+        # _listening_ports: IP -> set of service ports it appears to serve
+        # _hostname_by_ip: IP -> hostname (from observed DNS replies)
+        self._mac_by_ip: Dict[str, str] = {}
+        self._listening_ports: Dict[str, set] = {}
+        self._hostname_by_ip: Dict[str, str] = {}
+        self._last_passive_sync: float = time.time()
         
         # Statistics storage
         self.host_stats: Dict[str, HostTrafficStats] = {}
@@ -378,7 +450,63 @@ class TrafficAnalyzer:
 
         logger.info(f"Local IPs (excluded from alerts): {local_ips}")
         return local_ips
-    
+
+    def _detect_gateway_ips(self) -> set:
+        gateways: set = set()
+        try:
+            result = subprocess.run(
+                ['ip', 'route', 'show', 'default'],
+                capture_output=True, text=True, timeout=5
+            )
+            if result.returncode == 0:
+                for match in re.finditer(
+                    r'default\s+via\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})',
+                    result.stdout
+                ):
+                    gateways.add(match.group(1))
+        except Exception as e:
+            logger.debug(f"Gateway detection error: {e}")
+        if gateways:
+            logger.info(f"Default gateway(s) (port-scan exempt): {gateways}")
+        return gateways
+
+    def _derive_lan_networks(self) -> List[ipaddress.IPv4Network]:
+        nets: set = set()
+        candidates: set = set()
+        candidates.update(getattr(self, '_local_ips', set()) or set())
+        candidates.update(getattr(self, '_gateway_ips', set()) or set())
+        for ip in candidates:
+            try:
+                addr = ipaddress.IPv4Address(ip)
+            except (ValueError, ipaddress.AddressValueError):
+                continue
+            if addr.is_loopback or addr.is_link_local or addr.is_multicast:
+                continue
+            try:
+                net = ipaddress.IPv4Network(
+                    f"{ip}/{self.PASSIVE_LAN_PREFIX}", strict=False)
+                nets.add(net)
+            except (ValueError, ipaddress.NetmaskValueError):
+                continue
+        result = sorted(nets, key=lambda n: int(n.network_address))
+        if result:
+            logger.info(f"LAN networks for passive discovery: "
+                        f"{[str(n) for n in result]}")
+        return result
+
+    def _is_lan_ip(self, ip: str) -> bool:
+        if not ip:
+            return False
+        try:
+            addr = ipaddress.IPv4Address(ip)
+        except (ValueError, ipaddress.AddressValueError):
+            return False
+        if addr.is_loopback or addr.is_link_local or addr.is_multicast:
+            return False
+        if int(addr) == 0 or int(addr) == 0xFFFFFFFF:
+            return False
+        return any(addr in net for net in self._lan_networks)
+
     def is_available(self) -> bool:
         """Check if traffic analysis is available"""
         return get_server_capabilities().capabilities.traffic_analysis_enabled
@@ -547,7 +675,15 @@ class TrafficAnalyzer:
 
                 # Periodically score flows for beacon behaviour
                 self._sweep_beacons()
-                    
+
+                # Periodically flush passive host discoveries to the DB
+                if time.time() - self._last_passive_sync >= self.PASSIVE_SYNC_INTERVAL:
+                    try:
+                        self._passive_sync_to_db()
+                    except Exception as exc:
+                        logger.debug(f"Passive host sync error: {exc}")
+                    self._last_passive_sync = time.time()
+
             except Exception as e:
                 logger.error(f"Analysis error: {e}")
     
@@ -593,7 +729,12 @@ class TrafficAnalyzer:
                     protocol = 'udp'
                 else:
                     protocol = 'other'
-            
+
+            # ARP harvesting: pull IP↔MAC mappings for passive host discovery.
+            if protocol == 'arp':
+                self._parse_arp_line(line)
+                return
+
             # Extract IP addresses with regex - more flexible
             # Match patterns like: 192.168.1.100.443 or 192.168.1.100
             ip_pattern = r'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(?:\.(\d+))?'
@@ -619,12 +760,24 @@ class TrafficAnalyzer:
             # Update global stats  
             self.total_bytes += packet_size
             
-            # Update host stats
-            self._update_host_stats(src_ip, 'out', packet_size, protocol, dst_port)
-            self._update_host_stats(dst_ip, 'in', packet_size, protocol, src_port)
-            
-            # Update connection tracking
+            # Flow-direction inference: if we've already seen the reverse
+            # flow, this packet is a response (the src_ip is the responder).
             conn_key = f"{src_ip}:{src_port}->{dst_ip}:{dst_port}"
+            reverse_key = f"{dst_ip}:{dst_port}->{src_ip}:{src_port}"
+            is_response_flow = (reverse_key in self.connections
+                                and conn_key not in self.connections)
+
+            # Update host stats
+            self._update_host_stats(src_ip, 'out', packet_size, protocol,
+                                    my_port=src_port, peer_port=dst_port,
+                                    peer_ip=dst_ip,
+                                    is_response_flow=is_response_flow)
+            self._update_host_stats(dst_ip, 'in', packet_size, protocol,
+                                    my_port=dst_port, peer_port=src_port,
+                                    peer_ip=src_ip,
+                                    is_response_flow=False)
+
+            # Update connection tracking
             if conn_key not in self.connections:
                 self.connections[conn_key] = ConnectionStats(
                     src_ip=src_ip, dst_ip=dst_ip,
@@ -636,6 +789,10 @@ class TrafficAnalyzer:
             conn.bytes_sent += packet_size
             conn.last_seen = datetime.now()
             
+            # Record listening ports (a host using a service port = listener).
+            self._record_listening_port(src_ip, src_port)
+            self._record_listening_port(dst_ip, dst_port)
+
             # Check for suspicious patterns
             self._check_suspicious_patterns(src_ip, dst_ip, src_port, dst_port, protocol)
 
@@ -658,29 +815,66 @@ class TrafficAnalyzer:
         except Exception as e:
             logger.debug(f"Packet parse error: {e}")
     
-    def _update_host_stats(self, ip: str, direction: str, size: int, protocol: str, port: int):
-        """Update statistics for a host"""
+    def _update_host_stats(self, ip: str, direction: str, size: int, protocol: str,
+                           my_port: int, peer_port: int,
+                           peer_ip: str = '',
+                           is_response_flow: bool = False):
+        """Update statistics for a host.
+
+        ports_contacted: every peer-port this host's traffic involved (UI view).
+        ports_targeted: only peer-ports this host actively initiated to.
+        sweep_targets: per-port set of distinct dst-IPs this host initiated to,
+            used for horizontal-sweep detection.
+        """
         if ip not in self.host_stats:
             self.host_stats[ip] = HostTrafficStats(ip=ip)
-        
+
         stats = self.host_stats[ip]
         stats.total_packets += 1
         stats.total_bytes += size
         stats.last_seen = datetime.now()
-        
+
         if direction == 'in':
             stats.packets_in += 1
             stats.bytes_in += size
         else:
             stats.packets_out += 1
             stats.bytes_out += size
-        
-        # Protocol tracking
+
         stats.protocols[protocol] = stats.protocols.get(protocol, 0) + 1
-        
-        # Port tracking (limit to prevent memory bloat)
-        if len(stats.ports_contacted) < 1000:
-            stats.ports_contacted.add(port)
+
+        if peer_port and len(stats.ports_contacted) < 1000:
+            stats.ports_contacted.add(peer_port)
+
+        if (direction == 'out'
+                and peer_port
+                and not is_response_flow
+                and not self._looks_like_response(my_port, peer_port)):
+            if len(stats.ports_targeted) < 1000:
+                stats.ports_targeted.add(peer_port)
+
+            if peer_ip and self._is_sweep_relevant_port(peer_port):
+                bucket = stats.sweep_targets.get(peer_port)
+                if bucket is None:
+                    if len(stats.sweep_targets) >= self.SWEEP_MAX_TRACKED_PORTS:
+                        return
+                    bucket = set()
+                    stats.sweep_targets[peer_port] = bucket
+                if len(bucket) < self.SWEEP_MAX_TRACKED_IPS:
+                    bucket.add(peer_ip)
+
+    def _is_sweep_relevant_port(self, port: int) -> bool:
+        if port <= 0:
+            return False
+        if port < self.PORTSCAN_EPHEMERAL_FLOOR:
+            return True
+        return port in self.HIGH_VALUE_HIGH_PORTS
+
+    def _looks_like_response(self, my_port: int, peer_port: int) -> bool:
+        if peer_port in self.HIGH_VALUE_HIGH_PORTS:
+            return False
+        return (my_port in self.SERVICE_SOURCE_PORTS
+                and peer_port >= self.PORTSCAN_EPHEMERAL_FLOOR)
     
     def _record_dns_query(self, line: str, src_ip: str, dst_ip: str):
         """Record DNS queries for analysis and check for tunneling"""
@@ -700,7 +894,165 @@ class TrafficAnalyzer:
         # Check for DNS tunneling (high query rate)
         if src_ip not in self._local_ips:
             self._check_dns_tunneling(src_ip)
-    
+
+    _ARP_REPLY_RE = re.compile(
+        r'ARP,\s+Reply\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+is-at\s+'
+        r'([0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5})'
+    )
+    _ARP_AT_RE = re.compile(
+        r'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+is-at\s+'
+        r'([0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5})'
+    )
+
+    def _parse_arp_line(self, line: str):
+        match = self._ARP_REPLY_RE.search(line) or self._ARP_AT_RE.search(line)
+        if not match:
+            return
+        ip, mac = match.group(1), match.group(2).lower()
+        if not self._is_lan_ip(ip):
+            return
+        self._mac_by_ip[ip] = mac
+        if ip not in self.host_stats:
+            self.host_stats[ip] = HostTrafficStats(ip=ip, mac=mac)
+        elif not self.host_stats[ip].mac:
+            self.host_stats[ip].mac = mac
+
+    def _record_listening_port(self, ip: str, port: int):
+        if not ip or not port or port <= 0:
+            return
+        # A host using a service port (<1024 or high-value) = it's a listener.
+        if port >= self.PORTSCAN_EPHEMERAL_FLOOR and port not in self.HIGH_VALUE_HIGH_PORTS:
+            return
+        if not self._is_lan_ip(ip):
+            return
+        bucket = self._listening_ports.setdefault(ip, set())
+        if len(bucket) < self.PASSIVE_MAX_LISTEN_PORTS:
+            bucket.add(port)
+
+    # Port -> well-known service name for `services` column enrichment.
+    PORT_SERVICE_NAMES = {
+        20: 'ftp-data', 21: 'ftp', 22: 'ssh', 23: 'telnet', 25: 'smtp',
+        53: 'dns', 67: 'dhcp-server', 68: 'dhcp-client', 80: 'http',
+        110: 'pop3', 123: 'ntp', 135: 'msrpc', 137: 'netbios-ns',
+        138: 'netbios-dgm', 139: 'netbios-ssn', 143: 'imap', 161: 'snmp',
+        162: 'snmptrap', 389: 'ldap', 443: 'https', 445: 'smb',
+        465: 'smtps', 514: 'syslog', 587: 'submission', 636: 'ldaps',
+        993: 'imaps', 995: 'pop3s', 1433: 'mssql', 1521: 'oracle',
+        2375: 'docker', 2376: 'docker-tls', 2379: 'etcd', 2380: 'etcd-peer',
+        3306: 'mysql', 3389: 'rdp', 5432: 'postgresql', 5601: 'kibana',
+        5672: 'amqp', 5900: 'vnc', 5901: 'vnc', 5984: 'couchdb',
+        5985: 'winrm', 5986: 'winrm-ssl', 6379: 'redis', 7474: 'neo4j',
+        7687: 'neo4j-bolt', 8000: 'http-alt', 8008: 'http-alt',
+        8080: 'http-alt', 8086: 'influxdb', 8443: 'https-alt',
+        8888: 'http-alt', 9000: 'grafana', 9042: 'cassandra',
+        9090: 'prometheus', 9091: 'prometheus-push', 9092: 'kafka',
+        9200: 'elasticsearch', 9300: 'elasticsearch-transport',
+        11211: 'memcached', 15672: 'rabbitmq-mgmt', 27017: 'mongodb',
+        27018: 'mongodb-shard',
+    }
+
+    @staticmethod
+    def _ip_to_pseudo_mac(ip: str) -> str:
+        parts = ip.split('.')
+        if len(parts) != 4:
+            return ''
+        try:
+            return '00:00:' + ':'.join(f'{int(p):02x}' for p in parts)
+        except ValueError:
+            return ''
+
+    def _passive_sync_to_db(self):
+        """Flush passively-observed LAN hosts into the hosts DB.
+
+        For each LAN IP that meets the discovery threshold (real MAC seen via
+        ARP, or >= PASSIVE_MIN_PACKETS observed), upsert into `hosts`. Merges
+        listening ports with any existing port list — never replaces.
+        """
+        db = getattr(self.shared_data, 'db', None) if self.shared_data else None
+        if not db or not hasattr(db, 'upsert_host'):
+            return
+        if not self._lan_networks:
+            return
+
+        with self._lock:
+            snapshot: List[Tuple[str, str, set]] = []
+            for ip, stats in self.host_stats.items():
+                if not self._is_lan_ip(ip):
+                    continue
+                if ip in self._local_ips:
+                    continue
+                mac = self._mac_by_ip.get(ip) or stats.mac or ''
+                if not mac and stats.total_packets < self.PASSIVE_MIN_PACKETS:
+                    continue
+                listening = set(self._listening_ports.get(ip, set()))
+                snapshot.append((ip, mac, listening))
+
+        for ip, mac, listening in snapshot:
+            try:
+                self._upsert_passive_host(db, ip, mac, listening)
+            except Exception as exc:
+                logger.debug(f"Passive upsert failed for {ip}: {exc}")
+
+    def _upsert_passive_host(self, db, ip: str, mac: str, listening_ports: set):
+        existing = db.get_host_by_ip(ip)
+
+        if mac:
+            target_mac = mac.lower()
+        elif existing and existing.get('mac'):
+            target_mac = existing['mac']
+        else:
+            target_mac = self._ip_to_pseudo_mac(ip)
+        if not target_mac:
+            return
+
+        existing_ports: set = set()
+        existing_services: Dict[str, str] = {}
+        if existing:
+            for chunk in (existing.get('ports') or '').split(','):
+                chunk = chunk.strip()
+                if chunk.isdigit():
+                    existing_ports.add(int(chunk))
+            raw_services = existing.get('services') or ''
+            if raw_services:
+                try:
+                    parsed = json.loads(raw_services)
+                    if isinstance(parsed, dict):
+                        existing_services = {str(k): str(v) for k, v in parsed.items()}
+                except (ValueError, TypeError):
+                    pass
+
+        merged_ports = existing_ports | listening_ports
+        new_ports = listening_ports - existing_ports
+        if not existing and not merged_ports:
+            return  # nothing useful to write yet
+
+        services = dict(existing_services)
+        for port in merged_ports:
+            key = str(port)
+            if key not in services or not services[key]:
+                services[key] = self.PORT_SERVICE_NAMES.get(port, '')
+
+        ports_str = ','.join(str(p) for p in sorted(merged_ports))
+        # Only pass services if we have something to add — avoid clobbering
+        # richer service descriptions an active scan may have written.
+        services_arg = services if new_ports or not existing else None
+
+        db.upsert_host(
+            mac=target_mac,
+            ip=ip,
+            ports=ports_str if (new_ports or not existing) else None,
+            services=services_arg,
+        )
+
+        # Observed traffic = host is alive. Resurrects 'degraded' hosts that
+        # were wiped by a transient wifi flap or have simply stopped
+        # responding to active pings while still talking on the network.
+        if hasattr(db, 'update_ping_status'):
+            try:
+                db.update_ping_status(target_mac, success=True)
+            except Exception as exc:
+                logger.debug(f"update_ping_status failed for {target_mac}: {exc}")
+
     def _check_suspicious_patterns(self, src_ip: str, dst_ip: str,
                                    src_port: int, dst_port: int, protocol: str):
         """Check for suspicious traffic patterns"""
@@ -745,21 +1097,70 @@ class TrafficAnalyzer:
                 }
             )
 
-        # Check for potential port scanning (many ports from same source)
-        # Only alert for external IPs doing port scans
+        # Port-scan: score *targeted* ports (initiated to), weighted toward
+        # well-known service ports. Default gateway gets a softer threshold
+        # (5x) rather than full exemption — compromised routers still alert.
         if src_ip in self.host_stats and src_ip not in self._local_ips:
             stats = self.host_stats[src_ip]
-            ports_count = len(stats.ports_contacted)
-            if ports_count > 50:
+            targeted = stats.ports_targeted
+            low_ports = {p for p in targeted if 0 < p < self.PORTSCAN_EPHEMERAL_FLOOR}
+            high_value = {p for p in targeted if p in self.HIGH_VALUE_HIGH_PORTS}
+            total = len(targeted)
+            n_low = len(low_ports)
+            n_hv = len(high_value)
+            # Count high-value-high ports toward the "weighted" low-port score.
+            n_weighted = n_low + n_hv
+
+            mult = (self.PORTSCAN_GATEWAY_MULTIPLIER
+                    if src_ip in self._gateway_ips else 1)
+            low_threshold = self.PORTSCAN_LOW_PORT_THRESHOLD * mult
+            total_threshold = self.PORTSCAN_TOTAL_THRESHOLD * mult
+
+            level = None
+            if n_weighted >= low_threshold:
+                level = TrafficAlertLevel.HIGH
+                message = (f"Port scan detected: {src_ip} initiated to "
+                           f"{n_low} well-known + {n_hv} high-value ports "
+                           f"(+{total - n_weighted} other)")
+            elif total >= total_threshold:
+                level = TrafficAlertLevel.MEDIUM
+                message = (f"Heavy port activity: {src_ip} initiated to "
+                           f"{total} unique ports")
+
+            if level is not None:
+                self._create_alert(
+                    level=level,
+                    category=AlertCategory.PORT_SCAN.value,
+                    message=message,
+                    src_ip=src_ip,
+                    details={
+                        'ports_scanned': total,
+                        'low_ports_count': n_low,
+                        'high_value_ports_count': n_hv,
+                        'sample_low_ports': sorted(low_ports)[:20],
+                        'sample_high_value_ports': sorted(high_value)[:20],
+                        'sample_ports': sorted(targeted)[:20],
+                        'is_gateway': src_ip in self._gateway_ips,
+                        'scan_duration_seconds': (stats.last_seen - stats.first_seen).total_seconds()
+                    }
+                )
+
+            # Horizontal sweep: one port across many distinct destination hosts.
+            for port, dst_ips in stats.sweep_targets.items():
+                if len(dst_ips) < self.SWEEP_HOST_THRESHOLD * mult:
+                    continue
                 self._create_alert(
                     level=TrafficAlertLevel.HIGH,
                     category=AlertCategory.PORT_SCAN.value,
-                    message=f"Port scan detected: {src_ip} probed {ports_count} unique ports",
+                    message=(f"Horizontal sweep: {src_ip} hit "
+                             f"{len(dst_ips)} hosts on port {port}"),
                     src_ip=src_ip,
+                    dedup_key=f"sweep:{src_ip}:{port}",
                     details={
-                        'ports_scanned': ports_count,
-                        'sample_ports': list(stats.ports_contacted)[:20],
-                        'scan_duration_seconds': (stats.last_seen - stats.first_seen).total_seconds()
+                        'sweep_port': port,
+                        'hosts_targeted': len(dst_ips),
+                        'sample_hosts': sorted(dst_ips)[:20],
+                        'is_gateway': src_ip in self._gateway_ips,
                     }
                 )
 
@@ -1085,12 +1486,17 @@ class TrafficAnalyzer:
     
     def _create_alert(self, level: TrafficAlertLevel, category: str,
                       message: str, src_ip: str = None, dst_ip: str = None,
-                      details: Dict = None):
-        """Create a traffic alert with rate limiting and deduplication"""
+                      details: Dict = None, dedup_key: str = None):
+        """Create a traffic alert with rate limiting and deduplication.
+
+        dedup_key: optional override for the dedup hash. Use when the default
+            (category, src, dst) tuple would collapse distinct alerts — e.g.
+            sweep alerts that vary by port rather than dst_ip.
+        """
         current_time = time.time()
 
         # Alert deduplication - prevent same alert from firing repeatedly
-        alert_hash = f"{category}:{src_ip}:{dst_ip}"
+        alert_hash = dedup_key if dedup_key else f"{category}:{src_ip}:{dst_ip}"
         if alert_hash in self._alert_hashes:
             # Check if dedup window has expired
             if current_time < self._alert_hash_expiry.get(alert_hash, 0):

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -6804,8 +6804,52 @@ def run_arp_scan_localnet(interface='wlan0'):
         logger.error(f"Error running arp-scan: {e}")
         return {}
 
-def run_nmap_ping_scan(network='192.168.1.0/24'):
+def _detect_local_cidr():
+    """Return the local network CIDR derived from `ip` output, or None.
+
+    Used as a runtime fallback when an API caller doesn't pass an explicit
+    network=. Replaces the old hardcoded '192.168.1.0/24' default that
+    silently scanned the wrong subnet on any non-192.168.1.x network.
+    """
+    try:
+        iface = _get_wifi_iface()
+    except Exception:
+        iface = None
+    candidates = [iface] if iface else []
+    try:
+        result = subprocess.run(
+            ['ip', '-o', '-4', 'addr', 'show'],
+            capture_output=True, text=True, timeout=5)
+        if result.returncode != 0:
+            return None
+    except Exception:
+        return None
+    import ipaddress as _ipaddress
+    for line in result.stdout.strip().splitlines():
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        if candidates and parts[1] not in candidates:
+            continue
+        for i, p in enumerate(parts):
+            if p == 'inet' and i + 1 < len(parts):
+                cidr = parts[i + 1]
+                if cidr.startswith('127.'):
+                    continue
+                try:
+                    return str(_ipaddress.IPv4Network(cidr, strict=False))
+                except (ValueError, _ipaddress.NetmaskValueError):
+                    continue
+    return None
+
+
+def run_nmap_ping_scan(network=None):
     """Run nmap ping scan to discover active hosts"""
+    if network is None:
+        network = _detect_local_cidr()
+        if not network:
+            logger.error("run_nmap_ping_scan: no network specified and detection failed")
+            return {}
     command = ['sudo', 'nmap', '-sn', '-PR', network]
     logger.info(f"Running nmap ping scan: {' '.join(command)}")
     try:
@@ -6904,7 +6948,14 @@ def get_arp_scan_localnet():
 def get_nmap_ping_scan():
     """Get nmap ping scan results"""
     try:
-        network = request.args.get('network', '192.168.1.0/24')
+        network = request.args.get('network') or _detect_local_cidr()
+        if not network:
+            return jsonify({
+                'success': False,
+                'error': 'No network specified and local network detection failed',
+                'hosts': {},
+                'count': 0
+            }), 400
         hosts = run_nmap_ping_scan(network)
         
         return jsonify({
@@ -6928,8 +6979,15 @@ def get_combined_network_scan():
     """Get combined results from both ARP and nmap scans"""
     try:
         interface = request.args.get('interface', _get_wifi_iface())
-        network = request.args.get('network', '192.168.1.0/24')
-        
+        network = request.args.get('network') or _detect_local_cidr()
+        if not network:
+            return jsonify({
+                'success': False,
+                'error': 'No network specified and local network detection failed',
+                'hosts': {},
+                'count': 0
+            }), 400
+
         # Run both scans
         arp_hosts = run_arp_scan_localnet(interface)
         nmap_hosts = run_nmap_ping_scan(network)
@@ -12480,22 +12538,8 @@ def _collect_manual_targets():
                     except Exception:
                         continue
 
-        # Add example targets if no real data exists
-        if not targets:
-            targets = [
-                {
-                    'ip': '192.168.1.1',
-                    'hostname': '192.168.1.1',
-                    'ports': ['22', '80', '443'],
-                    'source': 'Example'
-                },
-                {
-                    'ip': '192.168.1.100',
-                    'hostname': '192.168.1.100',
-                    'ports': ['80', '443'],
-                    'source': 'Example'
-                }
-            ]
+        # No example seeding — empty list is the honest answer when no real
+        # data exists. Frontend shows an "empty" placeholder for this case.
     except Exception as e:
         logger.error(f"Error processing NetKB data for targets: {e}")
 
@@ -12843,9 +12887,14 @@ def stop_orchestrator_manual():
 def trigger_network_scan():
     """Trigger a manual network scan"""
     try:
-        data = request.get_json()
-        target_range = data.get('range', '192.168.1.0/24')  # Default range
-        
+        data = request.get_json() or {}
+        target_range = data.get('range') or _detect_local_cidr()
+        if not target_range:
+            return jsonify({
+                'success': False,
+                'error': 'No range specified and local network detection failed'
+            }), 400
+
         # Update status to show scanning is active
         shared_data.ragnarstatustext = "NetworkScanner"
         shared_data.ragnarstatustext2 = f"Manual scan: {target_range}"
@@ -16235,32 +16284,8 @@ def get_netkb_data():
             except Exception as e:
                 logger.warning(f"Could not list vulnerabilities directory: {e}")
         
-        # Add some example entries if no real data exists
-        if not netkb_entries:
-            netkb_entries = [
-                {
-                    'id': 'example_1',
-                    'type': 'service',
-                    'host': '192.168.1.1',
-                    'port': '22/tcp',
-                    'service': 'ssh',
-                    'description': 'SSH service detected',
-                    'severity': 'info',
-                    'discovered': time.time(),
-                    'source': 'Network Scan'
-                },
-                {
-                    'id': 'example_2',
-                    'type': 'vulnerability',
-                    'host': '192.168.1.100',
-                    'port': '80/tcp',
-                    'service': 'http',
-                    'description': 'Outdated web server version detected',
-                    'severity': 'medium',
-                    'discovered': time.time(),
-                    'source': 'Vulnerability Scan'
-                }
-            ]
+        # No example seeding — empty list is the honest answer when no real
+        # NetKB entries exist.
         
         # Calculate statistics using synchronized vulnerability count
         sync_all_counts()  # Ensure all counts are up to date
@@ -16349,19 +16374,8 @@ def export_netkb_data():
                     except Exception as e:
                         continue
         
-        # Add example data if no real data
-        if not netkb_entries:
-            netkb_entries = [
-                {
-                    'type': 'service',
-                    'host': '192.168.1.1',
-                    'port': '22/tcp',
-                    'service': 'ssh',
-                    'description': 'SSH service detected',
-                    'severity': 'info',
-                    'source': 'Network Scan'
-                }
-            ]
+        # No example seeding on export — empty CSV/JSON is the correct
+        # representation when no NetKB entries exist.
         
         if format_type == 'csv':
             import csv

--- a/wifi_manager.py
+++ b/wifi_manager.py
@@ -96,6 +96,16 @@ class WiFiManager:
         self._last_ping_sweep_time = 0
         self._last_ping_sweep_ssid = None
         self.ping_sweep_cooldown = shared_data.config.get('wifi_ping_sweep_cooldown', 120)
+
+        # SSID-change debounce: a transient SSID misread (roaming, dual-band
+        # flap, brief disconnect) used to flip the storage layer and trigger
+        # mark_all_hosts_degraded(), wiping every alive host. Require the
+        # NEW SSID to be observed consistently for this many seconds before
+        # propagating to shared_data.set_active_network().
+        self.ssid_change_debounce_s = shared_data.config.get(
+            'wifi_ssid_change_debounce_seconds', 30)
+        self._pending_ssid_change = None
+        self._pending_ssid_first_seen = 0.0
         # Failsafe cycle tracking (cycles with no WiFi and no AP clients)
         # This counter tracks prolonged disconnections (>5 minutes each) to prevent endless loops
         # It will only trigger a reboot after many consecutive long-term failures
@@ -272,13 +282,66 @@ class WiFiManager:
         return final_networks
 
     def _set_current_ssid(self, ssid):
-        """Update current SSID and notify shared storage manager."""
+        """Update current SSID and propagate to storage with debounce.
+
+        First-time establishment (no active network yet) propagates immediately
+        so the per-network DB switches before the next scan cycle. Subsequent
+        *changes* between known SSIDs are debounced: a transient misread of
+        the SSID (common during roaming on Pi Zero) used to trip
+        mark_all_hosts_degraded() and wipe the entire target list.
+        """
         self.current_ssid = ssid
-        if hasattr(self.shared_data, 'set_active_network'):
-            try:
-                self.shared_data.set_active_network(ssid)
-            except Exception as exc:
-                self.logger.warning(f"Failed to propagate network change to storage manager: {exc}")
+
+        if not hasattr(self.shared_data, 'set_active_network'):
+            return
+
+        active_ssid = getattr(self.shared_data, 'active_network_ssid', None)
+
+        # Same SSID as what storage already considers active → clear pending.
+        if ssid == active_ssid:
+            if self._pending_ssid_change is not None:
+                self.logger.debug(
+                    f"SSID change to {self._pending_ssid_change} aborted "
+                    f"(reverted to {active_ssid})")
+            self._pending_ssid_change = None
+            self._pending_ssid_first_seen = 0.0
+            return
+
+        # Fresh establishment from no active network → propagate immediately.
+        if not active_ssid:
+            self._propagate_active_network(ssid)
+            return
+
+        # Real change from one SSID to another → debounce.
+        now = time.time()
+        if self._pending_ssid_change != ssid:
+            self._pending_ssid_change = ssid
+            self._pending_ssid_first_seen = now
+            self.logger.info(
+                f"SSID change observed: {active_ssid!r} -> {ssid!r}, "
+                f"debouncing {self.ssid_change_debounce_s}s before switching "
+                f"network storage")
+            return
+
+        elapsed = now - self._pending_ssid_first_seen
+        if elapsed < self.ssid_change_debounce_s:
+            self.logger.debug(
+                f"SSID {ssid!r} pending {elapsed:.1f}/"
+                f"{self.ssid_change_debounce_s}s")
+            return
+
+        self.logger.info(
+            f"SSID {ssid!r} confirmed after {elapsed:.1f}s — switching storage")
+        self._propagate_active_network(ssid)
+        self._pending_ssid_change = None
+        self._pending_ssid_first_seen = 0.0
+
+    def _propagate_active_network(self, ssid):
+        try:
+            self.shared_data.set_active_network(ssid)
+        except Exception as exc:
+            self.logger.warning(
+                f"Failed to propagate network change to storage manager: {exc}")
 
     def _trigger_initial_ping_sweep(self, ssid):
         """Schedule a post-connection ping sweep to refresh network data."""


### PR DESCRIPTION
This pull request makes significant improvements to how the network scanning and ping sweep logic determine which network ranges to use, removing static fallback defaults and enforcing explicit or auto-detected CIDR usage. It also introduces a comprehensive new test suite for passive host discovery in `TrafficAnalyzer`, ensuring correct ARP parsing, LAN detection, port mapping, and database synchronization behavior.

**Network scanning and ping sweep logic improvements:**

* The default subnet  is no longer used as a fallback when network detection fails; instead, if network detection cannot determine a CIDR, the relevant scans are skipped and errors are logged, requiring the caller to provide an explicit CIDR. (`actions/scanning.py`, `get_network`, `run_arp_scan`, `_ping_sweep_missing_hosts`, `run_initial_ping_sweep`) [[1]](diffhunk://#diff-e6587ad9fedd56bf4f99efc063572bcf9489d0bf4df0878b60943527ec3d3076L246-R258) [[2]](diffhunk://#diff-e6587ad9fedd56bf4f99efc063572bcf9489d0bf4df0878b60943527ec3d3076L444-R461) [[3]](diffhunk://#diff-e6587ad9fedd56bf4f99efc063572bcf9489d0bf4df0878b60943527ec3d3076L589-R605) [[4]](diffhunk://#diff-e6587ad9fedd56bf4f99efc063572bcf9489d0bf4df0878b60943527ec3d3076L943-R963)
* The ping sweep priority list is now empty by default, and must be explicitly set by the caller if special hosts should be prioritized. (`actions/scanning.py`, `_ping_sweep_missing_hosts`)
* Documentation/specs updated to reflect that there is no static fallback CIDR and that the ping sweep will be skipped if network detection fails; also clarifies the new default for the priority list. (`docs/spec.md`, `spec.md`)

**Testing and validation:**

* Adds a thorough new test suite `test_passive_host_discovery.py` that covers ARP parsing, LAN network derivation, listening port detection, pseudo-MAC handling, passive DB sync logic, and liveness updates for observed hosts. This ensures robust coverage for passive host discovery and synchronization logic.