### PR TITLE
Heatmap

### DIFF
--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -1668,7 +1668,18 @@ authoritative):
   even when the physical uplink is a normal `eth0`/`wlan0`. This catches
   full-tunnel VPNs / exit nodes that silently reroute everything.
 
-- Endpoint: `GET /api/net/identity`
+**Per-interface scope.** By default the card shows the **default-route** view.
+Pick an **interface** from the selector to see the network *that NIC* is
+attached to instead — its own **gateway** (that segment's DHCP gateway, even
+when it's a higher-metric / non-active default) and its own **nameservers +
+search domains** (from `resolvectl`/`nmcli` per-link data; falls back to the
+global view, clearly flagged, when the system exposes no per-link DNS). This is
+the "the one I'm testing" case: a second dongle on a test LAN whose gateway and
+DNS are invisible in the default-route summary because another NIC carries the
+default route. The VPN egress check auto-targets the same interface.
+
+- Endpoint: `GET /api/net/identity` — optional `?interface=<name>` to scope to
+  one NIC
 
 ### ISP / WAN Detection
 Detects the **public IP and ISP/ASN reached *through each interface***. On a

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -1995,6 +1995,62 @@ def _default_gateway():
     return m.group(1) if m else None
 
 
+def _iface_gateway(iface):
+    """The IPv4 default gateway reachable via ONE interface (that segment's
+    own DHCP gateway on a multi-homed box), or None when the segment offers no
+    default route. A higher-metric default (the non-active uplink) still
+    counts — that's exactly the 'the one I'm testing' case."""
+    res = _run(['ip', '-4', 'route', 'show', 'default', 'dev', iface], timeout=5)
+    m = re.search(r'default\s+via\s+(\d+\.\d+\.\d+\.\d+)', res['out'])
+    if m:
+        return m.group(1)
+    # Last resort: any 'via' route on the device (classless static routes).
+    res = _run(['ip', '-4', 'route', 'show', 'dev', iface], timeout=5)
+    m = re.search(r'\bvia\s+(\d+\.\d+\.\d+\.\d+)', res['out'])
+    return m.group(1) if m else None
+
+
+def _iface_dns(iface):
+    """Per-link nameservers + search domains for one interface, from
+    systemd-resolved (resolvectl) or NetworkManager — i.e. what THAT
+    interface's DHCP lease advertised, not the merged global view.
+    Returns (domains, nameservers, source_or_None)."""
+    domains, ns = [], []
+    if _have('resolvectl'):
+        r = _run(['resolvectl', 'dns', iface], timeout=5)
+        if r['rc'] == 0:
+            # "Link 3 (wlan1): 192.168.8.1 fd00::1"
+            _, _, after = r['out'].partition(':')
+            for tok in after.split():
+                if tok not in ns:
+                    ns.append(tok)
+        r = _run(['resolvectl', 'domain', iface], timeout=5)
+        if r['rc'] == 0:
+            _, _, after = r['out'].partition(':')
+            for tok in after.split():
+                tok = tok.lstrip('~')
+                if tok and tok != '.' and tok not in domains:
+                    domains.append(tok)
+        if ns or domains:
+            return domains, ns, 'resolvectl (per-link)'
+    if _have('nmcli'):
+        r = _run(['nmcli', '-t', '-f', 'IP4.DNS,IP4.DOMAINS', 'device', 'show',
+                  iface], timeout=6)
+        if r['rc'] == 0:
+            for line in r['out'].splitlines():
+                key, _, v = line.partition(':')
+                v = v.strip()
+                if not v or v == '--':
+                    continue
+                if key.startswith('IP4.DNS') and v not in ns:
+                    ns.append(v)
+                elif key.startswith('IP4.DOMAINS') and v not in domains:
+                    domains.append(v)
+        if ns or domains:
+            return domains, ns, 'nmcli (per-device)'
+    return domains, ns, None
+
+
 def _default_route_iface():
     """Return the interface carrying the IPv4 default route, or None. Used to
     tell whether this host's internet traffic egresses through a VPN tunnel."""
@@ -2155,36 +2211,52 @@ def _reverse_dns(ip):
     return None
 
 
-def do_network_identity():
+def do_network_identity(interface=None):
     """Best-effort identity of the network Ragnar is attached to: DNS search
     domain(s), nameservers, this host's name/FQDN, and the default gateway
     (with reverse-DNS). No single source is authoritative, so several are
-    merged and the provenance is reported."""
+    merged and the provenance is reported.
+
+    With `interface` set, the gateway, nameservers and search domains are
+    scoped to THAT interface (its own routes + DHCP lease), so a second test
+    uplink can be inspected while another NIC carries the default route.
+    Hostname/FQDN stay host-global."""
     sources = []
+    stub = False
 
-    rc_domains, rc_ns, stub = _read_resolv_conf()
-
-    # Search domains: union of resolv.conf and NetworkManager (DHCP option 15 /
-    # 119). NM is preferred when resolv.conf is the systemd stub.
-    domains = list(rc_domains)
-    for d in _nmcli_global_values('IP4.DOMAINS'):
-        if d not in domains:
-            domains.append(d)
-    if rc_domains:
-        sources.append('resolv.conf')
-    if _have('nmcli'):
-        sources.append('nmcli')
-
-    # Nameservers: resolv.conf, unless it only holds the local stub -- then use
-    # the upstream servers NetworkManager learned from DHCP.
-    nameservers = list(rc_ns)
-    nm_ns = _nmcli_global_values('IP4.DNS')
-    if stub or not nameservers:
-        nameservers = nm_ns or nameservers
+    if interface:
+        domains, nameservers, src = _iface_dns(interface)
+        if src:
+            sources.append(src)
+        if not (nameservers or domains):
+            # No per-link DNS source on this system (no resolved/NM manages
+            # the iface) — fall back to the global view, flagged as such.
+            domains, nameservers, stub = _read_resolv_conf()
+            sources.append('resolv.conf (global fallback — no per-link DNS source)')
     else:
-        for n in nm_ns:
-            if n not in nameservers:
-                nameservers.append(n)
+        rc_domains, rc_ns, stub = _read_resolv_conf()
+
+        # Search domains: union of resolv.conf and NetworkManager (DHCP option
+        # 15 / 119). NM is preferred when resolv.conf is the systemd stub.
+        domains = list(rc_domains)
+        for d in _nmcli_global_values('IP4.DOMAINS'):
+            if d not in domains:
+                domains.append(d)
+        if rc_domains:
+            sources.append('resolv.conf')
+        if _have('nmcli'):
+            sources.append('nmcli')
+
+        # Nameservers: resolv.conf, unless it only holds the local stub --
+        # then use the upstream servers NetworkManager learned from DHCP.
+        nameservers = list(rc_ns)
+        nm_ns = _nmcli_global_values('IP4.DNS')
+        if stub or not nameservers:
+            nameservers = nm_ns or nameservers
+        else:
+            for n in nm_ns:
+                if n not in nameservers:
+                    nameservers.append(n)
 
     # Hostname / FQDN. `hostname -f` can resolve the FQDN via DNS; bounded by
     # _run's timeout so a misconfigured resolver can't hang the request.
@@ -2199,13 +2271,14 @@ def do_network_identity():
         if cand and cand != hostname and '.' in cand:
             fqdn = cand
 
-    gw_ip = _default_gateway()
+    gw_ip = _iface_gateway(interface) if interface else _default_gateway()
     gateway = {'ip': gw_ip, 'ptr': _reverse_dns(gw_ip)} if gw_ip else None
 
     # Is this host's traffic egressing through a VPN? True when the default
     # route leaves via a tunnel interface (full-tunnel VPN / exit node), even
-    # if the physical uplink is a normal eth0/wlan0.
-    route_if = _default_route_iface()
+    # if the physical uplink is a normal eth0/wlan0. When scoped, judge the
+    # selected interface itself.
+    route_if = interface or _default_route_iface()
     route_vpn = _iface_vpn_info(route_if) if route_if else {'is_vpn': False, 'kind': None, 'endpoint': None}
     vpn_egress = {'interface': route_if,
                   'via_vpn': route_vpn['is_vpn'],
@@ -2222,6 +2295,7 @@ def do_network_identity():
 
     return {
         'success': True,
+        'interface': interface,
         'hostname': hostname,
         'fqdn': fqdn,
         'domains': domains,
@@ -13188,8 +13262,11 @@ def register_network_diagnostics(app, logger=None):
 
     @app.route('/api/net/identity', methods=['GET'])
     def net_identity():
-        _log("net/identity")
-        return jsonify(do_network_identity())
+        iface = (request.args.get('interface') or '').strip() or None
+        if iface is not None and not _valid_iface(iface):
+            return _bad('Invalid interface')
+        _log(f"net/identity {iface or 'auto'}")
+        return jsonify(do_network_identity(interface=iface))
 
     @app.route('/api/net/install-tool', methods=['POST'])
     def net_install_tool():

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -1966,9 +1966,12 @@
                     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-2">
                         <div class="min-w-0">
                             <h3 class="text-lg font-semibold">Network Identity</h3>
-                            <p class="text-sm text-gray-400">DNS domain &amp; search suffix, nameservers, this host&#39;s name/FQDN, and the default gateway.</p>
+                            <p class="text-sm text-gray-400">DNS domain &amp; search suffix, nameservers, this host&#39;s name/FQDN, and the default gateway. Pick an <strong>interface</strong> to see the network <em>that NIC</em> is attached to (its own gateway + DHCP nameservers) instead of the default-route view — e.g. a second dongle on a test LAN.</p>
                         </div>
-                        <div class="flex gap-2 w-full sm:w-auto"><button onclick="loadNetworkIdentity()" class="flex-1 bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Refresh</button><button onclick="exportIdentityCsv()" class="w-full sm:w-auto bg-slate-700 hover:bg-slate-600 text-gray-200 px-3 py-2 rounded text-sm whitespace-nowrap">Export CSV</button></div>
+                        <div class="flex flex-wrap items-center gap-2 w-full sm:w-auto">
+                            <select id="net-identity-iface" onchange="loadNetworkIdentity()" class="bg-slate-800 border border-slate-700 rounded px-2 py-2 text-sm text-gray-300"><option value="">auto (default route)</option></select>
+                            <button onclick="loadNetworkIdentity()" class="flex-1 bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Refresh</button><button onclick="exportIdentityCsv()" class="w-full sm:w-auto bg-slate-700 hover:bg-slate-600 text-gray-200 px-3 py-2 rounded text-sm whitespace-nowrap">Export CSV</button>
+                        </div>
                     </div>
                     <div id="net-identity-results" class="mt-3 overflow-x-auto text-sm text-gray-400">Loading…</div>
                 </div>
@@ -6578,7 +6581,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260713-capture-progress"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260713-identity-iface"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -4049,12 +4049,30 @@ async function locatePort(force) {
     }
 }
 
+// Fill the Network Identity interface selector once (auto + each real NIC),
+// preserving the current selection on later calls.
+function _niPopulateIfaces() {
+    const sel = document.getElementById('net-identity-iface');
+    if (!sel || sel.options.length > 1) return;
+    fetchAPI('/api/net/interfaces').then(x => {
+        (x.interfaces || []).forEach(i => {
+            const o = document.createElement('option');
+            o.value = i.name;
+            o.textContent = i.name + (i.type && i.type !== 'ethernet' ? ' (' + i.type + ')' : '');
+            sel.appendChild(o);
+        });
+    }).catch(() => {});
+}
+
 async function loadNetworkIdentity() {
     const out = document.getElementById('net-identity-results');
     if (!out) return;
+    _niPopulateIfaces();
+    const isel = document.getElementById('net-identity-iface');
+    const scoped = (isel && isel.value) || '';
     out.innerHTML = '<p class="text-gray-400">Loading…</p>';
     try {
-        const d = await fetchAPI('/api/net/identity');
+        const d = await fetchAPI('/api/net/identity' + (scoped ? '?interface=' + encodeURIComponent(scoped) : ''));
         if (!d.success) {
             out.innerHTML = '<p class="text-red-400">' + escapeHtml(d.error || 'failed') + '</p>';
             return;
@@ -4095,12 +4113,14 @@ async function loadNetworkIdentity() {
         row('Nameservers', nsHtml);
 
         // Gateway
-        let gwHtml = '<span class="text-gray-500">—</span>';
+        let gwHtml = d.interface
+            ? '<span class="text-gray-500">none — no route via ' + escapeHtml(d.interface) + ' (segment without a gateway, or DHCP still pending)</span>'
+            : '<span class="text-gray-500">—</span>';
         if (d.gateway && d.gateway.ip) {
             gwHtml = escapeHtml(d.gateway.ip);
             if (d.gateway.ptr) gwHtml += ' <span class="text-gray-500">(' + escapeHtml(d.gateway.ptr) + ')</span>';
         }
-        row('Default gateway', gwHtml);
+        row(d.interface ? 'Gateway via ' + d.interface : 'Default gateway', gwHtml);
 
         // Traffic via VPN — a local tunnel on the default route is shown
         // instantly; anything else needs the *egress* checked (VPN/Tor on the
@@ -4123,10 +4143,12 @@ async function loadNetworkIdentity() {
             row('Traffic via VPN', veHtml);
         }
 
+        const scopeNote = d.interface
+            ? `<p class="text-[11px] text-cyan-400/80 mt-2">Scoped to <span class="font-mono">${escapeHtml(d.interface)}</span> — gateway + nameservers are what this interface's own network provides.</p>` : '';
         const src = (d.sources && d.sources.length)
             ? `<p class="text-[11px] text-gray-500 mt-2">Sources: ${d.sources.map(escapeHtml).join(', ')}</p>` : '';
         out.innerHTML = `<table class="min-w-full text-sm">
-            <tbody>${rows.join('')}</tbody></table>${src}`;
+            <tbody>${rows.join('')}</tbody></table>${scopeNote}${src}`;
         // Fill the egress-check interface selector (auto + each real NIC) so
         // the LAN path can be tested even when WiFi carries the default route.
         const sel = document.getElementById('vpn-egress-iface');
@@ -4138,6 +4160,8 @@ async function loadNetworkIdentity() {
                     o.textContent = i.name + (i.type && i.type !== 'ethernet' ? ' (' + i.type + ')' : '');
                     sel.appendChild(o);
                 });
+                // A scoped identity view should test the same interface's egress.
+                if (d.interface) sel.value = d.interface;
             }).catch(() => {});
         }
     } catch (e) {


### PR DESCRIPTION
This pull request adds support for per-interface network identity diagnostics, allowing users to view gateway, DNS, and search domains for a specific network interface rather than only the default route. The user interface now includes an interface selector, and the backend/API, documentation, and frontend logic have been updated to support and clearly indicate per-interface scoping.

**Per-interface network identity support:**

* Added backend logic to `network_diagnostics.py` to allow scoping the network identity (gateway, DNS, search domains) to a specified interface via the new `_iface_gateway` and `_iface_dns` helpers, and updated `do_network_identity()` to accept an optional `interface` parameter. [[1]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaR1998-R2053) [[2]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL2158-R2240) [[3]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL2202-R2281) [[4]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaR2298)
* Updated the `/api/net/identity` endpoint to accept an optional `?interface=<name>` parameter, validate the interface, and return per-interface results.

**Frontend and UI enhancements:**

* Modified the Network Identity card in `index_modern.html` to add a drop-down for interface selection and improved the help text to explain per-interface scoping.
* Updated the JavaScript in `ragnar_modern.js` to populate the interface selector, send the selected interface to the API, and clearly display when results are scoped to a specific interface (including handling cases where no gateway is present). [[1]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R4052-R4075) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L4098-R4123) [[3]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R4146-R4151) [[4]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R4163-R4164)

**Documentation updates:**

* Improved documentation in `docs/nettools.md` to describe per-interface scoping, the new API parameter, and example use cases.

**Other:**

* Updated the script version in `index_modern.html` for cache busting.