### PR TITLE
Net diag: 2.7" HAT key pad for diagnostic mode + DNS poisoning detection

### DIFF
--- a/display.py
+++ b/display.py
@@ -856,15 +856,17 @@ class Display:
     # Network Diagnostic mode (Ethernet-focused, internet-independent)
     # ------------------------------------------------------------------
 
-    def _netdiag_sleep(self, seconds):
-        """Sleep up to `seconds`, waking early if the display is exiting or the
-        network-diagnostic toggle is switched off, so the normal display
-        resumes promptly."""
+    def _netdiag_sleep(self, seconds, bl=None, seq0=0):
+        """Sleep up to `seconds`, waking early if the display is exiting, the
+        network-diagnostic toggle is switched off, or a HAT key fired (the
+        button listener bumps netdiag_seq), so key presses feel responsive."""
         steps = max(1, int(seconds / 0.1))
         for _ in range(steps):
             if self.shared_data.display_should_exit:
                 return
             if not self.shared_data.config.get('network_diagnostic_mode', False):
+                return
+            if bl is not None and getattr(bl, 'netdiag_seq', 0) != seq0:
                 return
             time.sleep(0.1)
 
@@ -910,7 +912,7 @@ class Display:
         return {'eth': eth, 'eth_count': len(eth_list),
                 'gateway': gateway, 'dns': nameservers, 'lldp': lldp}
 
-    def _render_netdiag_page(self, image, draw, page):
+    def _render_netdiag_page(self, image, draw, page, frozen=False):
         """Render one Ethernet network-diagnostic sub-page. Space on the panel
         is scarce, so each page shows only the handful of facts an engineer
         actually needs when diagnosing a switch port."""
@@ -918,8 +920,9 @@ class Display:
         data = self._get_cached_page_data('netdiag', self._fetch_netdiag_data, ttl=10)
         names = ["LINK", "IP", "SWITCH"]
         name = names[page % len(names)]
+        state = "PAUSED" if frozen else "auto5s"
         self._draw_page_frame(draw, f"NET {name}",
-                              hint=f"Ethernet diag  {page + 1}/{NETDIAG_PAGE_COUNT}  auto 5s")
+                              hint=f"{page + 1}/{NETDIAG_PAGE_COUNT} {state}  K1nav K2port K3png K4dns")
         y = int(28 * sy)
         if not data:
             self._draw_stat_rows(draw, y, [("Status", "gathering...")])
@@ -999,6 +1002,72 @@ class Display:
                 ("Proto", n.get('protocol') or '—'),
                 ("Mgmt IP", n.get('mgmt_ip') or '—'),
             ])
+
+    def _draw_wrapped_note(self, draw, y, text, max_lines=3):
+        """Word-wrap a short note across up to max_lines using the small font."""
+        w = getattr(self, 'render_w', self.shared_data.width)
+        sx = getattr(self, 'render_sx', self.scale_factor_x)
+        sy = getattr(self, 'render_sy', self.scale_factor_y)
+        font = self.shared_data.font_arial9
+        pad_x = int(6 * sx)
+        avail = w - 2 * pad_x
+        lines, cur = [], ''
+        for word in str(text).split():
+            trial = (cur + ' ' + word).strip()
+            if font.getlength(trial) <= avail or not cur:
+                cur = trial
+            else:
+                lines.append(cur)
+                cur = word
+                if len(lines) >= max_lines:
+                    break
+        if cur and len(lines) < max_lines:
+            lines.append(cur)
+        line_h = int(11 * sy)
+        for ln in lines[:max_lines]:
+            draw.text((pad_x, y), ln, font=font, fill=0)
+            y += line_h
+        return y
+
+    def _render_netdiag_result(self, image, draw, result):
+        """Render a one-shot netdiag test result (triggered by a HAT key). Holds
+        on screen until KEY1 returns to the auto-cycling pages."""
+        sy = getattr(self, 'render_sy', self.scale_factor_y)
+        w = getattr(self, 'render_w', self.shared_data.width)
+        title = str(result.get('title') or 'TEST')
+        running = result.get('running')
+        hint = "running..." if running else "K1 back to pages"
+        self._draw_page_frame(draw, f"NET {title}", hint=hint)
+        y = int(28 * sy)
+        if running:
+            self._draw_stat_rows(draw, y, [("Status", "running..."),
+                                           ("Please", "wait a few s")])
+            return
+        verdict = result.get('verdict')
+        if verdict:
+            big = str(verdict[0])
+            font_big = self.shared_data.font_viking
+            tw = font_big.getlength(big)
+            draw.text(((w - tw) / 2, y), big, font=font_big, fill=0)
+            y += int(24 * sy)
+        y = self._draw_stat_rows(draw, y, result.get('rows') or [])
+        note = result.get('note')
+        if note:
+            self._draw_wrapped_note(draw, y + int(3 * sy), note)
+
+    def _commit_netdiag_frame(self, image):
+        """Push a rendered netdiag frame to the panel and the web mirror."""
+        epd_img = _apply_epd_rotation(image, self.screen_reversed)
+        self.epd_helper.display_partial(epd_img)
+        self.epd_helper.display_partial(epd_img)
+        web_img = _apply_web_rotation(image, self.web_screen_reversed)
+        try:
+            with open(os.path.join(self.shared_data.webdir, "screen.png"), 'wb') as img_file:
+                web_img.save(img_file)
+                img_file.flush()
+                os.fsync(img_file.fileno())
+        except Exception:
+            pass
 
     def _fetch_network_data(self):
         """Fetch real host data from database."""
@@ -2851,25 +2920,47 @@ class Display:
                 # Rendered + committed here so the standard page pipeline is
                 # bypassed entirely while active.
                 if self.shared_data.config.get('network_diagnostic_mode', False):
-                    page = getattr(self, '_netdiag_page', 0) % NETDIAG_PAGE_COUNT
+                    # The 2.7" HAT keys drive this mode (see epd_button.py): the
+                    # button listener owns the current page / freeze state and
+                    # posts one-shot test results for us to render.
+                    bl = (self.button_listener
+                          if (self.button_listener and self.button_listener.available)
+                          else None)
+                    seq0 = getattr(bl, 'netdiag_seq', 0) if bl else 0
+                    result = getattr(bl, 'netdiag_result', None) if bl else None
+                    if result is not None:
+                        try:
+                            self._render_netdiag_result(image, draw, result)
+                        except Exception as e:
+                            logger.debug(f"netdiag result render error: {e}")
+                        self._commit_netdiag_frame(image)
+                        # Refresh ~1s while a test runs so completion shows fast;
+                        # once done, hold the result until a key wakes us.
+                        self._netdiag_sleep(1.0 if result.get('running') else NETDIAG_CYCLE_SECONDS, bl, seq0)
+                        continue
+                    frozen = bool(getattr(bl, 'netdiag_frozen', False)) if bl else False
+                    if bl is not None:
+                        page = bl.netdiag_page % NETDIAG_PAGE_COUNT
+                    else:
+                        page = getattr(self, '_netdiag_page', 0) % NETDIAG_PAGE_COUNT
                     try:
-                        self._render_netdiag_page(image, draw, page)
+                        self._render_netdiag_page(image, draw, page, frozen=frozen)
                     except Exception as e:
                         logger.debug(f"netdiag render error: {e}")
-                    self._netdiag_page = (page + 1) % NETDIAG_PAGE_COUNT
-                    epd_img = _apply_epd_rotation(image, self.screen_reversed)
-                    self.epd_helper.display_partial(epd_img)
-                    self.epd_helper.display_partial(epd_img)
-                    web_img = _apply_web_rotation(image, self.web_screen_reversed)
-                    try:
-                        with open(os.path.join(self.shared_data.webdir, "screen.png"), 'wb') as img_file:
-                            web_img.save(img_file)
-                            img_file.flush()
-                            os.fsync(img_file.fileno())
-                    except Exception:
-                        pass
-                    self._netdiag_sleep(NETDIAG_CYCLE_SECONDS)
+                    if not frozen:
+                        nextp = (page + 1) % NETDIAG_PAGE_COUNT
+                        if bl is not None:
+                            bl.netdiag_page = nextp
+                        else:
+                            self._netdiag_page = nextp
+                    self._commit_netdiag_frame(image)
+                    self._netdiag_sleep(NETDIAG_CYCLE_SECONDS, bl, seq0)
                     continue
+                # Not in net-diag mode: drop any stale one-shot result / freeze so
+                # re-entering the mode later starts clean on the pages.
+                if self.button_listener is not None and getattr(self.button_listener, 'netdiag_result', None) is not None:
+                    self.button_listener.netdiag_result = None
+                    self.button_listener.netdiag_frozen = False
 
                 # Wardriving display override: render the wardriving page when
                 # the engine is running, OR — if wardriving-on-boot is set and

--- a/epd_button.py
+++ b/epd_button.py
@@ -13,6 +13,19 @@
 #   KEY2: Flip the display (same rotation cycle as default)
 #   KEY3: Toggle the live e-paper map (GPS track + network dots)
 #   KEY4: Connect to a known WiFi (wardriving keeps running)
+#
+# While Network Diagnostic mode is active (config network_diagnostic_mode) the
+# keys become a standalone field-test pad. Each key has a short press and a
+# long press (hold ~0.6s); results render on the panel until KEY1 dismisses:
+#   KEY1  short: next diagnostic page    long: pause/resume auto-cycle
+#   KEY2  short: locate switch port      long: L2 health capture (~12s)
+#         (blink the port's link LED)         (STP/rogue-DHCP/storm/dup-IP)
+#   KEY3  short: ping the gateway (LAN)  long: ping the internet (WAN, 8.8.8.8)
+#   KEY4  short: speedtest               long: DNS Doctor poison/hijack check
+#
+# Gesture wiring: default & wardriving layers still act on press (unchanged);
+# the netdiag layer defers to release (short) / hold (long) so a long press
+# doesn't also fire the short action.
 
 import logging
 import threading
@@ -34,6 +47,15 @@ KEY4_PIN = 19
 # keys (see EPDButtonListener.ensure_available). Override via config key
 # 'wardriving_button_reclaim_services'.
 CONFLICTING_BUTTON_SERVICES = ['airprint.service']
+
+# Network Diagnostic sub-pages that the keys cycle through (mirrors
+# display.NETDIAG_PAGE_COUNT: 0=LINK, 1=IP, 2=SWITCH). Kept as a local constant
+# to avoid importing display.py here (display imports this module).
+NETDIAG_PAGE_COUNT = 3
+
+# Hold time (seconds) that separates a short press from a long press in the
+# netdiag layer. Comfortably above the 0.3s debounce.
+NETDIAG_HOLD_TIME = 0.6
 
 # Display pages
 PAGE_MAIN = 0         # Default Ragnar display
@@ -57,23 +79,31 @@ class EPDButtonListener:
         self._swap_cooldown = 0  # timestamp of last swap to prevent double triggers
         self.wardrive_map = False  # KEY3 while wardriving: show live map page
 
+        # --- Network Diagnostic mode state (read by display.py) ---
+        self.netdiag_page = 0          # current sub-page when net-diag mode is on
+        self.netdiag_frozen = False    # True = auto-cycle paused (KEY1 long)
+        self.netdiag_result = None     # dict of a one-shot test result, or None
+        self.netdiag_seq = 0           # bumped on any key action to wake the display
+        self._netdiag_busy = False     # a test thread is running
+        self._held_keys = set()        # keys whose long-press already fired
+
     def start(self):
         """Start the button listener using gpiozero callbacks."""
         try:
             from gpiozero import Button
 
-            btn1 = Button(KEY1_PIN, pull_up=True, bounce_time=0.3)
-            btn2 = Button(KEY2_PIN, pull_up=True, bounce_time=0.3)
-            btn3 = Button(KEY3_PIN, pull_up=True, bounce_time=0.3)
-            btn4 = Button(KEY4_PIN, pull_up=True, bounce_time=0.3)
+            self._buttons = []
+            for pin, key in ((KEY1_PIN, 1), (KEY2_PIN, 2), (KEY3_PIN, 3), (KEY4_PIN, 4)):
+                btn = Button(pin, pull_up=True, bounce_time=0.3,
+                             hold_time=NETDIAG_HOLD_TIME)
+                # Default binding: existing single-press behaviour fires on press.
+                # The netdiag layer instead classifies short (release) vs long
+                # (hold); when_held/when_released are no-ops outside net-diag mode.
+                btn.when_pressed = (lambda k=key: self._on_press(k))
+                btn.when_held = (lambda k=key: self._on_held(k))
+                btn.when_released = (lambda k=key: self._on_release(k))
+                self._buttons.append(btn)
 
-            btn1.when_pressed = self._on_key1
-            btn2.when_pressed = self._on_key2
-            btn3.when_pressed = self._on_key3
-            btn4.when_pressed = self._on_key4
-
-            # Keep references so they don't get garbage collected
-            self._buttons = [btn1, btn2, btn3, btn4]
             self.available = True
             logger.info(f"EPD button listener started via gpiozero (GPIO {KEY1_PIN},{KEY2_PIN},{KEY3_PIN},{KEY4_PIN})")
         except ImportError:
@@ -143,6 +173,42 @@ class EPDButtonListener:
         """Return the WiFiManager instance, or None if not reachable."""
         ragnar = getattr(self.shared_data, 'ragnar_instance', None)
         return getattr(ragnar, 'wifi_manager', None) if ragnar else None
+
+    def _netdiag_active(self):
+        """True when Network Diagnostic mode owns the keys (config toggle)."""
+        try:
+            return bool(self.shared_data.config.get('network_diagnostic_mode', False))
+        except Exception:
+            return False
+
+    # --- Gesture dispatch -------------------------------------------------
+    # gpiozero fires when_pressed on every press, when_held after the hold time,
+    # and when_released on every release. Default/wardriving layers act on press
+    # (as before). In net-diag mode we act on release (short) or hold (long) so a
+    # long press never also triggers the short action.
+
+    def _on_press(self, key):
+        self._held_keys.discard(key)
+        if self._netdiag_active():
+            return  # netdiag decides on release/hold
+        handler = {1: self._on_key1, 2: self._on_key2,
+                   3: self._on_key3, 4: self._on_key4}.get(key)
+        if handler:
+            handler()
+
+    def _on_held(self, key):
+        if not self._netdiag_active():
+            return
+        self._held_keys.add(key)
+        self._netdiag_gesture(key, 'long')
+
+    def _on_release(self, key):
+        if not self._netdiag_active():
+            return
+        if key in self._held_keys:
+            self._held_keys.discard(key)
+            return  # long press already handled on hold
+        self._netdiag_gesture(key, 'short')
 
     def _on_key1(self):
         """KEY1: wardriving → toggle phone-access AP; else swap to Pwnagotchi."""
@@ -224,3 +290,152 @@ class EPDButtonListener:
         """Restart the ragnar service after a short delay."""
         time.sleep(1)
         subprocess.Popen(['systemctl', 'restart', 'ragnar.service'])
+
+    # ------------------------------------------------------------------
+    # Network Diagnostic field-test pad (only while network_diagnostic_mode)
+    # ------------------------------------------------------------------
+
+    def _netdiag_gesture(self, key, gesture):
+        """Map a (key, short/long) gesture to a net-diag action."""
+        self.netdiag_seq += 1   # wake the display promptly
+        if key == 1:
+            if gesture == 'short':
+                # KEY1 short: dismiss a shown result, else advance the page.
+                if self.netdiag_result is not None:
+                    self.netdiag_result = None
+                else:
+                    self.netdiag_page = (self.netdiag_page + 1) % NETDIAG_PAGE_COUNT
+            else:  # long: pause / resume the auto-cycle
+                self.netdiag_frozen = not self.netdiag_frozen
+                logger.info(f"Netdiag: auto-cycle {'PAUSED' if self.netdiag_frozen else 'resumed'}")
+            return
+        action = {
+            (2, 'short'): 'port', (2, 'long'): 'l2',
+            (3, 'short'): 'ping_gw', (3, 'long'): 'ping_wan',
+            (4, 'short'): 'speedtest', (4, 'long'): 'dns',
+        }.get((key, gesture))
+        if action:
+            self._run_netdiag_test(action)
+
+    _NETDIAG_TITLES = {'port': 'LOCATE PORT', 'l2': 'L2 HEALTH',
+                       'ping_gw': 'PING GW', 'ping_wan': 'PING WAN',
+                       'speedtest': 'SPEEDTEST', 'dns': 'DNS DOCTOR'}
+
+    def _run_netdiag_test(self, kind):
+        """Show a 'running' placeholder and run the test on a daemon thread so
+        the button callback returns at once (some tests take many seconds)."""
+        if self._netdiag_busy:
+            logger.debug(f"Netdiag test '{kind}' ignored — another is running")
+            return
+        self._netdiag_busy = True
+        self.netdiag_result = {'title': self._NETDIAG_TITLES.get(kind, kind.upper()),
+                               'running': True, 'rows': [], 'ts': time.time()}
+        self.netdiag_seq += 1
+        threading.Thread(target=self._netdiag_test_worker, args=(kind,),
+                         daemon=True).start()
+
+    def _netdiag_test_worker(self, kind):
+        try:
+            res = self._netdiag_execute(kind)
+        except Exception as e:
+            logger.warning(f"Netdiag test '{kind}' failed: {e}")
+            res = {'rows': [('Error', str(e)[:22])]}
+        cur = self.netdiag_result or {}
+        cur.update(res)
+        cur['title'] = cur.get('title') or self._NETDIAG_TITLES.get(kind, kind.upper())
+        cur['running'] = False
+        cur['ts'] = time.time()
+        self.netdiag_result = cur
+        self._netdiag_busy = False
+        self.netdiag_seq += 1
+
+    def _netdiag_primary_iface(self):
+        """Pick the wired NIC to test: a link-up eth*/en*, else any up, else the
+        first. Mirrors display._fetch_netdiag_data's selection."""
+        try:
+            import network_diagnostics as nd
+            eth = [i for i in nd.do_interfaces(include_virtual=False).get('interfaces', [])
+                   if i.get('type') == 'ethernet'
+                   and str(i.get('name', '')).startswith(('eth', 'en'))]
+            for i in eth:
+                if i.get('link_detected') is True:
+                    return i['name']
+            for i in eth:
+                if str(i.get('operstate', '')).lower() == 'up':
+                    return i['name']
+            return eth[0]['name'] if eth else None
+        except Exception:
+            return None
+
+    def _netdiag_execute(self, kind):
+        """Run one diagnostic and return {rows, [verdict], [note], [title]} for
+        the e-Paper result page. All calls are to network_diagnostics.py."""
+        import network_diagnostics as nd
+
+        if kind == 'port':
+            iface = self._netdiag_primary_iface()
+            if not iface:
+                return {'rows': [('Ethernet', 'none found')]}
+            # force=True: on a field tool flapping the only uplink is expected.
+            r = nd.do_locate_port(iface, count=6, on_ms=800, off_ms=800, force=True)
+            if r.get('success'):
+                return {'rows': [('Iface', iface), ('Blink', f"{r.get('count', 6)}x ~{round(r.get('duration_s', 0))}s"),
+                                 ('Watch', 'switch LINK LED')],
+                        'note': 'The port whose link LED blinks in this cadence is yours.'}
+            return {'rows': [('Iface', iface), ('Failed', (r.get('error') or '')[:20])]}
+
+        if kind == 'l2':
+            iface = self._netdiag_primary_iface()
+            if not iface:
+                return {'rows': [('Ethernet', 'none found')]}
+            r = nd.do_l2_health(iface, seconds=12)
+            if not r.get('success'):
+                return {'rows': [('L2 health', (r.get('error') or 'failed')[:18])]}
+            findings = r.get('findings') or []
+            top = findings[0] if findings else {'level': 'ok', 'text': 'no issues'}
+            level = {'ok': 'OK', 'info': 'INFO', 'warn': 'WARN'}.get(top.get('level'), '?')
+            return {'rows': [('Packets', r.get('packets', 0)),
+                             ('Bc/Mc /s', r.get('bcast_mcast_per_s', 0)),
+                             ('Verdict', level)],
+                    'note': top.get('text')}
+
+        if kind in ('ping_gw', 'ping_wan'):
+            if kind == 'ping_gw':
+                target = nd._default_gateway()
+                if not target:
+                    return {'rows': [('Gateway', 'none')]}
+                label = 'Gateway'
+            else:
+                target = '8.8.8.8'
+                label = 'Internet'
+            r = nd.do_ping(target, count=4)
+            s = r.get('summary') or {}
+            loss = s.get('loss_pct')
+            rtt = s.get('rtt_avg')
+            return {'rows': [(label, target),
+                             ('Loss', f"{loss}%" if loss is not None else 'no reply'),
+                             ('RTT avg', f"{rtt} ms" if rtt is not None else '—')]}
+
+        if kind == 'speedtest':
+            r = nd.do_speedtest()
+            if not r.get('success'):
+                return {'rows': [('Speedtest', (r.get('error') or 'failed')[:18])]}
+            return {'rows': [('Down', f"{r.get('download_mbps', '?')} Mbps"),
+                             ('Up', f"{r.get('upload_mbps', '?')} Mbps"),
+                             ('Ping', f"{r.get('ping_ms', '?')} ms")]}
+
+        if kind == 'dns':
+            name = self.shared_data.config.get('netdiag_dns_test_name', 'example.com')
+            r = nd.do_dns_doctor(name)
+            if not r.get('success'):
+                return {'rows': [('DNS', (r.get('error') or 'failed')[:18])]}
+            p = r.get('poison') or {}
+            verdict = p.get('verdict', 'unknown')
+            big = {'clean': 'CLEAN', 'suspicious': 'SUSPECT',
+                   'hijacked': 'HIJACK'}.get(verdict, verdict.upper())
+            reasons = p.get('reasons') or []
+            return {'rows': [('Name', name[:20])],
+                    'verdict': (big, verdict),
+                    'note': reasons[0] if reasons else 'No poisoning signals detected.'}
+
+        return {'rows': [('Unknown test', kind)]}

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -18,6 +18,7 @@ appropriate sudoers entries.
 import bisect
 import json
 import re
+import secrets
 import shutil
 import subprocess
 import ipaddress
@@ -26,6 +27,7 @@ import threading
 import time
 import socket
 import tempfile
+import urllib.parse
 from datetime import datetime
 
 try:
@@ -1273,10 +1275,81 @@ def _dig(name, resolver=None, rtype='A'):
                      ((res['err'] or 'no response').strip()[:120])}
 
 
+# Hostname TLDs that are legitimately internal, so a private/RFC1918 answer for
+# them is expected rather than a hijack signal.
+_INTERNAL_TLDS = ('.local', '.lan', '.internal', '.home', '.corp', '.intranet',
+                  '.localdomain', '.home.arpa')
+
+
+def _looks_public_name(name):
+    """True if `name` is a public FQDN (has a dot and a non-internal TLD), so a
+    private/loopback answer for it would be a hijack smell rather than normal
+    intranet resolution. Bare hostnames and internal TLDs return False."""
+    n = (name or '').strip().lower().rstrip('.')
+    if not n or '.' not in n:
+        return False
+    try:
+        ipaddress.ip_address(n)   # a literal IP isn't a name to poison
+        return False
+    except ValueError:
+        pass
+    return not n.endswith(_INTERNAL_TLDS)
+
+
+def _is_bogon(ip):
+    """True if `ip` is a private / loopback / link-local / unspecified / reserved
+    address — i.e. not a real public destination a public name should resolve to."""
+    try:
+        a = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+    return (a.is_private or a.is_loopback or a.is_unspecified
+            or a.is_link_local or a.is_reserved or a.is_multicast)
+
+
+def _dns_nxdomain_probe(resolver, nonce_name):
+    """Ask `resolver` to resolve a random name that cannot exist. A well-behaved
+    resolver returns NXDOMAIN; a resolver that *synthesizes* an address (ISP
+    NXDOMAIN-redirect / typo-squat / portal) is rewriting DNS. Returns
+    {'rewriting': bool, 'redirect_ip': str|None, 'status': str|None}."""
+    d = _dig(nonce_name, resolver)
+    rewriting = (d['status'] == 'NOERROR' and bool(d['answers']))
+    return {'rewriting': rewriting,
+            'redirect_ip': d['answers'][0] if d['answers'] else None,
+            'status': d['status']}
+
+
+def _doh_lookup(name, rtype='A'):
+    """Resolve `name` over Cloudflare DNS-over-HTTPS (encrypted, tamper-resistant
+    to on-path :53 spoofing). Returns a set of A-record answers, or None when the
+    check couldn't run (curl missing / offline). An empty set means the encrypted
+    path returned no address (NXDOMAIN / no A record)."""
+    if not _have('curl'):
+        return None
+    q = urllib.parse.quote((name or '').strip(), safe='')
+    res = _run(['curl', '-s', '--max-time', '6',
+                '-H', 'accept: application/dns-json',
+                f'https://cloudflare-dns.com/dns-query?name={q}&type={rtype}'],
+               timeout=10)
+    if res['rc'] != 0 or not res['out'].strip():
+        return None
+    try:
+        d = json.loads(res['out'])
+    except ValueError:
+        return None
+    return {a['data'] for a in (d.get('Answer') or [])
+            if a.get('type') == 1 and a.get('data')}   # type 1 = A record
+
+
 def do_dns_doctor(name):
     """Resolve `name` through every system resolver plus public 1.1.1.1 / 8.8.8.8,
     reporting per-resolver answers, query latency and the DNSSEC AD flag, whether
-    the resolvers agree (split-DNS / hijack smell), and DoH/DoT reachability."""
+    the resolvers agree (split-DNS / hijack smell), and DoH/DoT reachability.
+
+    Also runs active DNS-poisoning / hijack probes: an NXDOMAIN-rewrite test (a
+    random name that must not resolve), a private-IP-for-a-public-name check, a
+    SERVFAIL/DNSSEC-bogus check, and a DoH cross-check comparing the encrypted
+    answer against the plaintext one. The combined verdict is in `poison`."""
     name = (name or '').strip()
     if not name:
         return {'success': False, 'error': 'hostname required'}
@@ -1292,10 +1365,20 @@ def do_dns_doctor(name):
         if pub not in seen:
             tested.append((pub, 'public'))
 
+    public_name = _looks_public_name(name)
+    nonce_name = 'nx-' + secrets.token_hex(10) + '.com'   # cannot be registered
+
     results, answer_sets = [], []
     for resolver, kind in tested:
         d = _dig(name, resolver)
         d.update({'resolver': resolver, 'kind': kind})
+        # Private/loopback answer for a public name = redirect/portal/blocklist.
+        d['bogon_answers'] = ([a for a in d['answers'] if _is_bogon(a)]
+                              if public_name else [])
+        # NXDOMAIN-rewrite probe against this same resolver (random name).
+        nx = _dns_nxdomain_probe(resolver, nonce_name)
+        d['nxdomain_rewrite'] = nx['rewriting']
+        d['nxdomain_redirect_ip'] = nx['redirect_ip']
         results.append(d)
         if d['answers']:
             answer_sets.append(set(d['answers']))
@@ -1305,11 +1388,86 @@ def do_dns_doctor(name):
     # real split-DNS / hijack smell.
     consistent = len(answer_sets) < 2 or bool(set.intersection(*answer_sets))
 
+    # --- Poisoning / hijack verdict -------------------------------------------
+    # Public resolvers (1.1.1.1 / 8.8.8.8) are the trust anchor; the system/ISP
+    # resolvers are what an attacker or captive network would tamper with.
+    public_union = set()
+    for r in results:
+        if r['kind'] == 'public' and r['answers']:
+            public_union |= set(r['answers'])
+
+    reasons = []
+
+    # 1. NXDOMAIN rewriting: a resolver invented an address for a name that
+    #    cannot exist. Public resolvers act as the control (they must NXDOMAIN).
+    nx_rewriters = [{'resolver': r['resolver'], 'kind': r['kind'],
+                     'redirect_ip': r['nxdomain_redirect_ip']}
+                    for r in results if r['nxdomain_rewrite']]
+    if nx_rewriters:
+        who = ', '.join(x['resolver'] for x in nx_rewriters)
+        reasons.append(f'NXDOMAIN rewriting: {who} synthesized an address for a '
+                       f'name that does not exist (ISP redirect / portal / typo page)')
+
+    # 2. Private/bogon address returned for a public name.
+    bogon_hits = [{'resolver': r['resolver'], 'kind': r['kind'],
+                   'ips': r['bogon_answers']}
+                  for r in results if r['bogon_answers']]
+    if bogon_hits:
+        who = ', '.join(x['resolver'] for x in bogon_hits)
+        reasons.append(f'private/bogon address for a public name from {who} '
+                       f'(redirect, blocklist sinkhole or captive portal)')
+
+    # 3. SERVFAIL where another resolver answered — a validating resolver
+    #    refusing a name others resolve is the DNSSEC-bogus (tampered) signature.
+    servfail = [r['resolver'] for r in results if r['status'] == 'SERVFAIL']
+    if servfail and answer_sets:
+        reasons.append(f'SERVFAIL from {", ".join(servfail)} while other resolvers '
+                       f'answered — possible DNSSEC validation failure (tampered record)')
+
+    # 4. System resolver's answer shares nothing with the public resolvers'.
+    #    Soft signal (CDN/anycast can legitimately differ), so it's "suspected".
+    sys_disjoint = [r['resolver'] for r in results
+                    if r['kind'] == 'system' and r['answers']
+                    and public_union and set(r['answers']).isdisjoint(public_union)]
+    if sys_disjoint:
+        reasons.append(f'{", ".join(sys_disjoint)} returned an answer with nothing in '
+                       f'common with public resolvers (split-DNS, or a hijack if unexpected)')
+
+    # 5. DoH cross-check: compare the encrypted (tamper-resistant) answer with the
+    #    plaintext public answer. Disjoint => on-path :53 spoofing of the clear path.
+    doh_answers = _doh_lookup(name)
+    doh = {'checked': doh_answers is not None,
+           'answers': sorted(doh_answers) if doh_answers else [],
+           'mismatch': None}
+    if doh_answers is not None and doh_answers and public_union:
+        doh['mismatch'] = doh_answers.isdisjoint(public_union)
+        if doh['mismatch']:
+            reasons.append('DoH (encrypted) answer disjoint from the plaintext answer '
+                           '— strong sign of on-path DNS spoofing')
+
+    # Strong = confirmed tampering; soft = worth a second look.
+    strong = bool(nx_rewriters or bogon_hits or doh['mismatch'])
+    soft = bool(servfail or sys_disjoint)
+    verdict = 'hijacked' if strong else ('suspicious' if soft else 'clean')
+
+    poison = {
+        'verdict': verdict,                 # clean | suspicious | hijacked
+        'hijack_suspected': verdict != 'clean',
+        'reasons': reasons,
+        'public_name': public_name,
+        'nxdomain_rewriters': nx_rewriters,
+        'bogon_hits': bogon_hits,
+        'servfail_resolvers': servfail,
+        'system_disjoint_resolvers': sys_disjoint,
+        'doh': doh,
+    }
+
     return {'success': True, 'name': name, 'results': results,
             'consistent': consistent,
             'dnssec_ok': any(r['ad'] for r in results),
             'doh_reachable': _tcp_reachable('1.1.1.1', 443),
-            'dot_reachable': _tcp_reachable('1.1.1.1', 853)}
+            'dot_reachable': _tcp_reachable('1.1.1.1', 853),
+            'poison': poison}
 
 
 def _tcp_reachable(host, port, timeout=4):

--- a/shared.py
+++ b/shared.py
@@ -709,7 +709,13 @@ class SharedData:
             # When True, the e-Paper shows an Ethernet-focused network
             # diagnostic screen (link / IP / switch port), auto-cycling pages
             # every 5s. Web-toggled from Network > Diagnostics. e-Paper only.
+            # In this mode the 2.7" HAT keys become a field-test pad (see
+            # epd_button.py): K1 nav/pause, K2 locate-port/L2-health,
+            # K3 ping gateway/internet, K4 speedtest/DNS-poison check.
             "network_diagnostic_mode": False,
+            # Hostname the K4-long DNS Doctor key resolves for its poison/hijack
+            # check on the e-Paper (no keyboard on the panel, so it's preset).
+            "netdiag_dns_test_name": "example.com",
             # Browser terminal (interactive shell over the web UI). OFF by
             # default — it exposes a shell on the Pi (as the 'ragnar' user),
             # gated by login. Enable in Settings only if you want it.

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -5604,7 +5604,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260706-vpniface"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260707-dnspoison"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -1467,22 +1467,46 @@ async function runDns() {
                 : '<p class="text-sm text-red-400">Error: ' + escapeHtml(d.error || 'failed') + '</p>';
             return;
         }
+        const bogonSet = {};
+        (d.results || []).forEach(r => { (r.bogon_answers || []).forEach(ip => { bogonSet[r.resolver + '|' + ip] = 1; }); });
         const rows = (d.results || []).map(r => {
-            const ans = (r.answers && r.answers.length) ? r.answers.map(escapeHtml).join('<br>')
+            const ans = (r.answers && r.answers.length)
+                ? r.answers.map(ip => bogonSet[r.resolver + '|' + ip]
+                    ? '<span class="text-red-400" title="private/bogon address for a public name">' + escapeHtml(ip) + ' ⚠</span>'
+                    : escapeHtml(ip)).join('<br>')
                 : '<span class="text-red-400">' + escapeHtml(r.error || (r.status || 'no answer')) + '</span>';
+            const flags = [];
+            if (r.nxdomain_rewrite) flags.push('<span class="text-red-400" title="synthesized an answer for a non-existent name">NXDOMAIN-rewrite</span>');
+            if (r.status === 'SERVFAIL') flags.push('<span class="text-amber-300" title="possible DNSSEC validation failure">SERVFAIL</span>');
+            const flagCell = flags.length ? '<div class="text-xs mt-0.5">' + flags.join(' · ') + '</div>' : '';
             return `<tr class="border-t border-slate-800">
                 <td class="px-3 py-1.5 font-mono">${escapeHtml(r.resolver)}</td>
                 <td class="px-3 py-1.5 text-gray-500">${escapeHtml(r.kind)}</td>
-                <td class="px-3 py-1.5 font-mono">${ans}</td>
+                <td class="px-3 py-1.5 font-mono">${ans}${flagCell}</td>
                 <td class="px-3 py-1.5 text-right">${r.query_ms != null ? r.query_ms + ' ms' : '—'}</td>
                 <td class="px-3 py-1.5 text-center">${r.ad ? '<span class="text-green-400">✓</span>' : '<span class="text-gray-500">—</span>'}</td>
             </tr>`;
         }).join('');
+        const p = d.poison || {};
+        let poisonBanner = '';
+        if (p.verdict === 'hijacked') {
+            poisonBanner = '<div class="mb-2 px-3 py-2 rounded bg-red-950/60 border border-red-800 text-red-300 text-sm">🛑 <strong>DNS poisoning / hijack detected</strong></div>';
+        } else if (p.verdict === 'suspicious') {
+            poisonBanner = '<div class="mb-2 px-3 py-2 rounded bg-amber-950/50 border border-amber-800 text-amber-300 text-sm">⚠ <strong>Possible DNS tampering</strong> — review the signals below</div>';
+        } else if (p.verdict === 'clean') {
+            poisonBanner = '<div class="mb-2 px-3 py-2 rounded bg-green-950/40 border border-green-900 text-green-400 text-sm">✓ No DNS poisoning signals</div>';
+        }
+        const reasonsList = (p.reasons && p.reasons.length)
+            ? '<ul class="text-xs text-gray-400 mb-2 list-disc pl-5">' + p.reasons.map(x => '<li>' + escapeHtml(x) + '</li>').join('') + '</ul>'
+            : '';
+        const dohInfo = (p.doh && p.doh.checked)
+            ? ' · DoH cross-check ' + (p.doh.mismatch ? '<span class="text-red-400">mismatch</span>' : '<span class="text-green-400">match</span>')
+            : '';
         const banner = d.consistent
             ? '<span class="text-green-400">✓ resolvers agree (shared answer)</span>'
             : '<span class="text-amber-300">⚠ resolvers returned disjoint answers — normal for CDN/anycast, but a hijack/split-DNS smell if unexpected</span>';
-        out.innerHTML = `<p class="text-xs mb-2">${banner} · DNSSEC ${d.dnssec_ok ? '<span class="text-green-400">validated</span>' : '<span class="text-gray-500">not validated</span>'}
-            · DoH ${d.doh_reachable ? '✓' : '✗'} · DoT ${d.dot_reachable ? '✓' : '✗'}</p>
+        out.innerHTML = poisonBanner + reasonsList + `<p class="text-xs mb-2">${banner} · DNSSEC ${d.dnssec_ok ? '<span class="text-green-400">validated</span>' : '<span class="text-gray-500">not validated</span>'}
+            · DoH ${d.doh_reachable ? '✓' : '✗'} · DoT ${d.dot_reachable ? '✓' : '✗'}${dohInfo}</p>
             <table class="min-w-full text-sm text-gray-300 whitespace-nowrap">
             <thead><tr class="text-left text-xs uppercase text-gray-500">
                 <th class="px-3 py-1.5">Resolver</th><th class="px-3 py-1.5"></th><th class="px-3 py-1.5">Answers</th>


### PR DESCRIPTION
Network Diagnostic mode now drives the 4 HAT keys as a standalone field tester, with a short press and a long press per key:
  K1  next page          / pause-resume auto-cycle
  K2  locate switch port / L2 health capture (~12s)
  K3  ping gateway (LAN)  / ping internet 8.8.8.8 (WAN)
  K4  speedtest          / DNS Doctor poison check
Results render on the panel until KEY1 dismisses them. Default and wardriving
key layers are unchanged (they still act on press); the netdiag layer defers to
release (short) / hold (long) so a long press never also fires the short action.

DNS Doctor now runs active poisoning/hijack probes: an NXDOMAIN-rewrite test, a private-IP-for-a-public-name check, a SERVFAIL/DNSSEC-bogus flag, a tighter system-vs-public divergence check, and a DoH cross-check against the plaintext answer. The combined verdict (clean/suspicious/hijacked) is surfaced in the web DNS panel and as the big verdict on the e-Paper K4 result page.