### PR TITLE
Stop web portal during wardriving without WiFi; reconnect on device disconnect

### DIFF
--- a/Ragnar.py
+++ b/Ragnar.py
@@ -53,6 +53,10 @@ class Ragnar:
         # Reference to display instance (will be set when display is started)
         self.display = None
 
+        # Web portal lifecycle management (stop during wardriving without WiFi)
+        self._web_portal_lock = threading.Lock()
+        self._web_thread_ref = None  # Reference to current web server thread
+
         # PiSugar button listener (for Ragnar/Pwnagotchi swap via hardware button)
         self.pisugar_listener = None
         try:
@@ -184,6 +188,43 @@ class Ragnar:
             webapp_modern._wardriving_engine = self._wd_engine
         except Exception as e:
             logger.error(f"Failed to auto-start wardriving on boot: {e}")
+
+    def start_web_portal(self):
+        """Start the web portal if not already running (called when WiFi connects during wardriving)."""
+        if not self.shared_data.config.get('websrv', True):
+            return False
+        with self._web_portal_lock:
+            if self._web_thread_ref and self._web_thread_ref.is_alive():
+                logger.debug("Web portal already running, skipping start")
+                return False
+            logger.info("Starting web portal (WiFi connected during wardriving)...")
+            self.shared_data.webapp_should_exit = False
+            from webapp_modern import run_server
+            t = threading.Thread(target=run_server, daemon=True, name="web-server")
+            t.start()
+            self._web_thread_ref = t
+            self.shared_data.web_portal_active = True
+            logger.info("Web portal started")
+            return True
+
+    def stop_web_portal(self):
+        """Stop the web portal to save memory (called when WiFi drops during wardriving)."""
+        with self._web_portal_lock:
+            if not self._web_thread_ref or not self._web_thread_ref.is_alive():
+                logger.debug("Web portal not running, skipping stop")
+                self.shared_data.web_portal_active = False
+                return False
+            logger.info("Stopping web portal to save memory (wardriving without WiFi)...")
+            self.shared_data.webapp_should_exit = True
+            try:
+                import webapp_modern
+                webapp_modern.socketio.stop()
+            except Exception as e:
+                logger.warning(f"socketio.stop() error: {e}")
+            self._web_thread_ref.join(timeout=5)
+            self.shared_data.web_portal_active = False
+            logger.info("Web portal stopped")
+            return True
 
     def stop(self):
         """Stop Ragnar and cleanup all resources."""
@@ -329,7 +370,7 @@ if __name__ == "__main__":
         if shared_data.config["websrv"]:
             logger.info("Starting the web server...")
             from webapp_modern import run_server
-            web_thread = threading.Thread(target=run_server, daemon=True)
+            web_thread = threading.Thread(target=run_server, daemon=True, name="web-server")
             web_thread.start()
         else:
             web_thread = None
@@ -345,6 +386,10 @@ if __name__ == "__main__":
         # Link display instance to ragnar instance
         if hasattr(shared_data, 'display_instance'):
             ragnar.display = shared_data.display_instance
+
+        # Register web thread with Ragnar instance for portal lifecycle management
+        ragnar._web_thread_ref = web_thread
+        shared_data.web_portal_active = web_thread is not None
 
         ragnar_thread = threading.Thread(target=ragnar.run)
         ragnar_thread.start()

--- a/shared.py
+++ b/shared.py
@@ -1051,7 +1051,8 @@ class SharedData:
         self.should_exit = False
         self.display_should_exit = False
         self.orchestrator_should_exit = False
-        self.webapp_should_exit = False 
+        self.webapp_should_exit = False
+        self.web_portal_active = True  # Tracks whether the web portal is currently running
         self.ragnar_instance = None
         self.gateway_info = {}  # Populated by NetworkScanner.get_gateway_info()
         self.wifichanged = False

--- a/wardriving.py
+++ b/wardriving.py
@@ -1506,6 +1506,32 @@ class WardrivingEngine:
             'gps_port': self._gps.port if gps_ok else None
         }
 
+    def _trigger_wifi_reconnect_on_disconnect(self, source: str, port: str):
+        """Attempt WiFi reconnect after a companion or USB antenna disconnects.
+
+        Only acts when not already connected to WiFi and not in AP mode; runs
+        in a daemon thread so the serial listener can continue its retry loop.
+        """
+        try:
+            if getattr(self.shared_data, 'wifi_connected', False):
+                return  # Already on WiFi — nothing to do
+            ragnar = getattr(self.shared_data, 'ragnar_instance', None)
+            if ragnar and hasattr(ragnar, 'wifi_manager'):
+                wm = ragnar.wifi_manager
+                if getattr(wm, 'ap_mode_active', False):
+                    return  # Don't disrupt an active AP session
+                logger.info(
+                    f"[wardriving] {source} on {port} disconnected — "
+                    "triggering WiFi reconnect attempt"
+                )
+                threading.Thread(
+                    target=wm._endless_loop_wifi_search,
+                    daemon=True,
+                    name="wifi-reconnect-companion-unplug",
+                ).start()
+        except Exception as exc:
+            logger.warning(f"[wardriving] WiFi reconnect trigger failed: {exc}")
+
     def stop(self):
         """Stop the current wardriving session."""
         if not self._running:
@@ -3166,6 +3192,8 @@ class WardrivingEngine:
             except Exception as e:
                 companion.connected = False
                 logger.warning(f"[wardriving] Listener iteration died ({companion.port}): {e!r}")
+                # Companion unplugged — try to reconnect to known WiFi if not connected
+                self._trigger_wifi_reconnect_on_disconnect("companion", companion.port)
                 for _ in range(5):
                     if not self._running or companion.port not in self._companions:
                         break

--- a/wifi_manager.py
+++ b/wifi_manager.py
@@ -461,17 +461,20 @@ class WiFiManager:
     def start(self):
         """Start the Wi-Fi management system with endless loop behavior"""
         self.logger.info("Starting Wi-Fi Manager with Endless Loop behavior...")
-        
+
         # Mark boot completion time for endless loop timing
         self.boot_completed_time = time.time()
-        
+
         # Create a restart detection file to help identify service restarts
         self._create_restart_marker()
-        
+
         # Start monitoring thread
         if not self.monitoring_thread or not self.monitoring_thread.is_alive():
             self.monitoring_thread = threading.Thread(target=self._endless_loop_monitoring, daemon=True)
             self.monitoring_thread.start()
+
+        # Start USB interface monitor to detect antenna/adapter disconnect events
+        self._start_usb_interface_monitor()
         
         # Initial connection assessment and endless loop startup
         self._initial_endless_loop_sequence()
@@ -581,6 +584,99 @@ class WiFiManager:
             self.logger.warning(f"Could not check restart marker: {e}")
             return False
     
+    # ============================================================================
+    # USB INTERFACE MONITOR — detect antenna/adapter hot-unplug events
+    # ============================================================================
+
+    def _get_wifi_interfaces_sysfs(self):
+        """Return the set of WiFi interface names visible in /sys/class/net/."""
+        ifaces = set()
+        try:
+            for name in os.listdir('/sys/class/net/'):
+                base = f'/sys/class/net/{name}'
+                if os.path.exists(f'{base}/wireless') or os.path.exists(f'{base}/phy80211'):
+                    ifaces.add(name)
+        except Exception:
+            pass
+        return ifaces
+
+    def _start_usb_interface_monitor(self):
+        """Start a background thread that watches for WiFi interface disappearance."""
+        t = threading.Thread(
+            target=self._usb_interface_monitor_loop,
+            daemon=True,
+            name="usb-iface-monitor",
+        )
+        t.start()
+
+    def _usb_interface_monitor_loop(self):
+        """Poll /sys/class/net/ every 5 s; trigger reconnect when a WiFi interface vanishes."""
+        prev_ifaces = self._get_wifi_interfaces_sysfs()
+        while not self.should_exit:
+            time.sleep(5)
+            try:
+                current_ifaces = self._get_wifi_interfaces_sysfs()
+                disappeared = prev_ifaces - current_ifaces
+                if disappeared:
+                    self.logger.warning(
+                        f"WiFi interface(s) disappeared (unplugged?): {disappeared}"
+                    )
+                    if not self.wifi_connected and not self.ap_mode_active:
+                        self.logger.info(
+                            "USB antenna removed while disconnected — triggering WiFi reconnect"
+                        )
+                        threading.Thread(
+                            target=self._endless_loop_wifi_search,
+                            daemon=True,
+                            name="wifi-reconnect-usb-unplug",
+                        ).start()
+                prev_ifaces = current_ifaces
+            except Exception as e:
+                self.logger.debug(f"USB interface monitor error: {e}")
+
+    # ============================================================================
+    # WARDRIVING / WEB PORTAL COORDINATION
+    # ============================================================================
+
+    def _is_wardriving_active(self):
+        """Return True if the wardriving engine is currently running."""
+        try:
+            ragnar = getattr(self.shared_data, 'ragnar_instance', None)
+            if ragnar and hasattr(ragnar, '_wd_engine'):
+                return getattr(ragnar._wd_engine, '_running', False)
+            import webapp_modern
+            engine = getattr(webapp_modern, '_wardriving_engine', None)
+            if engine:
+                return getattr(engine, '_running', False)
+        except Exception:
+            pass
+        return self.shared_data.config.get('wardriving_on_boot', False)
+
+    def _sync_web_portal_for_wardriving(self):
+        """Stop web portal when wardriving with no WiFi; restart when WiFi returns.
+
+        Called every monitoring iteration so the portal state converges quickly
+        regardless of how wardriving was started (boot flag, API call, etc.).
+        """
+        if not self._is_wardriving_active():
+            return
+        ragnar = getattr(self.shared_data, 'ragnar_instance', None)
+        if not ragnar:
+            return
+        portal_active = getattr(self.shared_data, 'web_portal_active', True)
+        if not self.wifi_connected and portal_active:
+            threading.Thread(
+                target=ragnar.stop_web_portal,
+                daemon=True,
+                name="web-portal-stopper",
+            ).start()
+        elif self.wifi_connected and not portal_active:
+            threading.Thread(
+                target=ragnar.start_web_portal,
+                daemon=True,
+                name="web-portal-starter",
+            ).start()
+
     def _initial_endless_loop_sequence(self):
         """Handle initial Wi-Fi connection with endless loop behavior"""
         self.logger.info("Starting Endless Loop Wi-Fi management...")
@@ -818,7 +914,10 @@ class WiFiManager:
                     ssid = self.current_ssid if self.wifi_connected else None
                     self._save_connection_state(ssid, self.wifi_connected)
                     last_state_save = current_time
-                
+
+                # Keep web portal in sync with wardriving + WiFi state
+                self._sync_web_portal_for_wardriving()
+
                 time.sleep(self.connection_check_interval)
                 
             except Exception as e:


### PR DESCRIPTION
- Ragnar: add start_web_portal()/stop_web_portal() with threading lock so the
  portal can be gracefully stopped (socketio.stop + thread join) and restarted
  in a fresh daemon thread when WiFi returns during a wardriving session.

- shared.py: add web_portal_active flag so all modules can read portal state.

- wifi_manager: add _sync_web_portal_for_wardriving() called every monitoring
  iteration — stops the portal when wardriving is active and WiFi is down,
  restarts it as soon as WiFi reconnects.
  Add _usb_interface_monitor_loop() (5 s poll of /sys/class/net/) that triggers
  _endless_loop_wifi_search() when a WiFi interface disappears while disconnected,
  covering hot-unplug of USB antennas.

- wardriving: add _trigger_wifi_reconnect_on_disconnect() called from the serial
  listener exception handler — when a companion (Huginn/Piglet) is unplugged and
  Ragnar is not on WiFi, a reconnect attempt is launched in a daemon thread
  without blocking the serial listener's own retry loop.

https://claude.ai/code/session_01HApR84feR5dPq1qTNvM1ZQ