### PR TITLE
Net tools SIGNAL/WIFI cards: live signal strength

### DIFF
--- a/display.py
+++ b/display.py
@@ -1119,15 +1119,19 @@ class Display:
     def _netdiag_wifi_scan(self):
         """Background-cached passive scan for the net-diag SIGNAL/SPECTRUM pages.
         A full passive scan takes several seconds, so it runs in a worker thread
-        and the page shows the last result — the render never blocks. Refreshes
-        at most ~every 45s, and only while a wifi page is on screen. Scans the
-        widest-band adapter (see _netdiag_scan_iface) so 5/6 GHz show up."""
+        and the page shows the last result — the render never blocks. Full
+        discovery sweeps run at most ~every 45s, and only while a wifi page is
+        on screen; between them a fast poll re-visits just the listed APs'
+        channels every ~1s so the signal bars move live. Scans the widest-band
+        adapter (see _netdiag_scan_iface) so 5/6 GHz show up."""
         st = getattr(self, '_netdiag_wifi_state', None)
         if st is None:
             st = self._netdiag_wifi_state = {'ts': 0, 'aps': None, 'scanning': False,
-                                             'spectrum': None, 'bands': None, 'iface': None}
+                                             'spectrum': None, 'bands': None, 'iface': None,
+                                             'fast_ts': 0, 'fast_scanning': False}
         now = time.time()
-        if not st['scanning'] and (now - st['ts']) > 45:
+        if (not st['scanning'] and not st.get('fast_scanning', False)
+                and (now - st['ts']) > 45):
             st['scanning'] = True
 
             def _worker():
@@ -1154,6 +1158,31 @@ class Display:
                 st['scanning'] = False
 
             threading.Thread(target=_worker, daemon=True).start()
+        elif (st.get('aps') and not st['scanning']
+              and not st.get('fast_scanning', False)
+              and (now - st.get('fast_ts', 0)) > 1.0):
+            # Fast path: passively re-visit only the channels of the APs
+            # already on screen. Values update in place (no re-sort) so the
+            # rows stay put while their bars move.
+            st['fast_scanning'] = True
+
+            def _fast_worker():
+                try:
+                    import wifi_analyzer as wa
+                    iface = st.get('iface') or self._netdiag_scan_iface()
+                    freqs = sorted({int(round(a['freq'])) for a in (st.get('aps') or [])
+                                    if a.get('freq')})
+                    sig = wa.fast_signal_poll(iface, freqs)
+                    for a in (st.get('aps') or []):
+                        s = sig.get(a.get('bssid'))
+                        if s is not None:
+                            a['signal'] = s
+                except Exception as e:
+                    logger.debug(f"netdiag fast signal poll error: {e}")
+                st['fast_ts'] = time.time()
+                st['fast_scanning'] = False
+
+            threading.Thread(target=_fast_worker, daemon=True).start()
         return st
 
     def _draw_signal_bar(self, draw, y, dbm, x0, x1):
@@ -3589,7 +3618,14 @@ class Display:
                         else:
                             self._netdiag_page = nextp
                     self._commit_netdiag_frame(image)
-                    self._netdiag_sleep(NETDIAG_CYCLE_SECONDS, bl, seq0)
+                    # WIFI/SIGNAL cards held in manual mode redraw every second
+                    # so the RSSI readings and bars move live as you walk
+                    # around; everything else keeps the normal cycle.
+                    live = (frozen and view != 'menu'
+                            and NETDIAG_CARD_NAMES[page % len(NETDIAG_CARD_NAMES)]
+                            in ("WIFI", "SIGNAL"))
+                    self._netdiag_sleep(1.0 if live else NETDIAG_CYCLE_SECONDS,
+                                        bl, seq0)
                     continue
                 # Not in net-diag mode: drop any stale one-shot result / freeze so
                 # re-entering the mode later starts clean on the pages.

--- a/docs/DISPLAY_CONTROLS.md
+++ b/docs/DISPLAY_CONTROLS.md
@@ -86,6 +86,10 @@ Navigated as **cards**: `LINK · IP · SWITCH · DHCP · WIFI · SIGNAL · SPECT
 | **KEY2** | **Card-selection menu** (press again to leave) |
 | **KEY3** | **Pause / start auto-switch** — auto-cycle the cards every 5 s |
 
+Pause auto-switch (KEY3) on the **WIFI** or **SIGNAL** card and it redraws
+**every second** with live RSSI — SIGNAL's bars are refreshed by a fast passive
+poll of just the listed APs' channels, so they move as you walk around.
+
 Functions: **LINK/SWITCH** → Locate Port · L2 Health; **IP** → Ping GW · Ping
 WAN · DNS Doctor · Speedtest; **DHCP/WIFI/SIGNAL** are read-only. On the
 **SPECTRUM** card the ↑/↓ "functions" select the **band** (2.4 / 5 / 6 GHz) —

--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -140,10 +140,15 @@ The display auto-cycles six pages every **5 seconds**:
    runs in the background so the page never blocks the cycle.
 5. **WIFI** — the wireless link you're on: **SSID**, **RSSI** (dBm) + quality %,
    band/channel and TX rate, with a live signal bar under the facts (walk around
-   to find dead spots). Read passively from `iw dev … link` — no scan.
+   to find dead spots). Read passively from `iw dev … link` — no scan. Held in
+   manual mode, the WIFI and SIGNAL cards **redraw every second** instead of
+   the normal 5 s cycle, so the readings track you in real time.
 6. **SIGNAL** — a bar chart of the **strongest nearby networks' signal
    strengths** (SSID + RSSI), from a background [passive Wi-Fi
-   scan](wifi-analyzer.md) so the page never blocks.
+   scan](wifi-analyzer.md) so the page never blocks. Between full discovery
+   sweeps (~45 s) a **fast poll re-visits just the listed APs' channels every
+   second**, so the bars move live as you walk — rows stay put, only the
+   values change.
 7. **SPECTRUM** — the [WiFi Spectrum Analyzer](wifi-analyzer.md)'s **Bar view on
    the panel**: a live **channel-occupancy graph** for one band (a bar per
    channel, height ∝ the strongest AP's signal there, **DFS/radar channels drawn

--- a/wifi_analyzer.py
+++ b/wifi_analyzer.py
@@ -1127,6 +1127,34 @@ def do_scan(interface="wlan0", band="all", passive=True):
     }
 
 
+def fast_signal_poll(interface, freqs, timeout=10):
+    """Quick passive scan restricted to `freqs` (MHz); returns
+    {bssid: signal_dbm} for every BSS heard fresh on those channels.
+
+    Dwelling on a handful of known channels takes well under a second (a full
+    all-band sweep takes several), so callers can refresh the signal of APs
+    they already know about near-live between full discovery scans. Results
+    the kernel merely cached from an earlier sweep (stale last-seen) are
+    dropped so a bar never freezes on an old reading."""
+    if not _valid_iface(interface) or not freqs:
+        return {}
+    args = [_IW, "dev", interface, "scan", "freq"]
+    args += [str(int(round(f))) for f in freqs]
+    args.append("passive")
+    rc, out, _err = _run(args, timeout=timeout)
+    if rc != 0:
+        return {}
+    sig = {}
+    for b in parse_scan(out):
+        if b.get("signal") is None:
+            continue
+        last = b.get("last_seen_ms")
+        if last is not None and last > 15000:
+            continue
+        sig[b["bssid"]] = b["signal"]
+    return sig
+
+
 def radius_from_fields(fields, tx_dbm=None, ple=_DEFAULT_PLE, rssi_offset=0.0,
                        antenna_gain=0.0, cable_loss=0.0, rssi0_override=None):
     """Compute the coverage rings from an AP's already-known scan fields — no


### PR DESCRIPTION
The SIGNAL card's bars only refreshed on the full all-band passive scan (~45s), so the display felt frozen. Between full discovery sweeps a fast passive poll now re-visits just the listed APs' channels (~0.5s for 5 channels) every second, updating the dBm values in place so rows stay put while the bars move. When auto-switch is paused on the WIFI or SIGNAL card, the page also redraws every 1s instead of 5s, so RSSI tracks you live as you walk around.