### PR TITLE
Rows whose position was estimated via backfill_gps_from_track

### DIFF
--- a/docs/wardriving.md
+++ b/docs/wardriving.md
@@ -327,6 +327,8 @@ Each session writes one row to `gps_track` every 5 s while GPS has a fix:
 gps_track (timestamp, latitude, longitude, altitude, speed_kmh, satellites, hdop)
 ```
 
+> **Opt-in only.** Backfilled positions are *estimates*, not observed fixes, and are **not allowed in WDGWARS**. The "Backfill GPS" map button is hidden by default; enable it under **Config → Wardriving → Allow GPS Backfill** (sets `wardriving_allow_backfill`). The endpoint returns `403` while the flag is off. Any row backfilled this way is flagged `gps_backfilled = 1` and is **excluded from WiGLE CSV export** (it still appears on the map and in KML).
+
 `POST /api/wardriving/backfill_gps` (or the "Backfill GPS" button) fills in missing positions on `networks`, `bluetooth_devices`, and `cells` rows by looking up each row's `first_seen` against the breadcrumb track:
 
 1. `bisect` the track to find the two trackpoints bracketing the row's timestamp.

--- a/wardriving.py
+++ b/wardriving.py
@@ -204,7 +204,8 @@ class WardrivingSession:
                     scan_count INTEGER DEFAULT 1,
                     interface TEXT DEFAULT '',
                     band TEXT DEFAULT '2.4GHz',
-                    is_camera INTEGER DEFAULT 0
+                    is_camera INTEGER DEFAULT 0,
+                    gps_backfilled INTEGER DEFAULT 0
                 )
             """)
             conn.execute("""
@@ -271,7 +272,8 @@ class WardrivingSession:
                     pending_count INTEGER DEFAULT 0,
                     first_seen TEXT NOT NULL,
                     last_seen TEXT NOT NULL,
-                    scan_count INTEGER DEFAULT 1
+                    scan_count INTEGER DEFAULT 1,
+                    gps_backfilled INTEGER DEFAULT 0
                 )
             """)
             conn.execute("""
@@ -286,9 +288,10 @@ class WardrivingSession:
                 ('best_rssi',     '-100'),
                 ('best_lat',      'NULL'),
                 ('best_lon',      'NULL'),
-                ('pending_lat',   'NULL'),
-                ('pending_lon',   'NULL'),
-                ('pending_count', '0'),
+                ('pending_lat',     'NULL'),
+                ('pending_lon',     'NULL'),
+                ('pending_count',   '0'),
+                ('gps_backfilled',  '0'),
             )
             for _name, _default in _BT_MIGRATE_COLS:
                 assert _name.replace('_', '').isalnum(), f'unsafe column name: {_name!r}'
@@ -316,12 +319,23 @@ class WardrivingSession:
                     longitude REAL,
                     first_seen TEXT NOT NULL,
                     last_seen TEXT NOT NULL,
-                    scan_count INTEGER DEFAULT 1
+                    scan_count INTEGER DEFAULT 1,
+                    gps_backfilled INTEGER DEFAULT 0
                 )
             """)
             conn.execute("""
                 CREATE UNIQUE INDEX IF NOT EXISTS idx_cell ON cell_towers(cell_id)
             """)
+            # Migrate older networks / cell_towers tables that predate the
+            # GPS-backfill flag. Table names here are hardcoded literals, so
+            # the f-string interpolation carries no injection risk.
+            for _tbl in ('networks', 'cell_towers'):
+                try:
+                    cols = {r[1] for r in conn.execute(f"PRAGMA table_info({_tbl})").fetchall()}
+                    if 'gps_backfilled' not in cols:
+                        conn.execute(f"ALTER TABLE {_tbl} ADD COLUMN gps_backfilled INTEGER DEFAULT 0")
+                except Exception:
+                    pass
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS gps_track (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -907,7 +921,8 @@ class WardrivingSession:
                                 "latitude = COALESCE(latitude, ?), "
                                 "longitude = COALESCE(longitude, ?), "
                                 "altitude = COALESCE(altitude, ?), "
-                                "best_lat = ?, best_lon = ? WHERE bssid = ?",
+                                "best_lat = ?, best_lon = ?, "
+                                "gps_backfilled = 1 WHERE bssid = ?",
                                 (pos[0], pos[1], pos[2], pos[0], pos[1], r['bssid'])
                             )
                             result['wifi'] += 1
@@ -925,7 +940,8 @@ class WardrivingSession:
                                     "latitude = ?, longitude = ?, "
                                     "altitude = COALESCE(altitude, ?), "
                                     "best_lat = COALESCE(best_lat, ?), "
-                                    "best_lon = COALESCE(best_lon, ?) WHERE mac = ?",
+                                    "best_lon = COALESCE(best_lon, ?), "
+                                    "gps_backfilled = 1 WHERE mac = ?",
                                     (pos[0], pos[1], pos[2], pos[0], pos[1], r['mac'])
                                 )
                                 result['bluetooth'] += 1
@@ -941,8 +957,8 @@ class WardrivingSession:
                             pos = _pos_at(_parse_iso(r['first_seen']))
                             if pos:
                                 conn.execute(
-                                    "UPDATE cell_towers SET latitude = ?, longitude = ? "
-                                    "WHERE cell_id = ?",
+                                    "UPDATE cell_towers SET latitude = ?, longitude = ?, "
+                                    "gps_backfilled = 1 WHERE cell_id = ?",
                                     (pos[0], pos[1], r['cell_id'])
                                 )
                                 result['cells'] += 1
@@ -959,7 +975,11 @@ class WardrivingSession:
         return result
 
     def export_wigle_csv(self, device_name='Ragnar'):
-        """Export session to WiGLE CSV format string including WiFi, BT, and cell."""
+        """Export session to WiGLE CSV format string including WiFi, BT, and cell.
+
+        Rows whose position was estimated via backfill_gps_from_track
+        (gps_backfilled = 1) are excluded — interpolated coordinates are not
+        permitted in WiGLE submissions (WDGWARS rules)."""
         lines = []
         dn = device_name or 'Ragnar'
         lines.append(f'WigleWifi-1.4,appRelease=Ragnar,model=RaspberryPi,release=1.0,device={dn},display=EPD,board=RPi,brand=Ragnar')
@@ -969,8 +989,11 @@ class WardrivingSession:
             try:
                 with sqlite3.connect(self.db_path) as conn:
                     conn.row_factory = sqlite3.Row
-                    # WiFi networks
-                    rows = conn.execute("SELECT * FROM networks ORDER BY first_seen").fetchall()
+                    # WiFi networks (skip backfilled positions)
+                    rows = conn.execute(
+                        "SELECT * FROM networks WHERE COALESCE(gps_backfilled, 0) = 0 "
+                        "ORDER BY first_seen"
+                    ).fetchall()
                     for row in rows:
                         r = dict(row)
                         lines.append(','.join([
@@ -988,7 +1011,10 @@ class WardrivingSession:
                         ]))
                     # Bluetooth devices
                     try:
-                        bt_rows = conn.execute("SELECT * FROM bluetooth_devices ORDER BY first_seen").fetchall()
+                        bt_rows = conn.execute(
+                            "SELECT * FROM bluetooth_devices WHERE COALESCE(gps_backfilled, 0) = 0 "
+                            "ORDER BY first_seen"
+                        ).fetchall()
                         for row in bt_rows:
                             r = dict(row)
                             lines.append(','.join([
@@ -1008,7 +1034,10 @@ class WardrivingSession:
                         pass
                     # Cell towers
                     try:
-                        cell_rows = conn.execute("SELECT * FROM cell_towers ORDER BY first_seen").fetchall()
+                        cell_rows = conn.execute(
+                            "SELECT * FROM cell_towers WHERE COALESCE(gps_backfilled, 0) = 0 "
+                            "ORDER BY first_seen"
+                        ).fetchall()
                         for row in cell_rows:
                             r = dict(row)
                             lines.append(','.join([

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -4016,23 +4016,26 @@
                         <label class="text-xs text-gray-400">Min Signal:</label>
                         <input type="range" id="wd-map-filter-signal" min="-100" max="-30" value="-100" oninput="document.getElementById('wd-map-signal-val').textContent=this.value+' dBm'; applyWardrivingMapFilters()" class="w-24">
                         <span id="wd-map-signal-val" class="text-xs text-gray-300">-100 dBm</span>
-                        <button onclick="backfillWardrivingGps()" id="wd-map-backfill-btn" title="Estimate positions for networks scanned during GPS dropouts by interpolating from the recorded GPS track"
-                            class="ml-auto bg-emerald-700 hover:bg-emerald-600 text-white text-xs rounded px-2 py-1 border border-emerald-800 flex items-center gap-1">
-                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                            </svg>
-                            Backfill GPS
-                        </button>
-                        <button onclick="toggleWardrivingMapFullscreen()" id="wd-map-fs-btn" title="Toggle fullscreen (Esc to exit)"
-                            class="bg-slate-700 hover:bg-slate-600 text-white text-xs rounded px-2 py-1 border border-slate-600 flex items-center gap-1">
-                            <svg id="wd-map-fs-icon-enter" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4h4M20 8V4h-4M4 16v4h4M20 16v4h-4"/>
-                            </svg>
-                            <svg id="wd-map-fs-icon-exit" class="w-3.5 h-3.5 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 4v4H5M15 4v4h4M9 20v-4H5M15 20v-4h4"/>
-                            </svg>
-                            <span id="wd-map-fs-label">Fullscreen</span>
-                        </button>
+                        <div class="ml-auto flex items-center gap-2">
+                            <!-- Hidden unless GPS backfill is enabled in Config → Wardriving -->
+                            <button onclick="backfillWardrivingGps()" id="wd-map-backfill-btn" title="Estimate positions for networks scanned during GPS dropouts by interpolating from the recorded GPS track. Not allowed in WDGWARS — backfilled rows are excluded from WiGLE export."
+                                class="hidden bg-emerald-700 hover:bg-emerald-600 text-white text-xs rounded px-2 py-1 border border-emerald-800 flex items-center gap-1">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                                </svg>
+                                Backfill GPS
+                            </button>
+                            <button onclick="toggleWardrivingMapFullscreen()" id="wd-map-fs-btn" title="Toggle fullscreen (Esc to exit)"
+                                class="bg-slate-700 hover:bg-slate-600 text-white text-xs rounded px-2 py-1 border border-slate-600 flex items-center gap-1">
+                                <svg id="wd-map-fs-icon-enter" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4h4M20 8V4h-4M4 16v4h4M20 16v4h-4"/>
+                                </svg>
+                                <svg id="wd-map-fs-icon-exit" class="w-3.5 h-3.5 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 4v4H5M15 4v4h4M9 20v-4H5M15 20v-4h4"/>
+                                </svg>
+                                <span id="wd-map-fs-label">Fullscreen</span>
+                            </button>
+                        </div>
                     </div>
                     <div id="wd-map" style="height: 450px; border-radius: 0.75rem; z-index: 1;"></div>
                     <div class="text-xs text-gray-500 mt-1 text-right" id="wd-map-info"></div>
@@ -4314,6 +4317,25 @@
                             </div>
                             <div class="text-xs text-gray-500">
                                 Ragnar will enter wardriving mode immediately on power-on — ideal for mobile/walk setups.
+                            </div>
+                        </div>
+
+                        <!-- GPS Backfill Card -->
+                        <div class="glass rounded-lg p-4 border border-amber-900/40">
+                            <div class="flex items-center justify-between mb-3">
+                                <h4 class="font-medium">Allow GPS Backfill</h4>
+                                <label class="toggle-switch relative inline-flex items-center cursor-pointer">
+                                    <input type="checkbox" id="wardriving-allow-backfill" class="sr-only peer" onchange="toggleWardrivingBackfill()">
+                                    <div class="w-11 h-6 bg-gray-700 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all"></div>
+                                </label>
+                            </div>
+                            <div class="text-sm text-gray-400 mb-2">
+                                Reveals the “Backfill GPS” button on the wardriving map, which estimates positions for
+                                devices seen during GPS dropouts by interpolating from the recorded track.
+                            </div>
+                            <div class="flex items-start gap-2 text-xs text-amber-400 bg-amber-900/20 rounded px-2 py-2">
+                                <svg class="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/></svg>
+                                <span>Backfill GPS is <strong>not allowed in WDGWARS</strong>. WiGLE export will be disabled for any data that has been backfilled.</span>
                             </div>
                         </div>
 

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -4021,6 +4021,9 @@ async function loadConfigData() {
         // Load wardriving on-boot toggle state (card is in config page)
         loadWardrivingOnBootState();
 
+        // Load GPS-backfill opt-in state (gates the map Backfill GPS button)
+        loadWardrivingBackfillState();
+
         // Load on-screen kiosk state + service badge
         loadKioskState();
 
@@ -15732,6 +15735,9 @@ function updateWardrivingUI(status) {
     _wardrivingRunning = !!status.running;
     updateWardrivingToggleButton();
 
+    // Map "Backfill GPS" button is only shown when enabled in config
+    applyWardrivingBackfillVisibility(!!status.allow_backfill);
+
     if (status.running) {
         if (badge) { badge.textContent = 'Running'; badge.className = 'px-2 py-1 bg-emerald-600 bg-opacity-30 text-emerald-400 text-xs rounded-full animate-pulse'; }
     } else {
@@ -16199,6 +16205,43 @@ async function loadWardrivingOnBootState() {
         const data = await res.json();
         const cb = document.getElementById('wardriving-on-boot');
         if (cb) cb.checked = !!data.wardriving_on_boot;
+    } catch (e) { /* silent */ }
+}
+
+// GPS backfill is gated: the map "Backfill GPS" button stays hidden until the
+// user opts in here. Backfilled positions are estimates (not WDGWARS-legal) and
+// are excluded from WiGLE export, so this defaults off.
+function applyWardrivingBackfillVisibility(allow) {
+    const btn = document.getElementById('wd-map-backfill-btn');
+    if (btn) btn.classList.toggle('hidden', !allow);
+}
+
+async function toggleWardrivingBackfill() {
+    const cb = document.getElementById('wardriving-allow-backfill');
+    if (!cb) return;
+    const enabled = !!cb.checked;
+    try {
+        await postAPI('/api/config', { wardriving_allow_backfill: enabled });
+        applyWardrivingBackfillVisibility(enabled);
+        addConsoleMessage(
+            'GPS backfill ' + (enabled ? 'enabled — backfilled data is excluded from WiGLE export' : 'disabled'),
+            enabled ? 'warning' : 'info'
+        );
+    } catch (e) {
+        console.error('[Wardriving] backfill toggle error:', e);
+        addConsoleMessage('Failed to update GPS backfill setting', 'error');
+        cb.checked = !enabled;
+    }
+}
+
+async function loadWardrivingBackfillState() {
+    try {
+        const res = await fetch('/api/config');
+        const cfg = await res.json();
+        const allow = !!cfg.wardriving_allow_backfill;
+        const cb = document.getElementById('wardriving-allow-backfill');
+        if (cb) cb.checked = allow;
+        applyWardrivingBackfillVisibility(allow);
     } catch (e) { /* silent */ }
 }
 

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -6589,6 +6589,7 @@ def wardriving_status():
         engine = _get_wardriving_engine()
         status = engine.get_status()
         status['enabled'] = True
+        status['allow_backfill'] = bool(shared_data.config.get('wardriving_allow_backfill', False))
         return jsonify(status)
     except Exception as e:
         logger.error(f"Wardriving status error: {e}")
@@ -6912,8 +6913,17 @@ def wardriving_cells():
 def wardriving_backfill_gps():
     """Backfill missing GPS positions on networks / BT / cell rows from the
     session's gps_track table by interpolating each row's first_seen
-    timestamp. Covers brief GPS dropouts and the warm-up window before TTFF."""
+    timestamp. Covers brief GPS dropouts and the warm-up window before TTFF.
+
+    Gated behind the `wardriving_allow_backfill` config flag (off by default):
+    backfilled positions are estimates, not allowed in WDGWARS, and are
+    excluded from WiGLE export once written."""
     try:
+        if not shared_data.config.get('wardriving_allow_backfill', False):
+            return jsonify({
+                'error': 'GPS backfill is disabled. Enable it in Config → Wardriving. '
+                         'Backfill is not allowed in WDGWARS and backfilled rows are excluded from WiGLE export.'
+            }), 403
         engine = _get_wardriving_engine()
         body = request.get_json(silent=True) or {}
         session_id = request.args.get('session_id') or body.get('session_id')


### PR DESCRIPTION
(gps_backfilled = 1) are excluded. Interpolated coordinates are not actual observations, so they're omitted from WiGLE submissions to avoid polluting the dataset with synthetic positions.