### PR TITLE
Diagnostics: add CSV export to MAC Watch

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -1272,6 +1272,7 @@
                             <button onclick="runMacWatch(true)" class="w-full sm:w-auto bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Scan (arp-scan sweep)</button>
                             <button onclick="runMacWatch(false)" class="w-full sm:w-auto bg-slate-700 hover:bg-slate-600 text-gray-200 px-4 py-2 rounded text-sm whitespace-nowrap" title="Read the kernel neighbour table only — no traffic generated">Quick (neighbour table)</button>
                             <button onclick="macWatchReset()" class="w-full sm:w-auto bg-slate-700 hover:bg-slate-600 text-gray-200 px-4 py-2 rounded text-sm whitespace-nowrap" title="Clear the MAC-watch history (first/last-seen, per-IP history, change events)">Reset history</button>
+                            <button onclick="exportMacWatchCsv()" class="w-full sm:w-auto bg-slate-700 hover:bg-slate-600 text-gray-200 px-4 py-2 rounded text-sm whitespace-nowrap" title="Download the observed MACs as CSV">Export CSV</button>
                         </div>
                         <div id="macwatch-results" class="hidden mt-3 overflow-x-auto text-sm"></div>
                     </div>
@@ -5653,7 +5654,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260708-macwatch-list"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260708-macwatch-csv"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -1233,7 +1233,8 @@ function showNetworkSubtab(name) {
 
 // Last-fetched payloads for each net panel, so "Export CSV" has data to dump.
 let _ndLastLldp = [], _ndLastArp = null, _ndLastIfaces = [],
-    _ndLastMtr = null, _ndLastIdentity = null, _ndLastIsp = [];
+    _ndLastMtr = null, _ndLastIdentity = null, _ndLastIsp = [],
+    _ndLastMacWatch = null;
 
 // Build a CSV from a header row + rows (arrays of cells) and download it.
 function _ndDownloadCsv(nameBase, header, rows) {
@@ -2446,6 +2447,7 @@ async function runMacWatch(scan) {
             out.innerHTML = '<p class="text-sm text-red-400">Error: ' + escapeHtml((d && d.error) || 'failed') + '</p>';
             return;
         }
+        _ndLastMacWatch = d;
         const [cls, label] = _MACWATCH_VERDICT_STYLE[d.verdict] || _MACWATCH_VERDICT_STYLE.unknown;
         const s = d.summary || {};
         let html = `<div class="mb-3 px-3 py-2 rounded border ${cls} text-sm">${label}</div>`;
@@ -2552,6 +2554,20 @@ async function macWatchReset() {
     } catch (e) {
         addConsoleMessage('Failed to reset MAC Watch history: ' + e.message, 'error');
     }
+}
+function exportMacWatchCsv() {
+    const d = _ndLastMacWatch;
+    const TYPE = { spoofed_vendor_oui: 'Spoofed', universal: 'Vendor',
+                  randomized: 'Randomized', virtual_laa: 'Virtual/VM' };
+    _ndDownloadCsv('mac_watch' + (d && d.interface ? '_' + d.interface : ''),
+        ['MAC', 'Type', 'Vendor', 'IPs', 'Flag', 'Note'],
+        ((d && d.observed_macs) || []).map(c => {
+            const ips = c.ips || [];
+            const flag = c.klass === 'spoofed_vendor_oui' ? 'SPOOFED'
+                : (ips.length > 1 ? 'CLONE (multiple IPs)' : '');
+            return [c.mac, TYPE[c.klass] || c.klass, c.vendor || '',
+                    ips.join(' '), flag, c.note || ''];
+        }));
 }
 
 // Detect the ISP/public IP reached through each interface (multi-WAN). Makes


### PR DESCRIPTION
Export the observed MACs (MAC, type, vendor, IPs, flag, note) as CSV via the shared _ndDownloadCsv helper, matching the LLDP/ARP/interfaces/ISP export buttons. Spoofed and cloned MACs get a Flag column; the scanned interface is included in the filename. Reuses the observed_macs payload already returned.