### PR TITLE
Heatmap

### DIFF
--- a/display.py
+++ b/display.py
@@ -1167,25 +1167,38 @@ class Display:
     def _render_netdiag_menu(self, image, draw, highlight):
         """The card-selection menu (reached with KEY2 on the LCD HAT): list the
         net-diag cards and highlight the current one. The joystick moves the
-        highlight; the centre press opens that card."""
+        highlight; the centre press opens that card. No title header — the list
+        starts at the top so all cards fit on the short panel."""
         sy = getattr(self, 'render_sy', self.scale_factor_y)
         sx = getattr(self, 'render_sx', self.scale_factor_x)
         w = getattr(self, 'render_w', self.shared_data.width)
+        h = getattr(self, 'render_h', self.shared_data.height)
         font = self.shared_data.font_arial9
-        self._draw_page_frame(draw, "NET CARDS", hint="K2 back · press=open")
-        y = int(26 * sy)
+        # Thin border + footer hint only (no "NET CARDS" title / top divider),
+        # reclaiming that space for the list.
+        draw.rectangle((1, 1, w - 1, h - 1), outline=0)
+        foot_y = h - int(18 * sy)
+        draw.line((1, foot_y, w - 1, foot_y), fill=0)
+        hint = "K2 back · press=open"
+        avail_hint = w - int(8 * sx)
+        while hint and font.getlength(hint) > avail_hint:
+            hint = hint[:-1]
+        draw.text((int(4 * sx), h - int(16 * sy)), hint, font=font, fill=0)
         pad_x = int(8 * sx)
-        row_h = int(13 * sy)
         n = len(NETDIAG_CARD_NAMES)
+        # Fit every card between the top and the footer divider.
+        top = int(4 * sy)
+        row_h = max(int(11 * sy), min(int(15 * sy), (foot_y - top) // max(1, n)))
+        y = top
         for i, nm in enumerate(NETDIAG_CARD_NAMES):
             sel = (i == highlight % n)
             label = f"{i + 1}. {nm}"
             if sel:
-                draw.rectangle([int(3 * sx), y - int(1 * sy),
-                                w - int(3 * sx), y + row_h - int(2 * sy)], fill=0)
-                draw.text((pad_x, y), label, font=font, fill=1)
+                draw.rectangle([int(3 * sx), y,
+                                w - int(3 * sx), y + row_h - int(1 * sy)], fill=0)
+                draw.text((pad_x, y + int(1 * sy)), label, font=font, fill=1)
             else:
-                draw.text((pad_x, y), label, font=font, fill=0)
+                draw.text((pad_x, y + int(1 * sy)), label, font=font, fill=0)
             y += row_h
 
     def _render_netdiag_page(self, image, draw, page, frozen=False, func_idx=-1):

--- a/display.py
+++ b/display.py
@@ -87,13 +87,13 @@ try:
 except ImportError:
     EPDButtonListener = None
     PAGE_MAIN, PAGE_NETWORK, PAGE_VULN, PAGE_DISCOVERED, PAGE_ADVANCED, PAGE_TRAFFIC = 0, 1, 2, 3, 4, 5
-    NETDIAG_CARD_NAMES = ["LINK", "IP", "SWITCH", "DHCP", "WIFI", "SIGNAL"]
+    NETDIAG_CARD_NAMES = ["LINK", "IP", "SWITCH", "DHCP", "WIFI", "SIGNAL", "SPECTRUM"]
     NETDIAG_CARD_FUNCS = {}
 
-# Network Diagnostic mode: number of auto-cycling e-Paper sub-pages
-# (0=LINK, 1=IP, 2=SWITCH, 3=DHCP, 4=WIFI, 5=SIGNAL). See
+# Network Diagnostic mode: number of auto-cycling sub-pages
+# (0=LINK, 1=IP, 2=SWITCH, 3=DHCP, 4=WIFI, 5=SIGNAL, 6=SPECTRUM). See
 # Display._render_netdiag_page.
-NETDIAG_PAGE_COUNT = 6
+NETDIAG_PAGE_COUNT = 7
 NETDIAG_CYCLE_SECONDS = 5
 
 class Display:
@@ -1094,13 +1094,15 @@ class Display:
         ~every 45s, and only while this page is on screen."""
         st = getattr(self, '_netdiag_wifi_state', None)
         if st is None:
-            st = self._netdiag_wifi_state = {'ts': 0, 'aps': None, 'scanning': False}
+            st = self._netdiag_wifi_state = {'ts': 0, 'aps': None, 'scanning': False,
+                                             'spectrum': None, 'bands': None}
         now = time.time()
         if not st['scanning'] and (now - st['ts']) > 45:
             st['scanning'] = True
 
             def _worker():
                 aps = None
+                spectrum = bands = None
                 try:
                     import wifi_analyzer as wa
                     iface = getattr(self, '_wifi_iface', None) or 'wlan0'
@@ -1108,10 +1110,15 @@ class Display:
                     if 'error' not in d:
                         aps = sorted(d.get('aps', []),
                                      key=lambda a: -(a.get('signal') or -999))[:5]
+                        # Full per-channel spectrum feeds the SPECTRUM card too.
+                        spectrum = d.get('spectrum') or {}
+                        bands = d.get('supported_bands') or {}
                 except Exception as e:
                     logger.debug(f"netdiag wifi scan error: {e}")
                 if aps is not None:
                     st['aps'] = aps
+                    st['spectrum'] = spectrum
+                    st['bands'] = bands
                 st['ts'] = time.time()
                 st['scanning'] = False
 
@@ -1332,7 +1339,7 @@ class Display:
                 self._draw_signal_bar(draw, yy + int(3 * sy), wl['signal'],
                                       pad_x, w - pad_x)
 
-        else:  # page 5: SIGNAL — nearby networks' signal strengths (scan)
+        elif page == 5:  # SIGNAL — nearby networks' signal strengths (scan)
             st = self._netdiag_wifi_scan()
             aps = st.get('aps')
             if not aps:
@@ -1342,6 +1349,83 @@ class Display:
                 ])
                 return
             self._draw_signal_bars(draw, y, aps)
+
+        else:  # page 6: SPECTRUM — per-channel occupancy graph (band via func_idx)
+            st = self._netdiag_wifi_scan()
+            spectrum = st.get('spectrum')
+            if spectrum is None:
+                self._draw_stat_rows(draw, y, [
+                    ("Spectrum", "scanning..." if st.get('scanning') else "no data"),
+                    ("Wait", "~5s"),
+                ])
+                return
+            band = ['2.4', '5', '6'][(func_idx if func_idx >= 0 else 0) % 3]
+            self._draw_spectrum(draw, y, band, spectrum, st.get('bands') or {})
+
+    def _draw_spectrum(self, draw, y, band, spectrum, supported):
+        """Channel-occupancy spectrum for one band on the LCD HAT: a bar per
+        channel, height ∝ strongest AP's signal there, with DFS/radar channels
+        drawn hollow and the busiest channel tick-marked. This is the analyzer's
+        signature 'Bar' view shrunk to 128 px. `band` is '2.4'|'5'|'6'."""
+        w = getattr(self, 'render_w', self.shared_data.width)
+        h = getattr(self, 'render_h', self.shared_data.height)
+        sx = getattr(self, 'render_sx', self.scale_factor_x)
+        sy = getattr(self, 'render_sy', self.scale_factor_y)
+        font = self.shared_data.font_arial9
+        pad_x = int(6 * sx)
+        band_lbl = {'2.4': '2.4G', '5': '5G', '6': '6G'}.get(band, band)
+
+        info = spectrum.get(band) or {}
+        chans = info.get('channels') or []
+        if not chans:
+            reason = 'not supported' if not supported.get(band, True) else 'no APs seen'
+            self._draw_stat_rows(draw, y, [(band_lbl, reason),
+                                           ("Tip", "Up/Down = band")])
+            return
+
+        # Header: band · AP count · strongest signal + its channel.
+        best = max(chans, key=lambda c: (c.get('max_signal') is not None,
+                                         c.get('max_signal') or -999))
+        best_sig = best.get('max_signal')
+        hdr = f"{band_lbl}  {info.get('ap_count', 0)}AP"
+        if best_sig is not None:
+            hdr += f"  ch{best.get('channel')} {int(best_sig)}"
+        draw.text((pad_x, y), hdr, font=font, fill=0)
+
+        # Plot area under the header, leaving a row for channel-axis labels
+        # above the footer divider (h - 18·sy) so they don't collide with it.
+        top = y + int(13 * sy)
+        bottom = h - int(28 * sy)
+        axis_y = bottom
+        x0, x1 = pad_x, w - pad_x
+        if bottom - top < int(10 * sy) or x1 - x0 < 8:
+            return
+        draw.line((x0, axis_y, x1, axis_y), fill=0)         # baseline
+        n = len(chans)
+        slot = (x1 - x0) / float(n)
+        bar_w = max(1, int(slot) - 1)
+        plot_h = axis_y - top
+        for i, c in enumerate(chans):
+            bx = int(x0 + i * slot)
+            sig = c.get('max_signal')
+            q = self._dbm_to_quality(sig) if sig is not None else 0
+            bh = int(plot_h * (q or 0) / 100.0)
+            if bh <= 0:
+                continue
+            by = axis_y - bh
+            if c.get('radar'):                              # DFS/radar → hollow
+                draw.rectangle([bx, by, bx + bar_w, axis_y], outline=0)
+            else:
+                draw.rectangle([bx, by, bx + bar_w, axis_y], fill=0)
+            if c is best and bh > 0:                        # mark the busiest
+                draw.line((bx, by - int(3 * sy), bx + bar_w, by - int(3 * sy)), fill=0)
+
+        # Channel-axis ticks: label first, middle and last channel numbers.
+        for i in (0, n // 2, n - 1):
+            lab = str(chans[i].get('channel'))
+            lx = int(x0 + i * slot)
+            lx = min(lx, x1 - int(font.getlength(lab)))
+            draw.text((max(x0, lx), axis_y + int(1 * sy)), lab, font=font, fill=0)
 
     def _draw_wrapped_note(self, draw, y, text, max_lines=3):
         """Word-wrap a short note across up to max_lines using the small font."""

--- a/docs/DISPLAY_CONTROLS.md
+++ b/docs/DISPLAY_CONTROLS.md
@@ -75,7 +75,7 @@ GPIO pins (BCM), fixed by the HAT: `KEY1=21`, `KEY2=20`, `KEY3=16`; joystick
 
 ### Network Diagnostic mode
 
-Navigated as **cards**: `LINK · IP · SWITCH · DHCP · WIFI · SIGNAL`.
+Navigated as **cards**: `LINK · IP · SWITCH · DHCP · WIFI · SIGNAL · SPECTRUM`.
 
 | Input | Action |
 |-------|--------|
@@ -87,7 +87,12 @@ Navigated as **cards**: `LINK · IP · SWITCH · DHCP · WIFI · SIGNAL`.
 | **KEY3** | **Pause / start auto-switch** — auto-cycle the cards every 5 s |
 
 Functions: **LINK/SWITCH** → Locate Port · L2 Health; **IP** → Ping GW · Ping
-WAN · DNS Doctor · Speedtest; **DHCP/WIFI/SIGNAL** are read-only. See the full
+WAN · DNS Doctor · Speedtest; **DHCP/WIFI/SIGNAL** are read-only. On the
+**SPECTRUM** card the ↑/↓ "functions" select the **band** (2.4 / 5 / 6 GHz) —
+it draws that band's live **channel-occupancy spectrum** (a bar per channel,
+height ∝ the strongest AP's signal, DFS/radar channels hollow, busiest channel
+tick-marked) — the WiFi Spectrum Analyzer's Bar view on the panel. Press KEY3 to
+freeze the auto-cycle, then ↑/↓ to sweep bands. See the full
 [field‑test pad](nettools.md#field-test-pad-144-lcd-hat--joystick) table.
 
 ---

--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -144,10 +144,18 @@ The display auto-cycles six pages every **5 seconds**:
 6. **SIGNAL** — a bar chart of the **strongest nearby networks' signal
    strengths** (SSID + RSSI), from a background [passive Wi-Fi
    scan](wifi-analyzer.md) so the page never blocks.
+7. **SPECTRUM** — the [WiFi Spectrum Analyzer](wifi-analyzer.md)'s **Bar view on
+   the panel**: a live **channel-occupancy graph** for one band (a bar per
+   channel, height ∝ the strongest AP's signal there, **DFS/radar channels drawn
+   hollow**, the busiest channel tick-marked), with the band, AP count and
+   strongest channel in the header. The ↑/↓ joystick picks the **band**
+   (2.4 / 5 / 6 GHz); an unsupported band says so. Shares the same background
+   passive scan as SIGNAL, so it never blocks the cycle. *(LCD HAT only — the
+   2.7" e-Paper HAT's card set stops at SWITCH.)*
 
 The wired pages focus on the **physical** wired NIC (`eth*` / `en*`), ignoring
-VPN, tunnel, bridge and container interfaces; the WIFI/SIGNAL pages use the
-wireless interface. Toggle it off to restore the normal Ragnar display. The
+VPN, tunnel, bridge and container interfaces; the WIFI/SIGNAL/SPECTRUM pages use
+the wireless interface. Toggle it off to restore the normal Ragnar display. The
 setting is persisted (`network_diagnostic_mode` in the config) and shared across
 sessions.
 
@@ -181,9 +189,9 @@ Network Diagnostic Mode on/off directly (no web UI needed). Select the HAT in
 **Display settings** as *"1.44" ST7735S LCD HAT + joystick"*.
 
 The mode is navigated as a stack of **cards** — `LINK · IP · SWITCH · DHCP ·
-WIFI · SIGNAL`. **Left/Right move between cards; Up/Down cycle the test functions
-*inside* a card; the centre press runs the highlighted one** (the footer shows
-`>` + its name). While the mode is on:
+WIFI · SIGNAL · SPECTRUM`. **Left/Right move between cards; Up/Down cycle the test
+functions *inside* a card; the centre press runs the highlighted one** (the
+footer shows `>` + its name). While the mode is on:
 
 | Input | Action |
 |-------|--------|
@@ -191,7 +199,7 @@ WIFI · SIGNAL`. **Left/Right move between cards; Up/Down cycle the test functio
 | **Joystick ← / →** | Previous / next **card** |
 | **Joystick ↑ / ↓** | Cycle the highlighted **function** inside the card |
 | **Joystick press** | **OK / select** — run the highlighted function (or dismiss a shown result) |
-| **KEY2** | **Card-selection menu** — an overview list of the six cards; press again to leave it |
+| **KEY2** | **Card-selection menu** — an overview list of the cards; press again to leave it |
 | **KEY3** | **Pause / start auto-switch** — auto-cycle the cards every 5 s (off by default) |
 
 The functions selectable inside each card (Up/Down, then press):
@@ -201,6 +209,7 @@ The functions selectable inside each card (Up/Down, then press):
 | **LINK** / **SWITCH** | **Locate port** (blink the switch link LED) · **L2 health** capture (~12 s) |
 | **IP** | **Ping gateway** (LAN) · **Ping internet** (`8.8.8.8`, WAN) · **DNS Doctor** (poison/hijack verdict) · **Speed test** |
 | **DHCP** / **WIFI** / **SIGNAL** | read-only (no functions) |
+| **SPECTRUM** | Up/Down selects the **band** (2.4 / 5 / 6 GHz) whose live channel-occupancy spectrum is drawn; press does nothing (nothing to run) |
 
 In the **card-selection menu** any joystick direction moves the highlight and
 press opens that card. The joystick arrows above are **as you read them on the

--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -16,7 +16,8 @@ It is split into three sub-tabs: **Diagnostics**, **Switch & L2/L3**, and
 > **Co-authored by [Solarflere](https://www.instagram.com/solarflere).** The
 > Authority Verification suite was designed and built in collaboration with Solarflere.
 
-<img width="1080" height="1824" alt="image" src="https://github.com/user-attachments/assets/1556051a-2114-4144-8e4b-0020cf0b2c1d" />
+<img width="3375" height="5700" alt="image" src="https://github.com/user-attachments/assets/e8ab8188-56ed-4f43-9671-4b4cbf4efd3d" />
+
 
 
 

--- a/docs/wifi-analyzer.md
+++ b/docs/wifi-analyzer.md
@@ -83,6 +83,12 @@ shaded. Toggle between:
   centred on its operating channel and spanning its channel width, peak = RSSI.
   This is the view that makes channel overlap and crowding obvious at a glance.
 
+**On the device (1.44" LCD HAT):** the Bar view is also available head-less as
+the **SPECTRUM** card in on-screen Network Diagnostic mode — a per-channel
+occupancy graph for one band (height ∝ the strongest AP's signal, DFS/radar
+channels hollow, busiest channel tick-marked); the joystick ↑/↓ picks the band.
+See [Display Controls](DISPLAY_CONTROLS.md#network-diagnostic-mode).
+
 ---
 
 ## Interference & channel planning

--- a/epd_button.py
+++ b/epd_button.py
@@ -58,7 +58,7 @@ NETDIAG_PAGE_COUNT = 3
 # one with the centre press (the "card" navigation model); the 2.7" e-Paper HAT
 # still fires them from its hardware keys. Kept module-level so both display.py
 # (for rendering) and the LCD listener (for dispatch) share one definition.
-NETDIAG_CARD_NAMES = ["LINK", "IP", "SWITCH", "DHCP", "WIFI", "SIGNAL"]
+NETDIAG_CARD_NAMES = ["LINK", "IP", "SWITCH", "DHCP", "WIFI", "SIGNAL", "SPECTRUM"]
 NETDIAG_CARD_FUNCS = {
     0: [("Locate Port", "port"), ("L2 Health", "l2")],            # LINK
     1: [("Ping GW", "ping_gw"), ("Ping WAN", "ping_wan"),
@@ -67,6 +67,11 @@ NETDIAG_CARD_FUNCS = {
     3: [],                                                         # DHCP (auto)
     4: [],                                                         # WIFI (live)
     5: [],                                                         # SIGNAL (auto)
+    # SPECTRUM: the "functions" are band selectors — Up/Down picks which band's
+    # channel spectrum is drawn (band_* keys are no-ops on press, see
+    # _run_netdiag_test). Only the LCD HAT reaches this card (its
+    # NETDIAG_PAGE_COUNT is 7; the e-Paper HAT's is 3).
+    6: [("2.4 GHz", "band_24"), ("5 GHz", "band_5"), ("6 GHz", "band_6")],
 }
 
 # Hold time (seconds) that separates a short press from a long press in the
@@ -340,6 +345,10 @@ class EPDButtonListener:
     def _run_netdiag_test(self, kind):
         """Show a 'running' placeholder and run the test on a daemon thread so
         the button callback returns at once (some tests take many seconds)."""
+        # SPECTRUM band selectors aren't tests — Up/Down already picked the band
+        # the card renders; a press should do nothing rather than pop a result.
+        if str(kind).startswith('band_'):
+            return
         if self._netdiag_busy:
             logger.debug(f"Netdiag test '{kind}' ignored — another is running")
             return

--- a/lcdhat_input.py
+++ b/lcdhat_input.py
@@ -56,10 +56,10 @@ logger = logging.getLogger(__name__)
 # (joystick-center toggles it). Matches the net-diag auto-cycle cadence.
 AUTOSCROLL_INTERVAL = 5.0
 
-# Number of net-diag sub-pages (LINK / IP / SWITCH / DHCP / WIFI / SIGNAL).
-# Mirrors display.NETDIAG_PAGE_COUNT; kept local so this module needn't import
-# display.py.
-NETDIAG_PAGE_COUNT = 6
+# Number of net-diag sub-pages (LINK / IP / SWITCH / DHCP / WIFI / SIGNAL /
+# SPECTRUM). Mirrors display.NETDIAG_PAGE_COUNT; kept local so this module
+# needn't import display.py.
+NETDIAG_PAGE_COUNT = 7
 
 # Button pins
 KEY1_PIN = 21


### PR DESCRIPTION
This pull request adds a new "SPECTRUM" card to the Network Diagnostic mode on the LCD HAT, providing a live WiFi channel-occupancy spectrum analyzer view. The SPECTRUM card displays a per-channel occupancy graph for selected WiFi bands (2.4, 5, or 6 GHz), with joystick up/down cycling the band. Documentation and UI have been updated to reflect this new feature, and minor code improvements were made for menu rendering and function handling.

**New SPECTRUM Card and WiFi Spectrum Analyzer Integration:**

* Added "SPECTRUM" to `NETDIAG_CARD_NAMES` and increased `NETDIAG_PAGE_COUNT` to 7 in both `display.py`, `epd_button.py`, and `lcdhat_input.py`, enabling navigation to the new card. [[1]](diffhunk://#diff-f6c06aabaaa561e18d40bbe59a0e91b4f589b497ab5cb4d59d5242e8704f3c3aL90-R96) [[2]](diffhunk://#diff-ff62ad88a6a6161a65f15838b813409d422050d28d6a7ffa004346419448b543L61-R61) [[3]](diffhunk://#diff-0165d186970a65124b175a8fbcefe290bf319bcba2b1ca56ca82331307bb78a1L59-R62)
* Implemented the SPECTRUM card's rendering: performs a background WiFi scan, extracts per-channel spectrum data, and draws a bar graph for the selected band. Joystick up/down cycles through 2.4, 5, and 6 GHz bands. [[1]](diffhunk://#diff-f6c06aabaaa561e18d40bbe59a0e91b4f589b497ab5cb4d59d5242e8704f3c3aL1097-R1121) [[2]](diffhunk://#diff-f6c06aabaaa561e18d40bbe59a0e91b4f589b497ab5cb4d59d5242e8704f3c3aR1366-R1442)
* SPECTRUM card's function selectors (Up/Down) are handled as band selectors, and pressing the joystick does nothing (prevents running a test for band selectors). [[1]](diffhunk://#diff-ff62ad88a6a6161a65f15838b813409d422050d28d6a7ffa004346419448b543R70-R74) [[2]](diffhunk://#diff-ff62ad88a6a6161a65f15838b813409d422050d28d6a7ffa004346419448b543R348-R351)

**User Interface and Menu Improvements:**

* Updated the card-selection menu rendering to fit all cards, including SPECTRUM, by removing the title header and optimizing spacing.

**Documentation Updates:**

* Updated all relevant documentation (`DISPLAY_CONTROLS.md`, `nettools.md`, `wifi-analyzer.md`) to describe the new SPECTRUM card, its controls, and its visual output. Added references to the new card in card lists, control tables, and feature descriptions. [[1]](diffhunk://#diff-0fce17d6fa48de503d0c756901725d6db73de1510a993e4b427fc0b298d46fb6L78-R78) [[2]](diffhunk://#diff-0fce17d6fa48de503d0c756901725d6db73de1510a993e4b427fc0b298d46fb6L90-R95) [[3]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaR148-R159) [[4]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaL184-R203) [[5]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaR213) [[6]](diffhunk://#diff-e536007904be3f81c8debf8e3041607ba3764067bd19f7cd221d9a7fc0951271R86-R91)

These changes provide a headless WiFi spectrum analyzer directly on the device, making channel crowding and interference visible without external tools.