### PR TITLE
Screen

### DIFF
--- a/docs/wifi-defense.md
+++ b/docs/wifi-defense.md
@@ -52,7 +52,12 @@ it (best when you already know where the attack is).
 ## Using it
 
 1. Plug in a monitor-capable adapter and pick it in **Monitor adapter**.
-2. **Enable monitor** (adds `ragmon0`, or switches the adapter).
+2. **Enable monitor** (adds `ragmon0`, or switches the adapter). The **same
+   button toggles it off** — it reads *Disable monitor (ragmon0)* while active.
+   Enabling always rebuilds a **fresh, channel-primed** vif (tearing down any
+   lingering one first), so disable→re-enable reliably comes back working rather
+   than a vif that exists but hears nothing. Disabling also stops a running
+   **Continuous** scan (otherwise its next loop would just re-enable monitor).
 3. **Trust current APs** in a known-good environment — this **adds** the
    currently-shown APs to the SSID→BSSID baseline that powers **evil-twin**
    detection. It *accumulates* (union), so run it a few times / across a scan or

--- a/docs/wifi-defense.md
+++ b/docs/wifi-defense.md
@@ -32,11 +32,15 @@ BSSIDs/attackers, then frame counts and an inventory of every AP heard.
 WiFi Defense needs an adapter in **monitor mode**, configured with plain `iw`
 (no `aircrack-ng` required):
 
-- Where the driver allows it (e.g. the **Alfa AWUS036AXM** / `mt7921u`), a
-  **separate monitor vif** (`ragmon0`) is added so the box **keeps its normal
-  Wi-Fi link** while it sniffs.
-- Otherwise the adapter itself is switched into monitor mode — which takes it
-  **off your network** until you disable monitor mode (the UI warns you).
+- A **separate monitor vif** (`ragmon0`) is added on the adapter's radio (e.g.
+  the **Alfa AWUS036AXM** / `mt7921u`). While monitoring, that adapter's
+  **managed interface is brought down** — on a single-radio adapter a managed
+  interface that stays up *holds the channel*, so the monitor can't be tuned
+  (`iw set channel` → `EBUSY -16`) and hears nothing. Taking it down hands the
+  radio to the monitor; **Disable monitor** brings it back up. Use the Pi's
+  onboard Wi-Fi (or Ethernet) for connectivity while that adapter monitors.
+- If a concurrent vif can't be created/tuned, the adapter itself is switched
+  into monitor mode (also off your network until you disable it; the UI warns).
 
 The Pi's **onboard `brcmfmac` radio does not support monitor mode** at all, so
 you need a capable USB adapter. **Enable monitor** sets it up; **Disable

--- a/docs/wifi-defense.md
+++ b/docs/wifi-defense.md
@@ -39,6 +39,10 @@ WiFi Defense needs an adapter in **monitor mode**, configured with plain `iw`
   (`iw set channel` → `EBUSY -16`) and hears nothing. Taking it down hands the
   radio to the monitor; **Disable monitor** brings it back up. Use the Pi's
   onboard Wi-Fi (or Ethernet) for connectivity while that adapter monitors.
+  While monitoring, the adapter is also set **unmanaged in NetworkManager** (and
+  `wpa_supplicant` released) so it isn't re-upped/reset under the monitor — the
+  cause of `ragmon0` "disappearing" (ENODEV) right after a disable→re-enable.
+  Disable re-manages it.
 - If a concurrent vif can't be created/tuned, the adapter itself is switched
   into monitor mode (also off your network until you disable it; the UI warns).
 

--- a/docs/wifi-defense.md
+++ b/docs/wifi-defense.md
@@ -129,3 +129,21 @@ the same call. Continuous mode keeps looping through a recovery, so live
 monitoring self-heals. If it still fails after that, **Disable monitor** then
 **Enable monitor** to force a fresh vif. Your trusted-AP baseline and tuned
 thresholds are preserved across all monitor bookkeeping.
+
+**Diagnosing a stubborn adapter — `scripts/wifidef_doctor.sh`.** When monitor
+comes up but captures nothing (or a specific dongle misbehaves), run the doctor:
+
+```bash
+sudo ./scripts/wifidef_doctor.sh            # auto-detects the adapter
+sudo ./scripts/wifidef_doctor.sh wlan1      # or name it explicitly
+```
+
+It records the environment (kernel, driver, `rfkill`, radio modes, code version
+and **when the service last restarted** — a common gotcha after `git pull`),
+then enables monitor through Ragnar's own code and compares an **OS-level
+capture (`tcpdump`)** against Ragnar's capture on a channel that has traffic. The
+contrast is the diagnosis: if `tcpdump` hears frames but Ragnar reports `frames=0`
+the bug is in the capture path; if neither hears anything while `iw dev ragmon0
+info` shows a real monitor channel, it's the driver/firmware. It also does a
+disable→re-enable cycle and a manual vif rebuild, and dumps `dmesg`. Everything
+is saved to `/tmp/wifidef_doctor_*.log` to paste into a bug report.

--- a/docs/wifi-defense.md
+++ b/docs/wifi-defense.md
@@ -179,6 +179,14 @@ monitoring self-heals. If it still fails after that, **Disable monitor** then
 **Enable monitor** to force a fresh vif. Your trusted-AP baseline and tuned
 thresholds are preserved across all monitor bookkeeping.
 
+*Why a **service restart** used to be the only thing that fixed it:* recreating
+`ragmon0` (a disable→re-enable) gives it a **new kernel ifindex**, but the packet
+library (scapy) caches the interface's old ifindex for the life of the process
+and keeps binding the capture socket to the dead index → ENODEV on every scan —
+until the process restarts and rebuilds that cache. Ragnar now **refreshes that
+cache before every capture**, so a runtime re-enable heals just like a restart
+(no `sudo systemctl restart ragnar` needed).
+
 **Diagnosing a stubborn adapter — `scripts/wifidef_doctor.sh`.** When monitor
 comes up but captures nothing (or a specific dongle misbehaves), run the doctor:
 

--- a/docs/wifi-defense.md
+++ b/docs/wifi-defense.md
@@ -55,6 +55,47 @@ box on **`hop`** to cycle the common 2.4/5 GHz channels during the capture
 (catches attacks on any channel), or pin a specific channel number to dwell on
 it (best when you already know where the attack is).
 
+### Dedicated monitor (boot-time) — most robust
+
+If you have an adapter you can **dedicate 100% to sniffing** (a spare USB dongle,
+with the Pi's onboard Wi-Fi / Ethernet carrying connectivity), claim it as a
+**dedicated monitor at boot** instead of toggling it from the web UI. The whole
+interface is switched into `type monitor` (switch-mode) once, before the app
+starts, so there is **no shared-radio vif, no runtime enable/disable dance, and
+none of the EBUSY / "`ragmon0` disappeared" (ENODEV) failure modes**. WiFi
+Defense then just captures on the already-monitor interface. The web UI detects
+this and shows **"Dedicated monitor (wlan1) — boot-managed"** with the toggle
+disabled (systemd owns the adapter).
+
+Set it up (opt-in):
+
+```bash
+# 1. Try it once by hand (root):
+sudo scripts/wifidef_dedicate.sh wlan1 US 2437 0
+#      <iface> <regdomain> <init-freq-MHz> <six_ghz:0|1>
+
+# 2. Make it persistent across reboots:
+sudo cp scripts/ragnar-wifidef-monitor.service /etc/systemd/system/
+sudo mkdir -p /etc/ragnar
+sudo cp scripts/wifidef-monitor.env.example /etc/ragnar/wifidef-monitor.env
+sudoedit /etc/ragnar/wifidef-monitor.env        # set WIFIDEF_IFACE=wlan1 etc.
+sudo systemctl daemon-reload
+sudo systemctl enable --now ragnar-wifidef-monitor
+```
+
+The unit runs **before** `ragnar.service` and, on stop/disable, hands the adapter
+back to NetworkManager. Config lives in `/etc/ragnar/wifidef-monitor.env`:
+
+| Var | Meaning |
+|-----|---------|
+| `WIFIDEF_IFACE` | the dedicated capture adapter (e.g. `wlan1`) — **not** the Pi's onboard `wlan0` |
+| `WIFIDEF_REGDOMAIN` | 2-letter ISO regdomain (`iw reg set`) — needed to unlock 5 GHz DFS / 6 GHz |
+| `WIFIDEF_INIT_FREQ` | MHz to park on at boot; the scan hopper retunes immediately |
+| `WIFIDEF_SIX_GHZ` | `1` also hops 6 GHz — requires a Wi-Fi 6E radio (e.g. `mt7921u` / AXM) and a correct regdomain |
+
+You can also run it directly: `python3 wifi_defense.py dedicate --interface wlan1
+--regdomain US --init-freq 2437 [--six-ghz]`.
+
 ---
 
 ## Using it

--- a/scripts/ragnar-wifidef-monitor.service
+++ b/scripts/ragnar-wifidef-monitor.service
@@ -1,0 +1,25 @@
+[Unit]
+# Ragnar WiFi Defense — dedicated boot-time passive monitor.
+# OPT-IN: install + enable this only on a box whose USB WiFi adapter you want
+# to dedicate 100% to sniffing (it goes off the network while monitoring).
+#   sudo cp scripts/ragnar-wifidef-monitor.service /etc/systemd/system/
+#   sudoedit /etc/ragnar/wifidef-monitor.env      # set WIFIDEF_IFACE=wlan1 etc.
+#   sudo systemctl enable --now ragnar-wifidef-monitor
+Description=Ragnar WiFi Defense dedicated monitor claim
+After=network-pre.target
+Wants=network-pre.target
+# Re-claim the adapter before the main app starts capturing.
+Before=ragnar.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Edit WIFIDEF_IFACE (and optionally WIFIDEF_REGDOMAIN / WIFIDEF_INIT_FREQ /
+# WIFIDEF_SIX_GHZ) in this file. The '-' makes a missing file non-fatal.
+EnvironmentFile=-/etc/ragnar/wifidef-monitor.env
+ExecStart=/home/ragnar/Ragnar/scripts/wifidef_dedicate.sh
+# On stop, hand the adapter back to NetworkManager (best-effort).
+ExecStop=-/bin/bash -c 'python3 /home/ragnar/Ragnar/wifi_defense.py monitor --interface "${WIFIDEF_IFACE:-wlan1}" --disable || true'
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/wifidef-monitor.env.example
+++ b/scripts/wifidef-monitor.env.example
@@ -1,0 +1,19 @@
+# Ragnar WiFi Defense — dedicated monitor config.
+# Copy to /etc/ragnar/wifidef-monitor.env and edit, then:
+#   sudo systemctl enable --now ragnar-wifidef-monitor
+#
+# The adapter named here is switched WHOLLY into monitor mode at boot and stays
+# off the network — dedicate one you don't need for connectivity.
+
+# Capture adapter (the USB dongle, NOT the Pi's onboard wlan0).
+WIFIDEF_IFACE=wlan1
+
+# Regulatory domain (2-letter ISO). Needed for 5 GHz DFS / 6 GHz channels.
+WIFIDEF_REGDOMAIN=US
+
+# Frequency (MHz) to park on at boot; the scan hopper retunes immediately.
+WIFIDEF_INIT_FREQ=2437
+
+# Also hop 6 GHz (1) — requires a Wi-Fi 6E radio (e.g. mt7921u/AXM) and a
+# correct regdomain. Leave 0 unless you know the radio + region support it.
+WIFIDEF_SIX_GHZ=0

--- a/scripts/wifidef_dedicate.sh
+++ b/scripts/wifidef_dedicate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# wifidef_dedicate.sh — claim a WiFi adapter as a DEDICATED passive monitor for
+# Ragnar WiFi Defense, once, at boot (meant for systemd ExecStart / a sensor box
+# that owns the adapter). Switch-mode: the whole interface becomes type=monitor,
+# so there's no shared-radio vif, no runtime enable/disable dance, and none of
+# the EBUSY / "ragmon0 disappeared" failure modes.
+#
+# Delegates to wifi_defense.py so the claim logic lives in ONE place (regdomain,
+# NM/wpa_supplicant/dhclient release, switch to monitor, verify). WiFi Defense
+# then just captures on the already-monitor interface.
+#
+# Usage:  wifidef_dedicate.sh <iface> [regdomain] [init_freq_mhz] [six_ghz:0|1]
+#   e.g.  wifidef_dedicate.sh wlan1 US 2437 0
+# Env (override args):  WIFIDEF_IFACE, WIFIDEF_REGDOMAIN, WIFIDEF_INIT_FREQ,
+#                       WIFIDEF_SIX_GHZ
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+# Run as root — monitor-mode + reg set need it.
+if [ "$(id -u)" -ne 0 ]; then exec sudo -E bash "$0" "$@"; fi
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+
+IFACE="${1:-${WIFIDEF_IFACE:-}}"
+REG="${2:-${WIFIDEF_REGDOMAIN:-}}"
+INIT_FREQ="${3:-${WIFIDEF_INIT_FREQ:-}}"
+SIX_GHZ="${4:-${WIFIDEF_SIX_GHZ:-0}}"
+
+if [ -z "$IFACE" ]; then
+  echo "[wifidef-dedicate] ERROR: no interface given (arg 1 or WIFIDEF_IFACE)" >&2
+  exit 1
+fi
+if ! ip link show "$IFACE" >/dev/null 2>&1; then
+  echo "[wifidef-dedicate] ERROR: interface $IFACE not found" >&2
+  exit 1
+fi
+
+args=(dedicate --interface "$IFACE")
+[ -n "$REG" ]        && args+=(--regdomain "$REG")
+[ -n "$INIT_FREQ" ]  && args+=(--init-freq "$INIT_FREQ")
+[ "$SIX_GHZ" = "1" ] && args+=(--six-ghz)
+
+echo "[wifidef-dedicate] claiming $IFACE as dedicated monitor (${args[*]})"
+exec python3 "$REPO/wifi_defense.py" "${args[@]}"

--- a/scripts/wifidef_doctor.sh
+++ b/scripts/wifidef_doctor.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Ragnar WiFi-Defense monitor-mode doctor
+#
+# Diagnoses why 802.11 monitor capture ("ragmon0") fails or hears nothing.
+# It captures the environment, enables monitor via the SAME code the webapp
+# uses, then compares an OS-level capture (tcpdump) against Ragnar's own
+# capture — that contrast tells us whether the bug is our code or the driver.
+#
+# Usage:   sudo ./scripts/wifidef_doctor.sh [interface]
+#   (interface is auto-detected if omitted, e.g. the USB Alfa's wlanX)
+#
+# Output is printed AND saved to /tmp/wifidef_doctor_<timestamp>.log
+# Paste the whole log back.
+# ---------------------------------------------------------------------------
+set -u
+
+# Re-exec as root (monitor ops + sniffing need it).
+if [ "$(id -u)" -ne 0 ]; then exec sudo -E bash "$0" "$@"; fi
+
+IW="$(command -v iw || echo /usr/sbin/iw)"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+LOG="/tmp/wifidef_doctor_$(date +%Y%m%d_%H%M%S).log"
+MON="ragmon0"
+
+# Mirror everything to the log file.
+exec > >(tee "$LOG") 2>&1
+
+section() { echo; echo "===================== $* ====================="; }
+run()     { echo "\$ $*"; "$@" 2>&1; echo; }
+
+phy_supports_monitor() {
+  "$IW" phy "$1" info 2>/dev/null \
+    | grep -A25 "Supported interface modes" | grep -q "\* monitor"
+}
+
+freq_to_chan() {
+  local f="$1"
+  if   [ "$f" -eq 2484 ] 2>/dev/null; then echo 14
+  elif [ "$f" -ge 2412 ] 2>/dev/null && [ "$f" -le 2472 ]; then echo $(((f-2407)/5))
+  elif [ "$f" -ge 5000 ] 2>/dev/null; then echo $(((f-5000)/5))
+  else echo 6; fi
+}
+
+# ---- summarise a wifi_defense.py JSON result --------------------------------
+summarize() {
+  python3 - <<'PY'
+import sys, json
+raw = sys.stdin.read()
+try:
+    d = json.loads(raw)
+except Exception:
+    print("  (could not parse JSON) ->", raw[:400]); sys.exit()
+print("  frames=%s  monitor=%s  channel=%s  error=%s  detections=%d"
+      % (d.get("frames"), d.get("monitor"), d.get("channel"),
+         d.get("error"), len(d.get("detections", []))))
+aps = d.get("aps") or []
+if aps:
+    print("  APs heard: %d  e.g. %s"
+          % (len(aps), ", ".join(sorted({a.get("ssid") or "?" for a in aps})[:6])))
+PY
+}
+
+capture_test() {
+  local ch="$1"
+  run "$IW" dev "$MON" info
+  if command -v tcpdump >/dev/null; then
+    echo "\$ tcpdump -i $MON on channel $ch (OS-level oracle, 8s)"
+    timeout 8 tcpdump -i "$MON" -c 30 -en 2>&1 | tail -n 12
+    echo
+  else
+    echo "  (tcpdump not installed — skipping OS oracle; 'apt install tcpdump')"
+  fi
+  echo "\$ Ragnar scan --channel $ch (fixed):"
+  python3 "$REPO/wifi_defense.py" scan --interface "$IFACE" --seconds 8 --channel "$ch" | summarize
+  echo "\$ Ragnar scan hopping (all bands, 12s):"
+  python3 "$REPO/wifi_defense.py" scan --interface "$IFACE" --seconds 12 | summarize
+}
+
+# ===========================================================================
+section "META / BUILD"
+date
+run uname -a
+run "$IW" --version
+echo "repo: $REPO"
+run git -C "$REPO" log --oneline -3
+echo -n "ragnar.service last (re)start: "
+systemctl show ragnar.service -p ActiveEnterTimestamp --value 2>/dev/null
+command -v tcpdump >/dev/null && echo "tcpdump: present" || echo "tcpdump: MISSING (apt install tcpdump)"
+python3 -c 'import scapy; print("scapy:", scapy.__version__)' 2>/dev/null || echo "scapy: MISSING"
+
+section "RADIOS / INTERFACES"
+run "$IW" dev
+run rfkill list
+for d in /sys/class/net/wlan*; do
+  n="$(basename "$d")"
+  echo -n "$n driver: "; basename "$(readlink "/sys/class/net/$n/device/driver" 2>/dev/null)" 2>/dev/null || echo "?"
+done
+echo; lsusb | grep -iE 'ralink|mediatek|realtek|atheros|0e8d|0bda' || echo "(no known USB wifi vendor lines)"
+
+# ---- choose interface -------------------------------------------------------
+IFACE="${1:-}"
+if [ -z "$IFACE" ]; then
+  CAND=""
+  for n in $("$IW" dev 2>/dev/null | awk '/Interface/{print $2}'); do
+    wp="$("$IW" dev "$n" info 2>/dev/null | awk '/wiphy/{print $2}')"
+    [ -n "$wp" ] || continue
+    if phy_supports_monitor "phy$wp"; then
+      if [ "$n" != "wlan0" ]; then IFACE="$n"; break; fi
+      CAND="$n"
+    fi
+  done
+  [ -z "$IFACE" ] && IFACE="$CAND"
+fi
+if [ -z "$IFACE" ]; then
+  echo; echo "!! No monitor-capable interface found. Plug in the adapter, or pass one explicitly:"
+  echo "   sudo $0 wlan1"
+  exit 1
+fi
+PHY="phy$("$IW" dev "$IFACE" info 2>/dev/null | awk '/wiphy/{print $2}')"
+echo; echo ">> Testing interface: $IFACE  ($PHY)"
+
+section "RADIO CAPABILITIES ($PHY)"
+"$IW" phy "$PHY" info 2>/dev/null | sed -n '/Supported interface modes/,/valid interface combinations/p' | head -n 30
+
+# ---- pick a channel that actually has traffic -------------------------------
+TESTCH=6
+LINKFREQ="$("$IW" dev "$IFACE" link 2>/dev/null | awk '/freq:/{print $2}')"
+if [ -n "$LINKFREQ" ]; then
+  TESTCH="$(freq_to_chan "$LINKFREQ")"
+  echo ">> $IFACE is associated on freq $LINKFREQ -> testing channel $TESTCH (guaranteed traffic)"
+else
+  echo ">> $IFACE not associated; will test on channel $TESTCH plus a hopping scan"
+fi
+
+section "CURRENT RAGNAR STATE"
+run cat "$REPO/data/wifi_defense.json"
+echo "recent ragnar.service log lines (monitor/scan/ragmon):"
+journalctl -u ragnar.service --no-pager -n 400 2>/dev/null | grep -iE "wifidef|monitor|ragmon" | tail -n 30
+
+# ===========================================================================
+section "TEST 1 — ENABLE MONITOR (Ragnar's code path)"
+python3 "$REPO/wifi_defense.py" monitor --interface "$IFACE" --enable
+echo
+capture_test "$TESTCH"
+
+section "TEST 2 — DISABLE -> RE-ENABLE (the reported failure)"
+python3 "$REPO/wifi_defense.py" monitor --interface "$IFACE" --disable
+sleep 1
+python3 "$REPO/wifi_defense.py" monitor --interface "$IFACE" --enable
+echo
+capture_test "$TESTCH"
+
+section "TEST 3 — MANUAL vif REBUILD (bypasses Ragnar, tests the driver alone)"
+run "$IW" dev "$MON" del
+sleep 1
+run "$IW" phy "$PHY" interface add "$MON" type monitor
+run ip link set "$MON" up
+run "$IW" dev "$MON" set channel "$TESTCH"
+run "$IW" dev "$MON" info
+if command -v tcpdump >/dev/null; then
+  echo "\$ tcpdump -i $MON (raw driver, 8s):"
+  timeout 8 tcpdump -i "$MON" -c 30 -en 2>&1 | tail -n 12
+fi
+
+section "KERNEL / DRIVER MESSAGES"
+dmesg --ctime 2>/dev/null | tail -n 40 || dmesg | tail -n 40
+
+section "DONE"
+echo "Full log saved to: $LOG"
+echo "Please paste the entire log back."

--- a/scripts/wifidef_doctor.sh
+++ b/scripts/wifidef_doctor.sh
@@ -93,10 +93,28 @@ run uname -a
 run "$IW" --version
 echo "repo: $REPO"
 run git -C "$REPO" log --oneline -3
+SVC_START="$(systemctl show ragnar.service -p ActiveEnterTimestampMonotonic --value 2>/dev/null)"
 echo -n "ragnar.service last (re)start: "
 systemctl show ragnar.service -p ActiveEnterTimestamp --value 2>/dev/null
+# Warn LOUDLY if the service is older than the newest code — a very common
+# reason "the fix doesn't work": the running process still has the old module.
+COMMIT_EPOCH="$(git -C "$REPO" log -1 --format=%ct 2>/dev/null)"
+SVC_EPOCH="$(date -d "$(systemctl show ragnar.service -p ActiveEnterTimestamp --value 2>/dev/null)" +%s 2>/dev/null)"
+if [ -n "$COMMIT_EPOCH" ] && [ -n "$SVC_EPOCH" ] && [ "$SVC_EPOCH" -lt "$COMMIT_EPOCH" ]; then
+  echo "  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo "  !! STALE SERVICE: the running ragnar.service started BEFORE the latest"
+  echo "  !! commit, so the web UI is still running OLD code. Run:"
+  echo "  !!     sudo systemctl restart ragnar"
+  echo "  !! then RE-RUN this doctor. (CLI tests below use the fresh code regardless.)"
+  echo "  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+fi
 command -v tcpdump >/dev/null && echo "tcpdump: present" || echo "tcpdump: MISSING (apt install tcpdump)"
 python3 -c 'import scapy; print("scapy:", scapy.__version__)' 2>/dev/null || echo "scapy: MISSING"
+
+echo "interfering managers (they can re-up / reset the adapter under monitor):"
+systemctl is-active NetworkManager 2>/dev/null | sed 's/^/  NetworkManager: /'
+command -v nmcli >/dev/null && echo "  nmcli: present (Ragnar will set the adapter unmanaged while monitoring)" || echo "  nmcli: absent"
+pgrep -a wpa_supplicant 2>/dev/null | sed 's/^/  wpa_supplicant: /' || echo "  wpa_supplicant: not running"
 
 section "RADIOS / INTERFACES"
 run "$IW" dev
@@ -154,9 +172,17 @@ echo
 capture_test "$TESTCH"
 
 section "TEST 2 — DISABLE -> RE-ENABLE (the reported failure)"
+DMESG_BEFORE="$(dmesg 2>/dev/null | wc -l)"
 python3 "$REPO/wifi_defense.py" monitor --interface "$IFACE" --disable
 sleep 1
 python3 "$REPO/wifi_defense.py" monitor --interface "$IFACE" --enable
+echo
+echo "-- new kernel messages during the disable/re-enable (watch for USB reset / re-enumeration) --"
+dmesg 2>/dev/null | tail -n +"$((DMESG_BEFORE + 1))" | grep -iE "mt7921|usb|reset|firmware|disconnect|new .* device|phy[0-9]" | tail -n 20
+if dmesg 2>/dev/null | tail -n +"$((DMESG_BEFORE + 1))" | grep -qiE "reset|disconnect|new high-speed|new full-speed"; then
+  echo ">> NOTE: the adapter appears to RESET/re-enumerate on the enable/disable cycle."
+  echo ">>       That is the root cause of ragmon0 'disappearing' (ENODEV) after re-enable."
+fi
 echo
 capture_test "$TESTCH"
 
@@ -178,6 +204,29 @@ fi
 
 section "KERNEL / DRIVER MESSAGES"
 dmesg --ctime 2>/dev/null | tail -n 40 || dmesg | tail -n 40
+
+section "FINAL VERDICT (post disable/re-enable)"
+# Leave the adapter in a working state and report whether capture works NOW.
+python3 "$REPO/wifi_defense.py" monitor --interface "$IFACE" --enable >/dev/null 2>&1
+VTMP="$(mktemp)"
+python3 "$REPO/wifi_defense.py" scan --interface "$IFACE" --seconds 10 >"$VTMP" 2>/dev/null
+python3 - "$VTMP" <<'PY'
+import sys, json
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception as e:
+    print("VERDICT: UNKNOWN (scan produced no JSON: %s)" % e); sys.exit()
+f = d.get("frames") or 0
+if d.get("error"):
+    print("VERDICT: FAIL — %s" % d["error"])
+elif f > 0:
+    print("VERDICT: PASS — captured %d frames on %s (monitor works)."
+          % (f, d.get("monitor")))
+else:
+    print("VERDICT: FAIL — monitor is up but captured 0 frames "
+          "(driver/channel issue — see dmesg + Test 3 above).")
+PY
+rm -f "$VTMP"
 
 section "DONE"
 echo "Full log saved to: $LOG"

--- a/scripts/wifidef_doctor.sh
+++ b/scripts/wifidef_doctor.sh
@@ -42,15 +42,22 @@ freq_to_chan() {
   else echo 6; fi
 }
 
-# ---- summarise a wifi_defense.py JSON result --------------------------------
-summarize() {
-  python3 - <<'PY'
+# ---- run a wifi_defense.py scan and summarise its JSON ----------------------
+# NB: the scan output goes to a temp FILE that python reads via argv — piping it
+# into a `python3 - <<HEREDOC` clashes (the heredoc IS python's stdin), which
+# silently ate the JSON in earlier runs.
+scan_summary() {
+  local desc="$1"; shift
+  local tmp; tmp="$(mktemp)"
+  "$@" >"$tmp" 2>"$tmp.err"
+  echo "$desc"
+  python3 - "$tmp" <<'PY'
 import sys, json
-raw = sys.stdin.read()
 try:
-    d = json.loads(raw)
-except Exception:
-    print("  (could not parse JSON) ->", raw[:400]); sys.exit()
+    d = json.load(open(sys.argv[1]))
+except Exception as e:
+    raw = open(sys.argv[1]).read()
+    print("  (no/invalid JSON: %s) raw=%r" % (e, raw[:300])); sys.exit()
 print("  frames=%s  monitor=%s  channel=%s  error=%s  detections=%d"
       % (d.get("frames"), d.get("monitor"), d.get("channel"),
          d.get("error"), len(d.get("detections", []))))
@@ -59,6 +66,8 @@ if aps:
     print("  APs heard: %d  e.g. %s"
           % (len(aps), ", ".join(sorted({a.get("ssid") or "?" for a in aps})[:6])))
 PY
+  [ -s "$tmp.err" ] && { echo "  stderr:"; sed 's/^/    /' "$tmp.err" | tail -n 5; }
+  rm -f "$tmp" "$tmp.err"
 }
 
 capture_test() {
@@ -71,10 +80,10 @@ capture_test() {
   else
     echo "  (tcpdump not installed — skipping OS oracle; 'apt install tcpdump')"
   fi
-  echo "\$ Ragnar scan --channel $ch (fixed):"
-  python3 "$REPO/wifi_defense.py" scan --interface "$IFACE" --seconds 8 --channel "$ch" | summarize
-  echo "\$ Ragnar scan hopping (all bands, 12s):"
-  python3 "$REPO/wifi_defense.py" scan --interface "$IFACE" --seconds 12 | summarize
+  scan_summary "\$ Ragnar scan --channel $ch (fixed):" \
+      python3 "$REPO/wifi_defense.py" scan --interface "$IFACE" --seconds 8 --channel "$ch"
+  scan_summary "\$ Ragnar scan hopping (all bands, 12s):" \
+      python3 "$REPO/wifi_defense.py" scan --interface "$IFACE" --seconds 12
 }
 
 # ===========================================================================
@@ -151,15 +160,19 @@ python3 "$REPO/wifi_defense.py" monitor --interface "$IFACE" --enable
 echo
 capture_test "$TESTCH"
 
-section "TEST 3 — MANUAL vif REBUILD (bypasses Ragnar, tests the driver alone)"
+section "TEST 3 — MANUAL vif REBUILD w/ base DOWN (proves the EBUSY fix)"
+# Bringing the managed base interface down frees the radio so the monitor vif
+# can be tuned. Without this, `set channel` returns EBUSY (-16) on shared-PHY
+# adapters (mt7921u) and the monitor hears nothing.
 run "$IW" dev "$MON" del
 sleep 1
+run ip link set "$IFACE" down
 run "$IW" phy "$PHY" interface add "$MON" type monitor
 run ip link set "$MON" up
-run "$IW" dev "$MON" set channel "$TESTCH"
+run "$IW" dev "$MON" set channel "$TESTCH"     # should now succeed (no EBUSY)
 run "$IW" dev "$MON" info
 if command -v tcpdump >/dev/null; then
-  echo "\$ tcpdump -i $MON (raw driver, 8s):"
+  echo "\$ tcpdump -i $MON on channel $TESTCH (raw driver, base down, 8s):"
   timeout 8 tcpdump -i "$MON" -c 30 -en 2>&1 | tail -n 12
 fi
 

--- a/scripts/wifidef_doctor.sh
+++ b/scripts/wifidef_doctor.sh
@@ -126,10 +126,22 @@ done
 echo; lsusb | grep -iE 'ralink|mediatek|realtek|atheros|0e8d|0bda' || echo "(no known USB wifi vendor lines)"
 
 # ---- choose interface -------------------------------------------------------
+# Only a MANAGED interface is a valid base — never our monitor vif (ragmon0) or a
+# P2P-device. Prefer the base_iface Ragnar already recorded, then a non-onboard
+# managed adapter whose radio supports monitor.
 IFACE="${1:-}"
+if [ -z "$IFACE" ]; then
+  STATE_BASE="$(python3 -c 'import json;print(json.load(open("'"$REPO"'/data/wifi_defense.json")).get("base_iface") or "")' 2>/dev/null)"
+  if [ -n "$STATE_BASE" ] && [ "$("$IW" dev "$STATE_BASE" info 2>/dev/null | awk '/type/{print $2;exit}')" = "managed" ]; then
+    IFACE="$STATE_BASE"
+  fi
+fi
 if [ -z "$IFACE" ]; then
   CAND=""
   for n in $("$IW" dev 2>/dev/null | awk '/Interface/{print $2}'); do
+    [ "$n" = "$MON" ] && continue                     # skip our monitor vif
+    typ="$("$IW" dev "$n" info 2>/dev/null | awk '/type/{print $2; exit}')"
+    [ "$typ" = "managed" ] || continue                # base must be managed
     wp="$("$IW" dev "$n" info 2>/dev/null | awk '/wiphy/{print $2}')"
     [ -n "$wp" ] || continue
     if phy_supports_monitor "phy$wp"; then

--- a/wardriving.py
+++ b/wardriving.py
@@ -18,6 +18,13 @@ from datetime import datetime, timezone
 
 logger = logging.getLogger("Wardriving")
 
+# WiFi Defense (wifi_defense.py) records its active monitor vif here. Wardriving
+# reclaims every non-management adapter (deleting monitor children), so it must
+# leave this radio alone while a capture is live — otherwise it deletes ragmon0
+# and the monitor dies mid-scan with "ragmon0 disappeared (Errno 19)".
+_WIFIDEF_STATE_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "data", "wifi_defense.json")
+
 # WiGLE CSV header
 WIGLE_HEADER = [
     'MAC', 'SSID', 'AuthMode', 'FirstSeen', 'Channel', 'RSSI',
@@ -2533,6 +2540,28 @@ class WardrivingEngine:
             pass
         return ''
 
+    def _wifidef_owned(self):
+        """Interfaces + phys that WiFi Defense is actively monitoring right now.
+        Wardriving must not reclaim/delete these (deleting ragmon0 kills the
+        capture with ENODEV mid-scan). Empty when no monitor is active."""
+        ifaces, phys = set(), set()
+        try:
+            with open(_WIFIDEF_STATE_FILE) as f:
+                st = json.load(f)
+        except Exception:
+            return ifaces, phys
+        if not st.get("mon_iface"):
+            return ifaces, phys           # monitor not active → nothing to protect
+        for key in ("mon_iface", "base_iface"):
+            name = st.get(key)
+            if not name:
+                continue
+            ifaces.add(name)
+            ph = self._iface_phy(name)
+            if ph:
+                phys.add(ph)
+        return ifaces, phys
+
     def _iface_phy(self, interface):
         """Return the phy name (e.g. 'phy0') for an interface, or '' on failure."""
         try:
@@ -2685,6 +2714,10 @@ class WardrivingEngine:
         phy = self._iface_phy(interface)
         if not phy:
             return
+        wd_ifaces, wd_phys = self._wifidef_owned()
+        if phy in wd_phys:
+            logger.debug(f"Wardriving: leaving phy {phy} to WiFi Defense (monitor active)")
+            return
         try:
             r = subprocess.run(['iw', 'dev'], capture_output=True, text=True, timeout=3)
             if r.returncode != 0:
@@ -2710,6 +2743,8 @@ class WardrivingEngine:
                             f"Wardriving: removing leftover {current_type} "
                             f"child {current_iface} on {phy} (parent {interface})"
                         )
+                        if current_iface in wd_ifaces:
+                            continue  # WiFi Defense's monitor vif — never delete it
                         try:
                             subprocess.run(['sudo', 'ip', 'link', 'set', current_iface, 'down'],
                                            capture_output=True, timeout=3)
@@ -2738,6 +2773,16 @@ class WardrivingEngine:
         enable wardriving_on_boot). Do not add an "if type=='ap' then skip"
         guard here without re-discussing this trade-off.
         """
+        # Hands off any adapter WiFi Defense is actively monitoring — reclaiming
+        # it (unmanage/managed/up + delete monitor children) would kill ragmon0.
+        wd_ifaces, wd_phys = self._wifidef_owned()
+        if interface in wd_ifaces or self._iface_phy(interface) in wd_phys:
+            logger.info(
+                f"Wardriving: skipping {interface} — WiFi Defense owns its radio "
+                f"(monitor active)"
+            )
+            return
+
         # rfkill unblock — cheap, idempotent
         try:
             subprocess.run(['sudo', 'rfkill', 'unblock', 'wifi'],

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -6394,7 +6394,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260713-wardriveguard"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260713-dedicated"></script>
 
 </body>
 </html>

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -6394,7 +6394,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260713-monbaseiface"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260713-wardriveguard"></script>
 
 </body>
 </html>

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -6394,7 +6394,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260712-matcolors"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260713-monreenable"></script>
 
 </body>
 </html>

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -6394,7 +6394,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260713-monreenable"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260713-monbaseiface"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -2632,11 +2632,22 @@ function _wifidefUpdateRunUI() {
     if (stop) stop.classList.toggle('hidden', !_wifidef.continuous);
 }
 
+// Must match wifi_defense.py `_BUILD`. If the running service reports something
+// else, the webapp is executing an OLD wifi_defense module (service not restarted
+// after a git pull) — the #1 cause of "the fix didn't work in the web UI".
+const WIFIDEF_BUILD = '20260713-wardriveguard';
+
 function _wifidefFillIfaces() {
     fetch('/api/wifidef/interfaces').then(r => r.json()).then(d => {
         const sel = document.getElementById('wifidef-iface');
         const ifs = (d && d.interfaces) || [];
         _wifidef.monitor = d.active_monitor || null;
+        const st = document.getElementById('wifidef-status');
+        if (d.build && d.build !== WIFIDEF_BUILD && st) {
+            st.innerHTML = '<span class="text-amber-400">⚠ WiFi Defense service is running old code (build '
+                + _esc(d.build) + ', page expects ' + WIFIDEF_BUILD
+                + '). Restart it: <code>sudo systemctl restart ragnar</code></span>';
+        }
         if (!ifs.length) { sel.innerHTML = '<option value="">No wireless adapter</option>'; }
         else {
             sel.innerHTML = ifs.map(i =>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -2642,7 +2642,11 @@ function _wifidefFillIfaces() {
             sel.innerHTML = ifs.map(i =>
                 `<option value="${i.iface}"${i.monitor_capable ? '' : ' disabled'}>${i.iface}${i.monitor_capable ? '' : ' (no monitor)'}${i.is_monitor ? ' • MONITOR' : ''}</option>`).join('');
             const cap = ifs.find(i => i.monitor_capable) || ifs[0];
-            if (!_wifidef.iface || !ifs.some(i => i.iface === _wifidef.iface && i.monitor_capable)) _wifidef.iface = (d.base_iface) || cap.iface;
+            // Never let the base selection be our own monitor vif; base_iface is
+            // only trusted if it's actually in the (vif-excluded) adapter list.
+            const baseOk = d.base_iface && ifs.some(i => i.iface === d.base_iface);
+            if (!_wifidef.iface || !ifs.some(i => i.iface === _wifidef.iface && i.monitor_capable))
+                _wifidef.iface = (baseOk ? d.base_iface : cap.iface);
             sel.value = _wifidef.iface;
             sel.onchange = () => { _wifidef.iface = sel.value; };
         }

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -2665,6 +2665,9 @@ function _wifidefUpdateMonBtn() {
 function wifidefToggleMonitor() {
     const st = document.getElementById('wifidef-status');
     if (_wifidef.monitor) {
+        // Stop any continuous scan first — otherwise its next loop would
+        // immediately auto-re-enable the monitor and "disable" would look broken.
+        if (_wifidef.continuous) wifidefStopContinuous();
         st.textContent = 'Disabling monitor…';
         fetch('/api/wifidef/monitor', { method: 'POST', headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ action: 'disable' }) })

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -2635,13 +2635,15 @@ function _wifidefUpdateRunUI() {
 // Must match wifi_defense.py `_BUILD`. If the running service reports something
 // else, the webapp is executing an OLD wifi_defense module (service not restarted
 // after a git pull) — the #1 cause of "the fix didn't work in the web UI".
-const WIFIDEF_BUILD = '20260713-wardriveguard';
+const WIFIDEF_BUILD = '20260713-dedicated';
 
 function _wifidefFillIfaces() {
     fetch('/api/wifidef/interfaces').then(r => r.json()).then(d => {
         const sel = document.getElementById('wifidef-iface');
         const ifs = (d && d.interfaces) || [];
         _wifidef.monitor = d.active_monitor || null;
+        _wifidef.mode = d.mode || null;
+        _wifidef.dedicated = !!d.dedicated;
         const st = document.getElementById('wifidef-status');
         if (d.build && d.build !== WIFIDEF_BUILD && st) {
             st.innerHTML = '<span class="text-amber-400">⚠ WiFi Defense service is running old code (build '
@@ -2668,6 +2670,18 @@ function _wifidefFillIfaces() {
 function _wifidefUpdateMonBtn() {
     const btn = document.getElementById('wifidef-mon-btn');
     if (!btn) return;
+    // A boot-dedicated adapter is owned by the systemd unit, not the UI: it's
+    // always in monitor mode by design, so don't offer a toggle that would hand
+    // it back to NetworkManager and defeat the whole point.
+    if (_wifidef.dedicated) {
+        btn.textContent = 'Dedicated monitor (' + (_wifidef.monitor || '') + ') — boot-managed';
+        btn.classList.remove('text-red-300');
+        btn.disabled = true;
+        btn.classList.add('opacity-60', 'cursor-not-allowed');
+        return;
+    }
+    btn.disabled = false;
+    btn.classList.remove('opacity-60', 'cursor-not-allowed');
     if (_wifidef.monitor) {
         btn.textContent = 'Disable monitor (' + _wifidef.monitor + ')';
         btn.classList.add('text-red-300');
@@ -2679,6 +2693,11 @@ function _wifidefUpdateMonBtn() {
 
 function wifidefToggleMonitor() {
     const st = document.getElementById('wifidef-status');
+    // Boot-dedicated monitor is managed by systemd; the UI must not toggle it.
+    if (_wifidef.dedicated) {
+        if (st) st.textContent = 'Adapter is a boot-dedicated monitor (managed by ragnar-wifidef-monitor.service)';
+        return;
+    }
     if (_wifidef.monitor) {
         // Stop any continuous scan first — otherwise its next loop would
         // immediately auto-re-enable the monitor and "disable" would look broken.

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -11689,7 +11689,9 @@ def network_threat_sweep():
                     ln = ln.strip()
                     if ln.startswith('Interface '):
                         cur = ln.split()[1]
-                        if cur != iface and cur != _mon:
+                        # 'ragmon0' is WiFi Defense's monitor vif — don't grab or
+                        # reset it, that kills its capture with ENODEV.
+                        if cur != iface and cur != _mon and cur != 'ragmon0':
                             secondary = cur
 
                 if secondary:

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -201,15 +201,18 @@ def _mon_name(base):
 
 
 def _monitor_ready(mon):
-    """Bring a freshly-created monitor vif up on a known channel and confirm the
-    kernel really made it a monitor. Priming the channel matters: a just-added
-    (or just re-added) vif can sit on channel 0 and hear NOTHING — the classic
-    'ragmon0 is back but detects nothing after a re-enable' symptom."""
+    """Bring a freshly-created monitor vif up on a known channel and confirm both
+    that the kernel made it a monitor AND that we can actually TUNE it. The
+    channel set is the real test: on a shared-radio adapter (e.g. mt7921u) a
+    managed vif that is still up holds the channel, so `iw set channel` returns
+    EBUSY (-16) and the monitor hears nothing. If we can't set the channel the
+    vif is useless for capture."""
     if not _iface_exists(mon):
         return False
     _run(["ip", "link", "set", mon, "up"], timeout=5)
-    _set_channel(mon, 6)          # common 2.4 GHz channel; capture re-sets/hops later
-    return _iw_dev_list().get(mon, {}).get("type") == "monitor"
+    rc, _, _ = _run([_IW, "dev", mon, "set", "channel", "6"], timeout=5)
+    is_monitor = _iw_dev_list().get(mon, {}).get("type") == "monitor"
+    return is_monitor and rc == 0
 
 
 def enable_monitor(iface):
@@ -236,13 +239,19 @@ def enable_monitor(iface):
         _run([_IW, "dev", mon, "del"], timeout=8)
         time.sleep(0.3)
 
+    # Free the radio: a shared-PHY managed interface that stays UP holds the
+    # channel, so the monitor vif can't be tuned (`iw set channel` => EBUSY) and
+    # captures nothing. Take the managed base down while we monitor — this is what
+    # makes capture reliable on mt7921u and friends. disable_monitor restores it.
+    _run(["ip", "link", "set", iface, "down"], timeout=5)
+
     # Try a concurrent monitor vif first.
     rc, _, err = _run([_IW, "phy", phy, "interface", "add", mon,
                        "type", "monitor"], timeout=8)
     if rc == 0 and _monitor_ready(mon):
         _save_state({"mon_iface": mon, "base_iface": iface, "mode": "vif"})
         return {"mon_iface": mon, "mode": "vif"}
-    # Half-created / not-a-monitor vif — clean it up before the fallback.
+    # Half-created / not-a-monitor / un-tunable vif — clean up before the fallback.
     if mon in _iw_dev_list():
         _run([_IW, "dev", mon, "del"], timeout=8)
 
@@ -270,6 +279,10 @@ def disable_monitor(mon_iface=None):
         _run(["ip", "link", "set", mon, "down"], timeout=5)
         _run([_IW, "dev", mon, "del"], timeout=8)
         time.sleep(0.3)  # let the delete settle so a quick re-enable doesn't race
+        # Bring the managed base interface back up (we took it down to free the
+        # radio for the monitor) so normal Wi-Fi resumes.
+        if base and base != mon:
+            _run(["ip", "link", "set", base, "up"], timeout=5)
     else:
         # We switched the base iface into monitor; switch it back to managed.
         _run(["ip", "link", "set", mon, "down"], timeout=5)
@@ -1157,6 +1170,28 @@ def selftest():
             check("re-enable re-adds the vif and primes a channel",
                   any(len(c) >= 5 and c[4] == "add" for c in cmds)
                   and _load_state().get("mon_iface") == "ragmon0")
+            check("enable frees the radio by bringing the managed base down",
+                  any(c[:3] == ["ip", "link", "set"] and c[3] == "wlan9"
+                      and c[-1] == "down" for c in cmds),
+                  json.dumps([c for c in cmds if "wlan9" in c]))
+            # _monitor_ready must reject an un-tunable vif (set channel EBUSY).
+            def _busy_run(args, **kw):
+                a = list(args)
+                if a[0] == _IW and len(a) >= 5 and a[3] == "set" and a[4] == "channel":
+                    return (240, "", "command failed: Device or resource busy (-16)")
+                return (0, "", "")
+            globals()["_run"] = _busy_run
+            check("_monitor_ready fails when the channel can't be set (EBUSY)",
+                  _monitor_ready("ragmon0") is False)
+            # disable brings the managed base back up.
+            globals()["_run"] = _fake_run
+            _save_state({"mon_iface": "ragmon0", "base_iface": "wlan9", "mode": "vif"})
+            cmds.clear()
+            disable_monitor()
+            check("disable restores the managed base (brought back up)",
+                  any(c[:3] == ["ip", "link", "set"] and c[3] == "wlan9"
+                      and c[-1] == "up" for c in cmds),
+                  json.dumps([c for c in cmds if "wlan9" in c]))
         finally:
             time.sleep = _real_sleep
             globals().update(_saved_fns)

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -763,6 +763,24 @@ def _capture_error(mon_iface, exc):
     return {"error": f"capture failed: {exc}"}
 
 
+def _refresh_scapy_ifaces():
+    """Drop scapy's cached interface table so it re-reads the live ifindex.
+
+    scapy caches a NetworkInterface object (with a fixed .index) per name at
+    import time and binds its AF_PACKET/monitor socket using that. When we
+    delete+recreate the monitor vif — a disable→re-enable, or an ENODEV rebuild —
+    ragmon0 comes back with a NEW ifindex, but scapy keeps the stale cached one
+    and every sniff() then fails with ENODEV. A fresh process rebuilds this cache,
+    which is exactly why 'systemctl restart ragnar' heals it while a runtime
+    re-enable does not. Reload it ourselves so the running service self-heals too
+    (scapy's own resolve_iface() does the same reload as its miss fallback)."""
+    try:
+        from scapy.all import conf
+        conf.ifaces.reload()
+    except Exception:
+        pass
+
+
 def _capture_recover(capture_fn, interface, seconds, channel, auto_enable):
     """Resolve a live monitor, capture, and — if the vif dies around capture time
     (ENODEV) — rebuild it once and retry. Returns an events list, or an
@@ -771,12 +789,14 @@ def _capture_recover(capture_fn, interface, seconds, channel, auto_enable):
     mon = _resolve_monitor(interface, auto_enable=auto_enable)
     if isinstance(mon, dict):
         return mon
+    _refresh_scapy_ifaces()                   # pick up the current ifindex of `mon`
     events = capture_fn(mon, seconds, channel=channel)
     if isinstance(events, dict) and events.get("enodev") and auto_enable:
         _save_state({})                       # drop the dead vif bookkeeping
         mon = _resolve_monitor(interface, auto_enable=True)   # force a rebuild
         if isinstance(mon, dict):
             return mon
+        _refresh_scapy_ifaces()               # the rebuild gave `mon` a new ifindex
         events = capture_fn(mon, seconds, channel=channel)
     return events
 
@@ -1250,12 +1270,19 @@ def selftest():
                 return {"error": "capture failed: … (Errno 19)", "enodev": True}
             return [{"kind": "beacon", "src": "aa:aa:aa:00:00:01", "ssid": "OK"}]
         _orig_resolve = _resolve_monitor
+        _orig_refresh = _refresh_scapy_ifaces
+        refreshes = {"n": 0}
         try:
             globals()["_resolve_monitor"] = lambda interface, auto_enable=True: "ragmon0"
+            globals()["_refresh_scapy_ifaces"] = lambda: refreshes.__setitem__("n", refreshes["n"] + 1)
             rec = _capture_recover(_flaky, "wlan0", 5, None, True)
             check("_capture_recover rebuilds + retries after one ENODEV",
                   isinstance(rec, list) and len(rec) == 1 and calls["n"] == 2,
                   json.dumps({"calls": calls["n"], "rec": rec}))
+            # scapy's stale iface cache is refreshed before the initial capture AND
+            # after the rebuild — the fix for ENODEV-until-service-restart.
+            check("_capture_recover refreshes scapy ifaces on capture + rebuild",
+                  refreshes["n"] == 2, json.dumps({"refreshes": refreshes["n"]}))
             # With auto_enable off it must NOT retry — surfaces the error once.
             calls["n"] = 0
             rec2 = _capture_recover(_flaky, "wlan0", 5, None, False)
@@ -1264,6 +1291,7 @@ def selftest():
                   json.dumps({"calls": calls["n"]}))
         finally:
             globals()["_resolve_monitor"] = _orig_resolve
+            globals()["_refresh_scapy_ifaces"] = _orig_refresh
 
         # --- Robust re-enable: a lingering vif is torn down, rebuilt, primed
         #     on a channel, and verified — the disable→re-enable "comes back but

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -45,6 +45,12 @@ _IW = "/usr/sbin/iw" if os.path.exists("/usr/sbin/iw") else "iw"
 _STATE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                            "data", "wifi_defense.json")
 
+# Build marker — bump on every monitor-lifecycle change and mirror the value in
+# the web UI (WIFIDEF_BUILD in ragnar_modern.js). The UI compares them and warns
+# if the running (long-lived) webapp still has an OLD wifi_defense module loaded,
+# i.e. the service wasn't restarted after a git pull. Kills stale-service guesswork.
+_BUILD = "20260713-wardriveguard"
+
 # Detection thresholds (per capture window)
 _DEAUTH_FLOOD_MIN = 15      # deauth+disassoc frames => flood
 # Beacon flood. There is no reliable "shape" signal that separates a flood from a
@@ -197,7 +203,7 @@ def list_monitor_capable():
     if active and not _iface_exists(active):
         active = None
     return {"interfaces": out, "active_monitor": active,
-            "base_iface": state.get("base_iface")}
+            "base_iface": state.get("base_iface"), "build": _BUILD}
 
 
 def _mon_name(base):

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -49,7 +49,7 @@ _STATE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 # the web UI (WIFIDEF_BUILD in ragnar_modern.js). The UI compares them and warns
 # if the running (long-lived) webapp still has an OLD wifi_defense module loaded,
 # i.e. the service wasn't restarted after a git pull. Kills stale-service guesswork.
-_BUILD = "20260713-wardriveguard"
+_BUILD = "20260713-dedicated"
 
 # Detection thresholds (per capture window)
 _DEAUTH_FLOOD_MIN = 15      # deauth+disassoc frames => flood
@@ -67,6 +67,13 @@ _KARMA_SSID_MIN = 5               # distinct SSIDs answered by ONE bssid => KARM
 # Channels the hopper cycles when no fixed channel is requested (2.4 GHz + the
 # common U-NII-1/3 5 GHz set). Kept short so each channel gets real dwell time.
 _HOP_CHANNELS = [1, 6, 11, 36, 40, 44, 48, 149, 153, 157, 161]
+
+# 6 GHz (Wi-Fi 6E) preferred-scanning channels, as *frequencies* in MHz — 6 GHz
+# must be tuned by freq (channel numbers collide with 2.4/5 GHz) and only works
+# with a correct regulatory domain + a 6E-capable radio. Opt-in (see six_ghz).
+# freq = 5950 + 5*chan; these are the PSC (preferred scanning) channels.
+_HOP_6GHZ_FREQS = [5975, 6055, 6135, 6215, 6295, 6375, 6455, 6535,
+                   6615, 6695, 6775, 6855, 6935, 7015, 7095]
 
 # 802.11 management subtype -> event kind
 _MGMT_SUBTYPES = {
@@ -165,6 +172,12 @@ def _resolve_monitor(interface, auto_enable=True):
     mon = state.get("mon_iface")
     if mon and _iface_exists(mon):
         return mon
+    # A dedicated (boot-managed) monitor should still be present; if it vanished
+    # (adapter re-plugged), re-claim the same interface in dedicated switch-mode
+    # rather than adding a vif.
+    if state.get("mode") == "dedicated" and mon:
+        res = dedicate_monitor(mon, six_ghz=state.get("six_ghz", False))
+        return res["mon_iface"] if "error" not in res else res
     # Stale or absent — clear the dead bookkeeping (keeps baseline/thresholds).
     if mon:
         _save_state({})
@@ -203,7 +216,10 @@ def list_monitor_capable():
     if active and not _iface_exists(active):
         active = None
     return {"interfaces": out, "active_monitor": active,
-            "base_iface": state.get("base_iface"), "build": _BUILD}
+            "base_iface": state.get("base_iface"),
+            "mode": state.get("mode") if active else None,
+            "dedicated": state.get("mode") == "dedicated" and active is not None,
+            "build": _BUILD}
 
 
 def _mon_name(base):
@@ -227,17 +243,30 @@ def _monitor_ready(mon):
 
 
 def _release_iface(iface):
-    """Stop NetworkManager / wpa_supplicant from managing `iface` so they don't
-    re-up it under us (which re-grabs the channel → EBUSY). All best-effort and
-    silent where the tool/service isn't present."""
+    """Stop NetworkManager / wpa_supplicant / dhclient from managing `iface` so
+    they don't re-up it under us (which re-grabs the channel → EBUSY). Targets
+    only processes bound to THIS interface. All best-effort and silent where the
+    tool/service isn't present."""
     _run(["nmcli", "device", "set", iface, "managed", "no"], timeout=5)
-    # wpa_supplicant bound to this iface also holds the radio; ask it to drop it.
-    _run(["wpa_cli", "-i", iface, "terminate"], timeout=5)
+    # wpa_supplicant/dhclient bound to this iface hold the radio; drop only the
+    # instances tied to it (leave the management link's supplicant alone).
+    _run(["pkill", "-f", f"wpa_supplicant.*{iface}"], timeout=5)
+    _run(["pkill", "-f", f"dhclient.*{iface}"], timeout=5)
 
 
 def _restore_iface(iface):
     """Hand `iface` back to NetworkManager so normal Wi-Fi resumes after monitor."""
     _run(["nmcli", "device", "set", iface, "managed", "yes"], timeout=5)
+
+
+def set_regdomain(domain):
+    """Set the wireless regulatory domain (e.g. 'US', 'SE'). Required for 5 GHz
+    DFS and 6 GHz channels to become available. No-op for a falsy/blank domain."""
+    domain = (domain or "").strip().upper()
+    if not re.match(r"^[A-Z]{2}$", domain):
+        return {"error": "regdomain must be a 2-letter ISO code (e.g. US)"}
+    rc, _, err = _run([_IW, "reg", "set", domain], timeout=5)
+    return {"ok": rc == 0, "regdomain": domain, "error": (err or "").strip() or None}
 
 
 def enable_monitor(iface):
@@ -332,16 +361,68 @@ def disable_monitor(mon_iface=None):
             _restore_iface(base)
             _run(["ip", "link", "set", base, "up"], timeout=5)
     else:
-        # We switched the base iface into monitor; switch it back to managed.
+        # We switched the base iface itself into monitor (switch / dedicated
+        # mode); switch it back to managed and re-manage it.
         _run(["ip", "link", "set", mon, "down"], timeout=5)
         _run([_IW, "dev", mon, "set", "type", "managed"], timeout=8)
+        _restore_iface(mon)
         _run(["ip", "link", "set", mon, "up"], timeout=5)
     _save_state({})
     return {"ok": True, "restored": base or mon}
 
 
+def dedicate_monitor(iface, regdomain=None, init_freq=None, six_ghz=False):
+    """Claim `iface` as a *dedicated* passive monitor (switch-mode: the whole
+    interface becomes type=monitor). Meant to run once at boot for a sensor that
+    owns the adapter — no runtime enable/disable dance, no shared-radio vif, so
+    none of the EBUSY / 'ragmon0 disappeared' failure modes apply. Sets the
+    regulatory domain (needed for DFS/6 GHz), releases NM/wpa_supplicant/dhclient
+    on the iface, then switches it to monitor and parks a frequency."""
+    if not _valid_iface(iface):
+        return {"error": "invalid interface"}
+    phy = _phy_for_iface(iface)
+    if not _phy_supports_monitor(phy):
+        return {"error": f"{iface}'s radio ({phy}) does not support monitor mode"}
+    _run(["/usr/bin/rfkill", "unblock", "all"], timeout=5)
+    if regdomain:
+        set_regdomain(regdomain)
+    _release_iface(iface)
+    _run(["ip", "link", "set", iface, "down"], timeout=5)
+    rc, _, err = _run([_IW, "dev", iface, "set", "type", "monitor"], timeout=8)
+    _run(["ip", "link", "set", iface, "up"], timeout=5)
+    if rc != 0 or _iw_dev_list().get(iface, {}).get("type") != "monitor":
+        return {"error": f"driver rejected monitor mode on {iface}: {(err or '').strip()}"}
+    if init_freq:
+        _set_freq(iface, init_freq)
+    _save_state({"mon_iface": iface, "base_iface": iface, "mode": "dedicated",
+                 "six_ghz": bool(six_ghz)})
+    return {"mon_iface": iface, "mode": "dedicated", "regdomain": regdomain,
+            "six_ghz": bool(six_ghz)}
+
+
 def _set_channel(mon_iface, channel):
     _run([_IW, "dev", mon_iface, "set", "channel", str(int(channel))], timeout=5)
+
+
+def _set_freq(mon_iface, freq_mhz):
+    _run([_IW, "dev", mon_iface, "set", "freq", str(int(freq_mhz))], timeout=5)
+
+
+def _hop_targets(six_ghz=False):
+    """Ordered tune targets for the channel hopper: ('chan', N) for 2.4/5 GHz and
+    ('freq', MHz) for 6 GHz (which must be tuned by frequency)."""
+    targets = [("chan", c) for c in _HOP_CHANNELS]
+    if six_ghz:
+        targets += [("freq", f) for f in _HOP_6GHZ_FREQS]
+    return targets
+
+
+def _tune(mon_iface, target):
+    kind, val = target
+    if kind == "freq":
+        _set_freq(mon_iface, val)
+    else:
+        _set_channel(mon_iface, val)
 
 
 # --------------------------------------------------------------------------
@@ -715,10 +796,11 @@ def _capture(mon_iface, seconds, channel=None):
     if channel:
         _set_channel(mon_iface, channel)
     else:
+        targets = _hop_targets(_load_state().get("six_ghz", False))
         def _hopper():
             i = 0
             while not stop.is_set():
-                _set_channel(mon_iface, _HOP_CHANNELS[i % len(_HOP_CHANNELS)])
+                _tune(mon_iface, targets[i % len(targets)])
                 i += 1
                 stop.wait(0.35)
         threading.Thread(target=_hopper, daemon=True).start()
@@ -753,10 +835,11 @@ def _capture_all(mon_iface, seconds, channel=None):
     if channel:
         _set_channel(mon_iface, channel)
     else:
+        targets = _hop_targets(_load_state().get("six_ghz", False))
         def _hopper():
             i = 0
             while not stop.is_set():
-                _set_channel(mon_iface, _HOP_CHANNELS[i % len(_HOP_CHANNELS)])
+                _tune(mon_iface, targets[i % len(targets)])
                 i += 1
                 stop.wait(0.35)
         threading.Thread(target=_hopper, daemon=True).start()
@@ -1201,6 +1284,10 @@ def selftest():
                     devs[a[5]] = {"phy": "phy9", "type": "monitor"}
                 if len(a) >= 4 and a[0] == _IW and a[1] == "dev" and a[3] == "del":
                     devs.pop(a[2], None)
+                # iw dev <if> set type <t>  → reflect the new type
+                if (len(a) >= 6 and a[0] == _IW and a[1] == "dev"
+                        and a[3] == "set" and a[4] == "type" and a[2] in devs):
+                    devs[a[2]]["type"] = a[5]
                 return (0, "", "")
 
             globals().update(
@@ -1252,6 +1339,40 @@ def selftest():
                   any(c[:3] == ["ip", "link", "set"] and c[3] == "wlan9"
                       and c[-1] == "up" for c in cmds),
                   json.dumps([c for c in cmds if "wlan9" in c]))
+
+            # --- Regdomain, targeted release, 6 GHz, dedicated boot-time mode ---
+            check("set_regdomain rejects a non-ISO code",
+                  "error" in set_regdomain("USA"))
+            cmds.clear()
+            check("set_regdomain issues `iw reg set` for a valid code",
+                  set_regdomain("us").get("regdomain") == "US"
+                  and any(c[:3] == [_IW, "reg", "set"] and c[3] == "US" for c in cmds))
+            cmds.clear()
+            _release_iface("wlan9")
+            check("_release_iface kills wpa_supplicant/dhclient bound to the iface",
+                  any(c[0] == "pkill" and "wpa_supplicant" in c[-1] for c in cmds)
+                  and any(c[0] == "pkill" and "dhclient" in c[-1] for c in cmds),
+                  json.dumps(cmds))
+            check("6 GHz hop targets are freq-tuned and opt-in",
+                  ("freq", 5975) in _hop_targets(True)
+                  and all(t[0] == "chan" for t in _hop_targets(False)))
+            # Dedicated (switch-mode) boot claim.
+            devs["wlan9"]["type"] = "managed"
+            cmds.clear()
+            ded = dedicate_monitor("wlan9", regdomain="US", init_freq=2437, six_ghz=True)
+            check("dedicate_monitor claims the whole iface as monitor",
+                  ded.get("mode") == "dedicated" and ded.get("mon_iface") == "wlan9"
+                  and devs["wlan9"]["type"] == "monitor", json.dumps(ded))
+            check("dedicate_monitor set regdomain + type monitor + init freq",
+                  any(c[:3] == [_IW, "reg", "set"] for c in cmds)
+                  and any(c[3:6] == ["set", "type", "monitor"] for c in cmds if len(c) >= 6)
+                  and any(c[3:5] == ["set", "freq"] for c in cmds if len(c) >= 5))
+            check("dedicated state persists mode + six_ghz",
+                  _load_state().get("mode") == "dedicated"
+                  and _load_state().get("six_ghz") is True)
+            # _resolve_monitor re-claims a dedicated monitor if the iface reappears.
+            check("_resolve_monitor returns the live dedicated monitor",
+                  _resolve_monitor("wlan9") == "wlan9")
         finally:
             time.sleep = _real_sleep
             globals().update(_saved_fns)
@@ -1320,6 +1441,14 @@ def _main(argv):
     pb = sub.add_parser("baseline")
     pb.add_argument("--interface", required=True)
     pb.add_argument("--seconds", type=int, default=20)
+    # Boot-time dedicated monitor: claim the whole interface (switch-mode) once,
+    # e.g. from a systemd ExecStartPre. See scripts/wifidef_dedicate.sh.
+    pd = sub.add_parser("dedicate")
+    pd.add_argument("--interface", required=True)
+    pd.add_argument("--regdomain", default=None, help="e.g. US, SE — unlocks DFS/6 GHz")
+    pd.add_argument("--init-freq", type=int, default=None, dest="init_freq")
+    pd.add_argument("--six-ghz", action="store_true", dest="six_ghz",
+                    help="also hop 6 GHz (needs a 6E radio + correct regdomain)")
     sub.add_parser("selftest")
 
     args = ap.parse_args(argv)
@@ -1330,6 +1459,11 @@ def _main(argv):
             print(json.dumps(disable_monitor(), indent=2))
         else:
             print(json.dumps(enable_monitor(args.interface), indent=2))
+    elif args.cmd == "dedicate":
+        r = dedicate_monitor(args.interface, regdomain=args.regdomain,
+                             init_freq=args.init_freq, six_ghz=args.six_ghz)
+        print(json.dumps(r, indent=2))
+        return 0 if "error" not in r else 1
     elif args.cmd == "scan":
         print(json.dumps(do_scan(args.interface, args.seconds, args.channel), indent=2))
     elif args.cmd == "baseline":

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -200,6 +200,18 @@ def _mon_name(base):
     return "ragmon0"
 
 
+def _monitor_ready(mon):
+    """Bring a freshly-created monitor vif up on a known channel and confirm the
+    kernel really made it a monitor. Priming the channel matters: a just-added
+    (or just re-added) vif can sit on channel 0 and hear NOTHING — the classic
+    'ragmon0 is back but detects nothing after a re-enable' symptom."""
+    if not _iface_exists(mon):
+        return False
+    _run(["ip", "link", "set", mon, "up"], timeout=5)
+    _set_channel(mon, 6)          # common 2.4 GHz channel; capture re-sets/hops later
+    return _iw_dev_list().get(mon, {}).get("type") == "monitor"
+
+
 def enable_monitor(iface):
     """Put a monitor interface up for `iface`'s radio.
 
@@ -215,19 +227,24 @@ def enable_monitor(iface):
     _run(["/usr/bin/rfkill", "unblock", "all"], timeout=5)
     mon = _mon_name(iface)
 
-    # Already have it?
+    # Always rebuild a FRESH vif. A ragmon0 left over from a previous
+    # enable/disable cycle can exist yet be in a half-dead state that captures
+    # nothing — so tear any lingering one down and recreate, letting the driver
+    # settle in between (the del→add race is what breaks mt7921u re-enables).
     if mon in _iw_dev_list():
-        _run(["ip", "link", "set", mon, "up"], timeout=5)
-        _save_state({"mon_iface": mon, "base_iface": iface, "mode": "vif"})
-        return {"mon_iface": mon, "mode": "vif"}
+        _run(["ip", "link", "set", mon, "down"], timeout=5)
+        _run([_IW, "dev", mon, "del"], timeout=8)
+        time.sleep(0.3)
 
     # Try a concurrent monitor vif first.
     rc, _, err = _run([_IW, "phy", phy, "interface", "add", mon,
                        "type", "monitor"], timeout=8)
-    if rc == 0:
-        _run(["ip", "link", "set", mon, "up"], timeout=5)
+    if rc == 0 and _monitor_ready(mon):
         _save_state({"mon_iface": mon, "base_iface": iface, "mode": "vif"})
         return {"mon_iface": mon, "mode": "vif"}
+    # Half-created / not-a-monitor vif — clean it up before the fallback.
+    if mon in _iw_dev_list():
+        _run([_IW, "dev", mon, "del"], timeout=8)
 
     # Fallback: switch the interface itself to monitor (disrupts its link).
     _run(["ip", "link", "set", iface, "down"], timeout=5)
@@ -252,6 +269,7 @@ def disable_monitor(mon_iface=None):
     if mode == "vif" or (mon in _iw_dev_list() and _iw_dev_list().get(mon, {}).get("type") == "monitor" and mon == _mon_name(base)):
         _run(["ip", "link", "set", mon, "down"], timeout=5)
         _run([_IW, "dev", mon, "del"], timeout=8)
+        time.sleep(0.3)  # let the delete settle so a quick re-enable doesn't race
     else:
         # We switched the base iface into monitor; switch it back to managed.
         _run(["ip", "link", "set", mon, "down"], timeout=5)
@@ -1102,6 +1120,46 @@ def selftest():
                   json.dumps({"calls": calls["n"]}))
         finally:
             globals()["_resolve_monitor"] = _orig_resolve
+
+        # --- Robust re-enable: a lingering vif is torn down, rebuilt, primed
+        #     on a channel, and verified — the disable→re-enable "comes back but
+        #     detects nothing" fix. Stub the shell primitives. ---
+        _names = ("_run", "_iw_dev_list", "_iface_exists", "_phy_for_iface",
+                  "_phy_supports_monitor", "_set_channel", "_valid_iface")
+        _saved_fns = {n: globals()[n] for n in _names}
+        _real_sleep = time.sleep
+        try:
+            devs = {"wlan9": {"phy": "phy9", "type": "managed"},
+                    "ragmon0": {"phy": "phy9", "type": "monitor"}}  # stale leftover
+            cmds = []
+
+            def _fake_run(args, **kw):
+                cmds.append(list(args))
+                a = list(args)
+                if len(a) >= 6 and a[1] == "phy" and a[3] == "interface" and a[4] == "add":
+                    devs[a[5]] = {"phy": "phy9", "type": "monitor"}
+                if len(a) >= 4 and a[0] == _IW and a[1] == "dev" and a[3] == "del":
+                    devs.pop(a[2], None)
+                return (0, "", "")
+
+            globals().update(
+                _run=_fake_run, _iw_dev_list=lambda: {k: dict(v) for k, v in devs.items()},
+                _iface_exists=lambda n: n in devs, _phy_for_iface=lambda i: "phy9",
+                _phy_supports_monitor=lambda p: True, _set_channel=lambda m, c: None,
+                _valid_iface=lambda i: True)
+            time.sleep = lambda *_a, **_k: None
+            res = enable_monitor("wlan9")
+            check("re-enable yields a working vif monitor",
+                  res.get("mon_iface") == "ragmon0" and res.get("mode") == "vif",
+                  json.dumps(res))
+            check("re-enable tears the stale vif down before recreating (fresh)",
+                  any(c[0] == _IW and c[1:2] == ["dev"] and c[-1] == "del" for c in cmds))
+            check("re-enable re-adds the vif and primes a channel",
+                  any(len(c) >= 5 and c[4] == "add" for c in cmds)
+                  and _load_state().get("mon_iface") == "ragmon0")
+        finally:
+            time.sleep = _real_sleep
+            globals().update(_saved_fns)
     finally:
         try:
             os.unlink(_STATE_FILE)

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -215,6 +215,20 @@ def _monitor_ready(mon):
     return is_monitor and rc == 0
 
 
+def _release_iface(iface):
+    """Stop NetworkManager / wpa_supplicant from managing `iface` so they don't
+    re-up it under us (which re-grabs the channel → EBUSY). All best-effort and
+    silent where the tool/service isn't present."""
+    _run(["nmcli", "device", "set", iface, "managed", "no"], timeout=5)
+    # wpa_supplicant bound to this iface also holds the radio; ask it to drop it.
+    _run(["wpa_cli", "-i", iface, "terminate"], timeout=5)
+
+
+def _restore_iface(iface):
+    """Hand `iface` back to NetworkManager so normal Wi-Fi resumes after monitor."""
+    _run(["nmcli", "device", "set", iface, "managed", "yes"], timeout=5)
+
+
 def enable_monitor(iface):
     """Put a monitor interface up for `iface`'s radio.
 
@@ -229,6 +243,11 @@ def enable_monitor(iface):
         return {"error": f"{iface}'s radio ({phy}) does not support monitor mode"}
     _run(["/usr/bin/rfkill", "unblock", "all"], timeout=5)
     mon = _mon_name(iface)
+
+    # Stop NetworkManager (and wpa_supplicant) from fighting us: an interface they
+    # manage gets brought back UP moments after we down it, which re-grabs the
+    # channel and brings the EBUSY straight back. No-ops where they aren't present.
+    _release_iface(iface)
 
     # Always rebuild a FRESH vif. A ragmon0 left over from a previous
     # enable/disable cycle can exist yet be in a half-dead state that captures
@@ -249,9 +268,15 @@ def enable_monitor(iface):
     rc, _, err = _run([_IW, "phy", phy, "interface", "add", mon,
                        "type", "monitor"], timeout=8)
     if rc == 0 and _monitor_ready(mon):
-        _save_state({"mon_iface": mon, "base_iface": iface, "mode": "vif"})
-        return {"mon_iface": mon, "mode": "vif"}
-    # Half-created / not-a-monitor / un-tunable vif — clean up before the fallback.
+        # Confirm the vif SURVIVES a beat. On a USB adapter (mt7921u) the churn
+        # of down/up + vif add can trigger a device reset that silently removes
+        # ragmon0 right after we make it — reporting "on" then would give the
+        # ENODEV-on-first-scan the tester saw after a re-enable.
+        time.sleep(0.4)
+        if _iface_exists(mon) and _iw_dev_list().get(mon, {}).get("type") == "monitor":
+            _save_state({"mon_iface": mon, "base_iface": iface, "mode": "vif"})
+            return {"mon_iface": mon, "mode": "vif"}
+    # Half-created / not-a-monitor / un-tunable / vanished vif — clean up first.
     if mon in _iw_dev_list():
         _run([_IW, "dev", mon, "del"], timeout=8)
 
@@ -279,9 +304,10 @@ def disable_monitor(mon_iface=None):
         _run(["ip", "link", "set", mon, "down"], timeout=5)
         _run([_IW, "dev", mon, "del"], timeout=8)
         time.sleep(0.3)  # let the delete settle so a quick re-enable doesn't race
-        # Bring the managed base interface back up (we took it down to free the
-        # radio for the monitor) so normal Wi-Fi resumes.
+        # Hand the managed base interface back to NetworkManager and bring it up
+        # (we took it down + unmanaged it to free the radio) so Wi-Fi resumes.
         if base and base != mon:
+            _restore_iface(base)
             _run(["ip", "link", "set", base, "up"], timeout=5)
     else:
         # We switched the base iface into monitor; switch it back to managed.

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -176,7 +176,12 @@ def list_monitor_capable():
     state = _load_state()
     out = []
     seen_phys = {}
+    mon_name = _mon_name(None)
     for iface, info in devs.items():
+        # Our own monitor vif (ragmon0) is not a selectable *base* adapter — hide
+        # it so the UI/tools never try to enable/disable monitor "on ragmon0".
+        if iface == mon_name and info["type"] == "monitor":
+            continue
         phy = info["phy"]
         if phy not in seen_phys:
             seen_phys[phy] = _phy_supports_monitor(phy)
@@ -238,6 +243,17 @@ def enable_monitor(iface):
     """
     if not _valid_iface(iface):
         return {"error": "invalid interface"}
+    # Never run monitor *on* our own monitor vif. A caller (a stale UI selection,
+    # a diagnostic) can hand us 'ragmon0'; map it back to the real managed base,
+    # otherwise disabling (which deletes ragmon0) makes the next enable fail with
+    # "radio (None) does not support monitor mode".
+    if iface == _mon_name(iface):
+        base = _load_state().get("base_iface")
+        if base and base != iface:
+            iface = base
+        else:
+            return {"error": f"'{iface}' is the monitor interface, not an adapter — "
+                             "select the adapter's managed interface (e.g. wlan1)"}
     phy = _phy_for_iface(iface)
     if not _phy_supports_monitor(phy):
         return {"error": f"{iface}'s radio ({phy}) does not support monitor mode"}
@@ -1200,6 +1216,18 @@ def selftest():
                   any(c[:3] == ["ip", "link", "set"] and c[3] == "wlan9"
                       and c[-1] == "down" for c in cmds),
                   json.dumps([c for c in cmds if "wlan9" in c]))
+            # The monitor vif (ragmon0) must never be offered as a selectable base.
+            check("list_monitor_capable hides our own monitor vif",
+                  not any(i["iface"] == "ragmon0"
+                          for i in list_monitor_capable()["interfaces"]),
+                  json.dumps([i["iface"] for i in list_monitor_capable()["interfaces"]]))
+            # enable_monitor must refuse to run monitor *on* ragmon0 (no base to map to).
+            _base_keep = _load_state().get("base_iface")
+            _save_state({"mode": "vif"})  # no base_iface
+            _guard = enable_monitor("ragmon0")
+            check("enable_monitor refuses the monitor vif (ragmon0) as a base",
+                  isinstance(_guard, dict) and "error" in _guard, json.dumps(_guard))
+            _save_state({"mon_iface": "ragmon0", "base_iface": _base_keep or "wlan9", "mode": "vif"})
             # _monitor_ready must reject an un-tunable vif (set channel EBUSY).
             def _busy_run(args, **kw):
                 a = list(args)


### PR DESCRIPTION
This pull request introduces robust support for dedicated monitor-mode WiFi adapters in Ragnar WiFi Defense, along with improved reliability and diagnostics for monitor-mode operation. It adds a boot-time systemd service for claiming an adapter as a dedicated passive monitor, a configuration file for persistent setup, and a comprehensive troubleshooting script. The documentation is significantly expanded to explain these workflows, and the wardriving tool is updated to avoid interfering with active WiFi Defense captures.

**Monitor-mode improvements and dedicated adapter support:**

* Added a new systemd unit `ragnar-wifidef-monitor.service` and helper script `wifidef_dedicate.sh` for claiming a USB WiFi adapter as a dedicated monitor at boot, avoiding runtime enable/disable issues and EBUSY/ENODEV failures. Includes an example config file `wifidef-monitor.env.example` for persistent setup. [[1]](diffhunk://#diff-de63b75027122356f005d7544b87a11109a17bc86708d50d8306b9c7aaa67782R1-R25) [[2]](diffhunk://#diff-be816ce49c0d9b5974c703e9c36ea3af136f629d61d86a14e84b97cbafc4bc3aR1-R45) [[3]](diffhunk://#diff-b7dd066d4fb7229ef02e4e1f040d67c3a6db718b9a79b6e8548c5caf1191c15cR1-R19)
* Updated documentation in `docs/wifi-defense.md` to describe the dedicated monitor workflow, configuration steps, and differences from runtime toggling. [[1]](diffhunk://#diff-d3a9d52dab97e82145aea8408c20c554def40a7dcea788ec7d4473efd64fa856R58-R109) [[2]](diffhunk://#diff-d3a9d52dab97e82145aea8408c20c554def40a7dcea788ec7d4473efd64fa856L35-R47)

**Diagnostics and reliability:**

* Introduced `wifidef_doctor.sh`, a comprehensive diagnostic script that checks environment, compares OS-level and application-level captures, and summarizes results for troubleshooting monitor-mode failures.
* Improved reliability by ensuring the capture library’s interface cache is refreshed after monitor re-enables, avoiding the need for a service restart after disable/enable cycles.

**Wardriving tool compatibility:**

* Updated `wardriving.py` to detect and avoid reclaiming or deleting interfaces currently owned by WiFi Defense, preventing mid-scan capture failures. [[1]](diffhunk://#diff-22fe1f64957729edb89cd0dc3b053ec11ce1ba58ed700fabf3e6e64fb9718052R21-R27) [[2]](diffhunk://#diff-22fe1f64957729edb89cd0dc3b053ec11ce1ba58ed700fabf3e6e64fb9718052R2543-R2564) [[3]](diffhunk://#diff-22fe1f64957729edb89cd0dc3b053ec11ce1ba58ed700fabf3e6e64fb9718052R2717-R2720)