### PR TITLE
feat(locate-port): add traffic-burst method (ACTIVITY LED) alongside …

### DIFF
--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -1553,25 +1553,39 @@ asymmetry is happening below BGP, e.g. a congested or re-routed transit leg).
 
 ### Locate Port
 Physically find **which switch port** the device is plugged into — the software
-equivalent of a cable tester / toner probe. It **flaps the link** on the chosen
-wired interface in a timed pattern (down/up, a configurable number of blinks),
-so on the switch the port's **link LED** goes dark/lit in that cadence. Watch
-the switch and the port blinking in sync is the one.
+equivalent of a cable tester / toner probe. It blinks a **per-port LED** on the
+chosen wired interface in a timed cadence (a configurable number of blinks);
+watch the switch and the port pulsing in sync is the one.
 
-On a **managed** switch you don't need this — Switch Discovery already reports
+Switches vary in **which LED they drive** off which event, so there are **two
+methods** (same card, pick one):
+
+- **Link flap** (`method: flap`, default) — links the port **down/up** each
+  cycle, so the **LINK** LED goes dark/lit. Genuinely drops the link for a
+  moment each cycle, so it briefly interrupts traffic on that port; if Ragnar is
+  reachable *through* that port the UI freezes until the sequence finishes, so
+  the tool refuses the interface carrying the default route unless you confirm.
+  Always restores the link when done.
+- **Traffic burst** (`method: burst`) — floods dense bursts of raw broadcast
+  Ethernet frames (EtherType `0x88b5`, ~25–30k pps) with idle gaps, so the
+  **ACTIVITY** LED pulses in the cadence while the **link stays up the whole
+  time**. Never drops connectivity, so it's **safe on any port including the
+  default route** — no confirmation needed. Raw `AF_PACKET` egress needs no
+  IP/route on the interface. Some switches only blink their per-port LED on
+  traffic, not on link changes — this covers those.
+
+On a **managed** switch you don't need either — Switch Discovery already reports
 the exact port over LLDP/CDP. Locate Port is the fallback for **unmanaged**
 switches that only have link/activity LEDs.
 
 Notes and safety:
-- Physical Ethernet only (`eth*`/`en*`) — a link-flap only identifies a port on
-  a wired link.
-- It genuinely **drops the link** each cycle, so it briefly interrupts traffic
-  on that port. If Ragnar is reachable *through* that port, the UI freezes until
-  the sequence finishes — so the tool refuses the interface carrying the default
-  route unless you confirm. It always restores the link when done, and runs in
-  the background so it completes even if your session blips.
+- Physical Ethernet only (`eth*`/`en*`) — locating a switch port only works on a
+  wired link. Both methods require the port's link to be up (a cable in the
+  switch); a dead/unplugged port can't blink.
+- Runs in the background so it completes even if your session blips.
 
-- Endpoint: `POST /api/net/locate-port` `{interface, count, force}` · uses `ip link`
+- Endpoint: `POST /api/net/locate-port` `{interface, count, method, force}` ·
+  `flap` uses `ip link`, `burst` uses a raw `AF_PACKET` socket
 
 ### PCAP Analyzer
 Upload a `.pcap` / `.pcapng` capture (from Wireshark, `tcpdump`, the L2 Link

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -2974,17 +2974,76 @@ def _flap_sequence(interface, count, on_ms, off_ms):
             _locate_active.pop(interface, None)
 
 
-def do_locate_port(interface, count=6, on_ms=800, off_ms=800, force=False):
-    """Physically locate which switch port this device is plugged into by
-    flapping the link in a timed pattern (link LED blinks). Managed switches
-    already report the port via LLDP/CDP (Switch Discovery) -- this is the
-    fallback for unmanaged switches. Runs in the background and returns at once.
+def _burst_sequence(interface, count, on_ms, off_ms):
+    """Blink the switch's ACTIVITY/TRAFFIC LED by sending dense bursts of raw
+    Ethernet frames out `interface`, idling between them, so the LED pulses in
+    the same recognisable on/off cadence as a flap — but the LINK stays up the
+    whole time. Some switches only blink their per-port LED on traffic, not on
+    link state, which is exactly what this covers. Raw AF_PACKET egress needs
+    no IP/route on the interface (it goes straight out the wire)."""
+    import socket
+    sock = None
+    try:
+        # The switch only sees traffic if the link is up first.
+        _run(['ip', 'link', 'set', interface, 'up'], timeout=10)
+        try:
+            with open('/sys/class/net/%s/address' % interface) as f:
+                mac = f.read().strip()
+            src = bytes(int(b, 16) for b in mac.split(':'))
+        except (OSError, ValueError):
+            src = b'\x02\x00\x00\x00\x00\x01'          # locally-administered fallback
+        # Broadcast dst + a local-experimental EtherType (0x88b5); a tagged
+        # payload so the frames are identifiable on a capture, padded to the
+        # 60-byte minimum Ethernet frame.
+        frame = (b'\xff\xff\xff\xff\xff\xff' + src + b'\x88\xb5'
+                 + b'RAGNAR-LOCATE-PORT')
+        frame += b'\x00' * (60 - len(frame))
+        try:
+            sock = socket.socket(socket.AF_PACKET, socket.SOCK_RAW)
+            sock.bind((interface, 0))
+        except OSError:
+            return                                     # no raw-socket perms / iface gone
+        for _ in range(count):
+            end = time.time() + on_ms / 1000.0
+            while time.time() < end:
+                for _ in range(64):                    # dense burst -> LED clearly lit
+                    try:
+                        sock.send(frame)
+                    except OSError:
+                        end = 0                        # link/iface dropped mid-burst
+                        break
+                time.sleep(0.002)                      # ~32k pps ceiling, CPU-friendly
+            time.sleep(off_ms / 1000.0)                # idle window -> LED dark
+    finally:
+        if sock is not None:
+            try:
+                sock.close()
+            except OSError:
+                pass
+        with _locate_lock:
+            _locate_active.pop(interface, None)
 
-    Refuses the interface carrying this host's default route unless force=True,
-    since flapping it briefly drops Ragnar's own connectivity."""
+
+def do_locate_port(interface, count=6, on_ms=800, off_ms=800, force=False, method='flap'):
+    """Physically locate which switch port this device is plugged into by
+    blinking a per-port LED in a timed cadence. Managed switches already report
+    the port via LLDP/CDP (Switch Discovery) -- this is the fallback for
+    unmanaged switches. Runs in the background and returns at once.
+
+    Two methods, because switches differ in which LED they drive:
+    - 'flap'  — links the port down/up so the **LINK** LED blinks (the link
+                drops for a moment each cycle). Refuses the default-route
+                interface unless force=True, since it briefly cuts Ragnar's own
+                connectivity.
+    - 'burst' — floods traffic bursts so the **ACTIVITY** LED blinks while the
+                link stays up. Never drops connectivity, so no force is needed
+                — safe even on the default route."""
     interface = (interface or '').strip()
     if not interface:
         return {'success': False, 'error': 'interface required'}
+    method = (method or 'flap').strip().lower()
+    if method not in ('flap', 'burst'):
+        method = 'flap'
 
     match = next((i for i in do_interfaces(include_virtual=True).get('interfaces', [])
                   if i['name'] == interface), None)
@@ -2992,33 +3051,37 @@ def do_locate_port(interface, count=6, on_ms=800, off_ms=800, force=False):
         return {'success': False, 'error': f'unknown interface: {interface}'}
     if match.get('type') != 'ethernet' or not interface.startswith(('eth', 'en')):
         return {'success': False,
-                'error': f'{interface} is not a physical Ethernet port; a link-flap '
-                         'only identifies a switch port on a wired link.'}
+                'error': f'{interface} is not a physical Ethernet port; locating '
+                         'a switch port only works on a wired link.'}
 
     count = _clamp_int(count, 6, 1, 30)
     on_ms = _clamp_int(on_ms, 800, 100, 3000)
     off_ms = _clamp_int(off_ms, 800, 100, 3000)
 
-    # Guard: flapping the default-route interface drops our own uplink.
-    if not force and _default_route_iface() == interface:
+    # Guard: only the flap method cuts our uplink; burst keeps the link up.
+    if method == 'flap' and not force and _default_route_iface() == interface:
         return {'success': False, 'needs_force': True, 'interface': interface,
                 'error': f'{interface} carries this device\'s default route — flapping '
                          'it will briefly drop Ragnar\'s connectivity (the UI freezes '
-                         'until the sequence finishes, then it auto-restores). '
-                         'Confirm to proceed anyway.'}
+                         'until the sequence finishes, then it auto-restores). Confirm '
+                         'to proceed anyway — or use the Traffic-burst method, which '
+                         'keeps the link up.'}
 
     with _locate_lock:
         if _locate_active.get(interface):
             return {'success': False, 'error': f'a locate sequence is already running on {interface}.'}
         _locate_active[interface] = True
 
-    threading.Thread(target=_flap_sequence, args=(interface, count, on_ms, off_ms),
+    seq = _burst_sequence if method == 'burst' else _flap_sequence
+    threading.Thread(target=seq, args=(interface, count, on_ms, off_ms),
                      daemon=True).start()
     total = round(count * (on_ms + off_ms) / 1000.0, 1)
-    return {'success': True, 'interface': interface, 'count': count,
+    verb = 'Bursting traffic on' if method == 'burst' else 'Flapping'
+    led = 'ACTIVITY' if method == 'burst' else 'LINK'
+    return {'success': True, 'interface': interface, 'count': count, 'method': method,
             'on_ms': on_ms, 'off_ms': off_ms, 'duration_s': total,
-            'message': f'Flapping {interface} {count}× (~{round(total)}s). Watch the '
-                       'switch — the port whose LINK LED blinks in this cadence is the one.'}
+            'message': f'{verb} {interface} {count}× (~{round(total)}s). Watch the switch — '
+                       f'the port whose {led} LED blinks in this cadence is the one.'}
 
 
 # --------------------------------------------------------------------------
@@ -13628,10 +13691,11 @@ def register_network_diagnostics(app, logger=None):
     def net_locate_port():
         data = request.get_json(silent=True) or {}
         iface = (data.get('interface') or '').strip()
-        _log(f"net/locate-port {iface}")
+        method = (data.get('method') or 'flap')
+        _log(f"net/locate-port {iface} ({method})")
         return jsonify(do_locate_port(iface, data.get('count', 6),
                                       data.get('on_ms', 800), data.get('off_ms', 800),
-                                      bool(data.get('force'))))
+                                      bool(data.get('force')), method))
 
     if logger is not None:
         try:

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -1926,10 +1926,18 @@
                 <div class="glass rounded-xl p-4 sm:p-6 mt-6">
                     <div class="mb-3">
                         <h3 class="text-lg font-semibold">Locate Port</h3>
-                        <p class="text-sm text-gray-400">Find which switch port this device is plugged into by blinking the link in a pattern — like a cable tester. Watch the switch: the port whose <strong>link LED</strong> flashes in cadence is the one. On a managed switch, Switch Discovery already names the port; this is the fallback for unmanaged switches. <span class="text-amber-400">Briefly drops the link on the chosen port.</span></p>
+                        <p class="text-sm text-gray-400">Find which switch port this device is plugged into by blinking a per-port LED in a pattern — like a cable tester. Watch the switch: the port that flashes in cadence is the one. On a managed switch, Switch Discovery already names the port; this is the fallback for unmanaged switches. Switches differ in which LED they drive, so pick the method that makes <em>your</em> switch blink:</p>
+                        <ul class="text-xs text-gray-500 mt-2 space-y-0.5">
+                            <li><strong class="text-gray-400">Link flap</strong> — links the port down/up so the <strong>LINK</strong> LED blinks. <span class="text-amber-400">Briefly drops the link each cycle</span> (fine on the port you're testing; needs confirmation on the uplink).</li>
+                            <li><strong class="text-gray-400">Traffic burst</strong> — floods traffic so the <strong>ACTIVITY</strong> LED blinks while the link <strong>stays up</strong>. Never drops connectivity — safe on any port.</li>
+                        </ul>
                     </div>
                     <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-2">
                         <input id="locate-iface" type="text" autocomplete="off" placeholder="interface (e.g. eth0)" class="w-full sm:w-auto sm:flex-1 sm:min-w-[12rem] bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm" onkeydown="if(event.key==='Enter')locatePort()">
+                        <select id="locate-method" title="Which LED to blink" class="w-full sm:w-auto bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm">
+                            <option value="flap">Link flap (LINK LED)</option>
+                            <option value="burst">Traffic burst (ACTIVITY LED)</option>
+                        </select>
                         <input id="locate-count" type="number" min="1" max="30" value="6" title="blink count" class="w-full sm:w-24 bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm">
                         <button onclick="locatePort()" class="w-full sm:w-auto bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Flash Port</button>
                     </div>
@@ -6581,7 +6589,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260713-identity-iface"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260714-locate-burst"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -4024,16 +4024,18 @@ async function locatePort(force) {
     if (!iface) { ifaceEl.focus(); return; }
     let count = parseInt(document.getElementById('locate-count').value, 10);
     if (!Number.isFinite(count)) count = 6;
+    const methEl = document.getElementById('locate-method');
+    const method = (methEl && methEl.value) || 'flap';
     const btn = event && event.target ? event.target : null;
-    _ndBusy(btn, true, 'Flashing…');
+    _ndBusy(btn, true, method === 'burst' ? 'Bursting…' : 'Flashing…');
     out.classList.remove('hidden');
     try {
-        const data = await postAPI('/api/net/locate-port', { interface: iface, count: count, force: !!force });
+        const data = await postAPI('/api/net/locate-port', { interface: iface, count: count, method: method, force: !!force });
         if (!data.success) {
             if (data.needs_force) {
                 _ndBusy(btn, false);
                 if (confirm(data.error + '\n\nFlash it anyway?')) return locatePort(true);
-                out.innerHTML = '<p class="text-gray-400">Cancelled.</p>';
+                out.innerHTML = '<p class="text-gray-400">Cancelled — tip: the Traffic-burst method locates it without dropping the link.</p>';
                 return;
             }
             out.innerHTML = '<p class="text-red-400">Error: ' + escapeHtml(data.error || 'failed') + '</p>';
@@ -4041,7 +4043,8 @@ async function locatePort(force) {
         }
         out.innerHTML = '<p class="text-green-400">⚡ ' + escapeHtml(data.message) + '</p>';
     } catch (e) {
-        // A flap on the interface serving this page can abort the request — that's expected.
+        // A flap on the interface serving this page can abort the request — that's
+        // expected. (Burst never drops the link, so this path is flap-only.)
         out.innerHTML = '<p class="text-amber-300">Flash started on ' + escapeHtml(iface)
             + '. If the UI dropped, that\'s the link flapping — watch the switch LED; it auto-restores.</p>';
     } finally {


### PR DESCRIPTION
…link flap

Switches differ in which per-port LED they drive off which event: some blink the LINK LED on link state, others only blink the ACTIVITY LED on traffic. Locate Port only did the former (link flap), so it was inconsistent across switches. Add a second method in the same card.

- 'burst': sends dense bursts of raw broadcast Ethernet frames (AF_PACKET SOCK_RAW, EtherType 0x88b5, ~25-30k pps) with idle gaps so the ACTIVITY LED pulses in cadence while the LINK stays up. Never drops connectivity, so it skips the default-route force guard entirely — safe on any port, including the uplink. Raw egress needs no IP/route.
- 'flap': unchanged (link down/up, LINK LED), still guarded on the default route.

API takes method=flap|burst (default flap, unknown falls back to flap); UI adds a method selector to the card with both explained. Verified: a veth-pair capture shows the burst emitting correctly-framed broadcast frames (bcast dst + real src MAC + 0x88b5); the guard fires for flap but not burst on the default route. Docs updated.