### PR TITLE
Ospf lsa parse fix

### DIFF
--- a/bgp_speaker.py
+++ b/bgp_speaker.py
@@ -249,8 +249,9 @@ class RIB:
         if r is None:
             r = {'prefix': prefix, 'first_seen': now, 'last_change': now,
                  'updates': 0, 'withdraws': 0, 'state': 'active',
-                 'origin_as': None, 'as_path': [], 'next_hop': None,
-                 'communities': [], '_changes': deque(maxlen=self._churn_cap)}
+                 'origin_as': None, 'as_path': [], 'prev_as_path': [],
+                 'next_hop': None, 'communities': [],
+                 '_changes': deque(maxlen=self._churn_cap)}
             self._routes[prefix] = r
         return r
 
@@ -267,6 +268,10 @@ class RIB:
                 if r['state'] != 'active' or r['as_path'] != new_path or r['next_hop'] != upd.get('next_hop'):
                     r['last_change'] = now
                     r['_changes'].append(now)
+                    # Remember the previous AS-path across a genuine path change so
+                    # the correlator can show old -> new (which carrier moved, how).
+                    if r['as_path'] and r['as_path'] != new_path:
+                        r['prev_as_path'] = list(r['as_path'])
                 r['state'] = 'active'
                 r['updates'] += 1
                 r['origin_as'] = origin_as
@@ -317,6 +322,7 @@ class RIB:
         now = now or time.time()
         return {'prefix': r['prefix'], 'state': r['state'],
                 'origin_as': r['origin_as'], 'as_path': list(r['as_path']),
+                'prev_as_path': list(r.get('prev_as_path') or []),
                 'next_hop': r['next_hop'], 'communities': list(r['communities']),
                 'updates': r['updates'], 'withdraws': r['withdraws'],
                 'first_seen': r['first_seen'], 'last_change': r['last_change'],

--- a/docs/arp_guard.md
+++ b/docs/arp_guard.md
@@ -1,0 +1,100 @@
+# arp_guard — layered ARP poisoning / spoofing detector
+
+`arp_guard` (`python/arp_guard.py`) is a standalone, **detection-only** ARP
+monitor. It never sends a corrective ARP, blocks traffic, or intervenes — it
+watches the live ARP packet stream and alerts. **Passive:** Scapy is used only as
+the live-capture front end; field extraction is a hand-rolled **raw-byte parser**
+(no library dissector), so `--self-test` and pcap `--replay` run with no radio/NIC
+and the self-test needs no Scapy.
+
+Unlike the snapshot-based ARP check in the web UI ([ARP Poisoning](nettools.md#arp-poisoning),
+which reads the kernel's *resolved* neighbour table), arp_guard watches the live
+stream — so it sees the attack **in progress**: gratuitous-ARP floods, a binding
+flapping between two racing hosts, and per-packet structural anomalies a snapshot
+can't show.
+
+- **Test floor:** Raspberry Pi Zero 2 W.
+- **Self-test:** 14/14 (`python3 python/arp_guard.py --self-test`).
+- **Deps:** Python 3.8+, Scapy (live capture only).
+
+## Four layers
+
+Each observed ARP frame is scored by four independent, stateful layers; findings
+from multiple layers about one packet are **merged into a single alert** (highest
+severity, combined evidence) to avoid alert fatigue during a sustained attack.
+
+1. **`binding`** — IP→MAC conflict tracker. Flags any change to a learned binding;
+   severity scales with how long the old binding was stable, and a binding
+   **flapping** between two MACs (two hosts racing to answer) escalates to
+   `critical` — the live signature of arpspoof/ettercap in progress.
+2. **`gratuitous`** — gratuitous-ARP rate/breadth. Per source MAC in a sliding
+   window: a high **rate** to one IP (targeted poisoning) and, separately, one MAC
+   claiming **many distinct IPs** (subnet-wide poisoning, ettercap's "poison whole
+   subnet" mode).
+3. **`structural`** — per-packet field/opcode/consistency sanity: bad
+   hwtype/ptype/length, invalid opcode, **Ethernet-source ≠ ARP-sender-hardware**
+   (forged), multicast/broadcast sender IP, a **solicited reply sent to broadcast**
+   (real replies are unicast; a *gratuitous* announcement is legitimately
+   broadcast and is not flagged here), and an invalid `0.0.0.0` reply. Judges
+   well-formedness only — a careful attacker crafts a clean packet, which is why
+   this layer doesn't stand alone.
+4. **`gateway`** — trusted IP→MAC pins set **manually, out of band** in the config.
+   A packet claiming a pinned IP from a non-pinned MAC is `critical` (gateway/host
+   impersonation). Deliberately **not** auto-learned at boot: if an attacker is
+   already active, auto-learning would pin *their* MAC as trusted. Use
+   `--learn-gateway` once, on a segment you currently trust, then copy the result
+   into `trusted_bindings`.
+
+## Run
+
+```bash
+python3 python/arp_guard.py --self-test                 # 14/14, no root/Scapy
+sudo python3 python/arp_guard.py -i eth0 --echo         # live, echo to stderr
+sudo python3 python/arp_guard.py -i eth0 --jsonl /var/log/arp-guard/alerts.jsonl
+python3 python/arp_guard.py --replay attack.pcap --echo # replay a capture (no NIC)
+
+# one-time, passive: read the gateway MAC from the kernel neighbour table
+# (/proc/net/arp — sends NOTHING). Ping the gateway once first if there's no entry.
+python3 python/arp_guard.py --learn-gateway --gateway-ip 192.168.1.1
+# copy the printed MAC into trusted_bindings in the config
+```
+
+## Alerts
+
+One JSON object per line: `ts`, `module`, `severity` (`info`/`low`/`medium`/
+`high`/`critical`), `sender_ip`, `sender_mac`, `eth_src`, `opcode`, `codes[]`
+(all layer codes that fired), `summary` (the worst finding), and `evidence[]` (the
+per-layer detail, severity-sorted).
+
+## Tuning (config JSON)
+
+`garp_window_s`, `garp_rate_threshold`, `garp_breadth_threshold` (gratuitous-ARP);
+`flap_window_s`, `flap_count`, `stable_threshold_s` (binding); and
+`trusted_bindings` (the layer-4 pins). Defaults suit a small home/lab subnet;
+loosen `garp_rate_threshold` if you run things that legitimately send frequent
+gratuitous ARPs (VRRP/keepalived, VM live-migration).
+
+## systemd
+
+`scripts/arp-guard.service` runs as a dedicated non-root `arpmon` user with only
+`CAP_NET_RAW`/`CAP_NET_ADMIN`, `ProtectSystem=strict`, and `MemoryMax=128M`;
+alerts land in `/var/log/arp-guard/alerts.jsonl`.
+
+## Known limitations
+
+- **Same-broadcast-domain only** — it sees only what reaches its interface (the
+  attack traffic, the victim, or a SPAN/mirror).
+- **No HSRP/VRRP virtual-MAC awareness** — a legitimate first-hop-redundancy
+  failover moves a virtual MAC on purpose and would look like a binding conflict;
+  pin both routers' real MACs or pair with FHRP Watch.
+- **Layer 3 catches sloppy tooling, not careful attackers** — a well-crafted
+  spoofed packet passes every structural check; layers 1 and 4 catch the *impact*.
+- **No IPv6 NDP** (structurally different — see [NDP Watch](nettools.md#ndp-watch))
+  and no switch-level MAC-flooding coverage (different attack surface).
+
+## Relation to the integrated ARP check
+
+The web UI's **ARP Poisoning** check (`do_arp_check`) is a point-in-time snapshot
+of the resolved neighbour table (gateway-MAC-vs-baseline + one-MAC-many-IPs).
+arp_guard is the continuous live-stream companion: the rate/flap/structural
+signals that only exist while the attack is happening.

--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -1704,8 +1704,18 @@ RIB*, but is **receive-only**: the FSM (Idle → Connect → OpenSent → OpenCo
 Established) sends only OPEN / KEEPALIVE and **never an UPDATE**, so it structurally
 **cannot advertise or withdraw a route**. It decodes UPDATEs into an Adj-RIB-In with
 per-prefix **churn/flap tracking** (a prefix changing origin/next-hop faster than a
-threshold is marked *flapping*) and longest-prefix lookup. Point it at a router
+threshold is marked *flapping*, and the previous AS-path is remembered so a change
+shows as `old → new`) and longest-prefix lookup. Point it at a router
 configured to peer with the Pi's AS (a route-server client / passive peer works well).
+
+**Multi-carrier mode** — start **one session per carrier-facing router** (each with
+its own thread + RIB) by passing a `peers` list instead of a single peer. When a
+convergence/asymmetry event fires, the verdict then **names which carrier moved and
+which are stable** — so a multi-homed operator knows which ISP to call. The scope is
+inferred from the pattern: *one* carrier's covering prefix churning → the change is
+in that carrier's AS or an upstream peer of it; *all* covering carriers moving
+together → upstream of every one of them (the origin AS or a shared major transit).
+Single-peer (`peer_ip`/`peer_as`) still works unchanged.
 
 **One-way-delay probe** (`path_asymmetry.py`) — a tiny UDP prober/reflector using the
 OWAMP/TWAMP 4-timestamp model (T1 send, T2 remote-recv, T3 remote-send, T4 recv). It
@@ -1718,20 +1728,25 @@ it flags a **shift** in asymmetry without false-alarming on a static clock skew.
 absolute number is trustworthy. Run the **reflector** on the far node (or here) so the
 other side can measure both directions.
 
-**Correlator** — when the collector is `Established`, each asymmetry event is
-annotated with control-plane truth from the RIB: the covering prefix, origin AS,
-AS-path, whether that prefix is currently flapping, and how recently it changed. The
-attribution heuristic then labels the event **route-churn** (RIB is flapping — the
-delay shift lines up with a real routing change), **recent path shift** (a fresh but
-stable change), or **stable / data-plane** (no matching control-plane change — the
-asymmetry is happening below BGP, e.g. a congested or re-routed transit leg).
+**Correlator** — when a collector session is `Established`, each asymmetry event is
+annotated with control-plane truth from the RIB(s): the covering prefix, origin AS,
+AS-path, whether that prefix is currently flapping, and how recently it changed. With
+multiple carrier sessions the correlator produces a **per-carrier breakdown**
+(`carriers_confirmed` / `carriers_stable`) and, when any carrier's covering prefix
+churned within the correlation window, upgrades the verdict to **`confirmed`** with a
+line like `confirmed [Carrier-A confirm; Carrier-B, Carrier-C stable] :: BGP RIB
+corroborates: Carrier-A: prefix 9.9.9.0/24 AS-path [64512, 64520] → [64512, 64530]`.
+Otherwise it labels the event **route-churn** (flapping), **recent path shift** (a
+fresh but stable change), or **stable / data-plane** (no matching control-plane
+change — the asymmetry is below BGP, e.g. a congested or re-routed transit leg).
 
 > **Safety:** the collector never originates routing information, and the OWD probe is
 > a handful of small UDP datagrams — neither injects state into the network. Both are
 > long-lived daemons managed with start/stop/status; nothing is persisted to disk.
 
 - Endpoints: `GET/POST /api/net/bgp-collector` `{action: start|stop|status|rib,
-  peer_ip, peer_as, local_as, router_id, port, hold}`,
+  local_as, router_id, port, hold, peer_ip, peer_as` (single) or `peers: [{ip, as,
+  name}, …]` (multi-carrier), `peer` (name, for per-session stop/rib)`}`,
   `GET/POST /api/net/owd-reflector` `{action: start|stop|status, port}`,
   `POST /api/net/path-asymmetry` `{target, count, clock_synced}`
 - CLI: `python3 path_asymmetry.py reflector [port]` runs a standalone reflector;

--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -332,6 +332,13 @@ is the *active* complement to the passive duplicate-IP check in
 [L2 Link Health](#l2-link-health), and it feeds the
 [Network Integrity Monitor](#-network-integrity-monitor).
 
+This snapshot view is complemented by a **standalone live-stream monitor** —
+[arp_guard](arp_guard.md) (`python/arp_guard.py`) — a four-layer packet pipeline
+(binding-flap · gratuitous-ARP rate/breadth · per-packet structural sanity ·
+out-of-band trusted-MAC pins) that catches the attack **in progress** (a raw-byte
+parser, JSON-lines alerts, pcap `--replay`, and a hardened daemon), which a
+neighbour-table snapshot can't see.
+
 - Endpoints: `GET /api/net/arp-check`,
   `GET|POST /api/net/arp-baseline` `{action:reset}` · uses `ip neigh` (iproute2)
 

--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -326,8 +326,12 @@ spoofed** verdict:
   neighbour table, i.e. a host impersonating much of the segment → **suspicious**
   (the gateway's own MAC is excluded so a router fronting its address is fine).
 
-The result shows the verdict, the current vs. trusted gateway MAC (highlighted
-on mismatch), the neighbour count, any impersonator MACs and the reasons. This
+An **interface selector** scopes the check to one segment — that interface's own
+default gateway (a higher-metric uplink still counts) and only the neighbours on
+it — which is the right lens on a **multi-homed** box; *Auto* uses the default
+route and the full neighbour table. The result shows the verdict, the interface
+checked, the current vs. trusted gateway MAC (highlighted on mismatch), the
+neighbour count, any impersonator MACs and the reasons. This
 is the *active* complement to the passive duplicate-IP check in
 [L2 Link Health](#l2-link-health), and it feeds the
 [Network Integrity Monitor](#-network-integrity-monitor).

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -12113,6 +12113,15 @@ def _parse_ospf_capture(output):
         av = re.search(r'Advertising Router:?\s+' + _OSPF_IPRE, line)
         if av and cur['adv_router'] is None:
             cur['adv_router'] = av.group(1)
+        # Real tcpdump prints the per-LSA "Advertising Router X, seq 0x.., age Ns"
+        # line BEFORE the "X LSA (n), LSA-ID: Y" line, so stash that metadata and
+        # attach it to the next LSA header. (The self-test's single-line format
+        # carries seq/age on the header line itself; both are handled below.)
+        meta = re.search(r'Advertising Router:?\s+' + _OSPF_IPRE +
+                         r',\s*seq\s+(0x[0-9a-fA-F]+)(?:,\s*age\s+(\d+))?', line)
+        if meta:
+            cur['_pend_lsa'] = {'adv': meta.group(1), 'seq': int(meta.group(2), 16),
+                                'age': int(meta.group(3)) if meta.group(3) else None}
         if cur['type'] == 'hello':
             hp = cur['hello'] or {'hello_timer': None, 'dead_timer': None,
                                   'mask': None, 'dr': None, 'neighbors': []}
@@ -12132,20 +12141,28 @@ def _parse_ospf_capture(output):
             if nb:
                 hp['neighbors'].append(nb.group(1))
             cur['hello'] = hp
-        # LSA record line (LS-Update / DD carry these)
+        # LSA header line ("X LSA (n), LSA-ID: Y"). Require an LSA-ID so sub-lines
+        # like "Router LSA Options: [none]" don't get parsed as ghost LSAs. seq/
+        # age/adv come from this line if present (single-line format), else from
+        # the preceding "Advertising Router ..." metadata line (real tcpdump).
         for rx, lsa_type in _OSPF_LSA_TYPES:
             if rx.search(line):
                 lid = re.search(r'LSA-ID:?\s+' + _OSPF_IPRE, line)
+                if not lid:
+                    break
+                pend = cur.get('_pend_lsa') or {}
                 adv = re.search(r'Advertising Router:?\s+' + _OSPF_IPRE, line)
                 sq = re.search(r'seq\s+(0x[0-9a-fA-F]+)', line)
                 ag = re.search(r'age\s+(\d+)', line)
                 cur['lsas'].append({
                     'lsa_type': lsa_type,
-                    'lsa_id': lid.group(1) if lid else None,
-                    'adv_router': (adv.group(1) if adv else cur.get('adv_router')),
-                    'seq': int(sq.group(1), 16) if sq else None,
-                    'age': int(ag.group(1)) if ag else None,
+                    'lsa_id': lid.group(1),
+                    'adv_router': (adv.group(1) if adv else
+                                   pend.get('adv') or cur.get('adv_router')),
+                    'seq': int(sq.group(1), 16) if sq else pend.get('seq'),
+                    'age': int(ag.group(1)) if ag else pend.get('age'),
                 })
+                cur['_pend_lsa'] = None
                 break
     flush()
     return packets
@@ -12492,22 +12509,37 @@ def _ospf_selftest():
         import tempfile
         from scapy.all import IP, Ether, wrpcap  # noqa
         try:
-            from scapy.contrib.ospf import OSPF_Hdr, OSPF_Hello
+            from scapy.contrib.ospf import (OSPF_Hdr, OSPF_Hello, OSPF_LSUpd,
+                                            OSPF_Router_LSA)
         except Exception:
             OSPF_Hdr = None
         if OSPF_Hdr is not None and _have('tcpdump'):
-            pkt = (Ether() / IP(src='10.0.0.5', dst='224.0.0.5', proto=89) /
-                   OSPF_Hdr(version=2, type=1, src='10.0.0.5', area='0.0.0.0',
-                            authtype=0) / OSPF_Hello(mask='255.255.255.0'))
+            hello = (Ether() / IP(src='10.0.0.5', dst='224.0.0.5', proto=89) /
+                     OSPF_Hdr(version=2, type=1, src='10.0.0.5', area='0.0.0.0',
+                              authtype=0) / OSPF_Hello(mask='255.255.255.0'))
+            # An LS-Update too: real tcpdump prints seq/age on the "Advertising
+            # Router" line ABOVE the "Router LSA, LSA-ID" line — the layout that
+            # broke seq/age parsing (and MaxSeq/MaxAge/fight-back) until fixed.
+            lsu = (Ether() / IP(src='10.0.0.5', dst='224.0.0.5', proto=89) /
+                   OSPF_Hdr(version=2, type=4, src='10.0.0.5', area='0.0.0.0') /
+                   OSPF_LSUpd(lsalist=[OSPF_Router_LSA(id='10.0.0.5', adrouter='10.0.0.5',
+                                                       seq=0x80000005, age=1)]))
             with tempfile.NamedTemporaryFile(suffix='.pcap', delete=False) as tf:
                 pcap_path = tf.name
-            wrpcap(pcap_path, [pkt])
+            wrpcap(pcap_path, [hello, lsu])
             res = _run(['tcpdump', '-nn', '-t', '-v', '-r', pcap_path, 'proto', 'ospf'],
                        timeout=10)
             parsed = _parse_ospf_capture(res['out'])
             got_auth = next((x.get('auth') for x in parsed if x.get('auth') is not None), None)
+            lsas = [l for x in parsed for l in x.get('lsas', [])]
+            # Regression guard: seq parsed off REAL tcpdump, and no ghost LSAs
+            # (sub-lines like "Router LSA Options" must not create lsa_id=None).
+            seq_ok = any(l.get('seq') == 0x80000005 for l in lsas)
+            no_ghost = all(l.get('lsa_id') for l in lsas)
             scapy_result = {'ran': True, 'parsed_packets': len(parsed),
-                            'auth': got_auth, 'pass': len(parsed) >= 1,
+                            'auth': got_auth, 'lsa_seq_parsed': seq_ok,
+                            'no_ghost_lsa': no_ghost, 'lsas': len(lsas),
+                            'pass': len(parsed) >= 1 and seq_ok and no_ghost,
                             'tcpdump_out': res['out'].strip()[:200]}
             try:
                 os.remove(pcap_path)

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -487,9 +487,13 @@ _arp_baseline_lock = threading.Lock()
 _ARP_IMPERSONATOR_MIN_IPS = 4
 
 
-def _neigh_entries():
-    """Parse `ip -4 neigh` into [(ip, mac, state)] for entries with a lladdr."""
-    res = _run(['ip', '-4', 'neigh', 'show'], timeout=5)
+def _neigh_entries(iface=None):
+    """Parse `ip -4 neigh` into [(ip, mac, state)] for entries with a lladdr.
+    Scoped to one interface's segment when `iface` is given."""
+    cmd = ['ip', '-4', 'neigh', 'show']
+    if iface:
+        cmd += ['dev', iface]
+    res = _run(cmd, timeout=5)
     out = []
     for line in res['out'].splitlines():
         m = re.match(r'^(\d+\.\d+\.\d+\.\d+)\b.*?\blladdr\s+([0-9a-fA-F:]{17})\s+(\w+)', line)
@@ -555,11 +559,18 @@ def do_arp_check(interface=None, learn=True):
     verdict: 'spoofed'    -- gateway MAC changed from the trusted baseline
              'suspicious' -- a MAC is impersonating several IPs
              'clean'      -- gateway matches baseline, no impersonators
-             'unknown'    -- no gateway, or its MAC couldn't be resolved"""
-    gw = _default_gateway()
+             'unknown'    -- no gateway, or its MAC couldn't be resolved
+
+    With `interface` set, the check is scoped to that segment: its own default
+    gateway (a higher-metric uplink still counts) and only the neighbours on that
+    interface — the right lens on a multi-homed box."""
+    iface = interface if _valid_iface(interface or '') else None
+    gw = _iface_gateway(iface) if iface else _default_gateway()
     if not gw:
         return {'success': True, 'verdict': 'unknown', 'gateway': None,
-                'reasons': ['no default gateway on this host — nothing to check'],
+                'interface': iface,
+                'reasons': [('no default gateway via %s — nothing to check' % iface)
+                            if iface else 'no default gateway on this host — nothing to check'],
                 'impersonators': [], 'neighbor_count': 0}
 
     gw_mac = _neigh_mac(gw)
@@ -586,7 +597,7 @@ def do_arp_check(interface=None, learn=True):
 
     # One MAC claiming many IPs (attacker impersonating multiple hosts). The
     # gateway MAC is excluded — a router legitimately fronts its own address.
-    entries = _neigh_entries()
+    entries = _neigh_entries(iface)
     mac_ips = {}
     for ip, mac, _ in entries:
         mac_ips.setdefault(mac, set()).add(ip)
@@ -602,7 +613,7 @@ def do_arp_check(interface=None, learn=True):
                            f"({', '.join(ips[:4])}{'…' if len(ips) > 4 else ''}) "
                            '— possible ARP spoofing')
 
-    return {'success': True, 'verdict': verdict,
+    return {'success': True, 'verdict': verdict, 'interface': iface,
             'gateway': {'ip': gw, 'mac': gw_mac, 'baseline': base_mac,
                         'learned': learned},
             'impersonators': impersonators,
@@ -14018,8 +14029,11 @@ def register_network_diagnostics(app, logger=None):
 
     @app.route('/api/net/arp-check', methods=['GET'])
     def net_arp_check():
-        _log("net/arp-check")
-        return jsonify(do_arp_check())
+        iface = (request.args.get('interface') or '').strip() or None
+        if iface is not None and not _valid_iface(iface):
+            return _bad('Invalid interface')
+        _log(f"net/arp-check iface={iface or 'default-route'}")
+        return jsonify(do_arp_check(interface=iface))
 
     @app.route('/api/net/arp-baseline', methods=['GET', 'POST'])
     def net_arp_baseline():

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -13326,7 +13326,7 @@ def do_routing_selftest():
 # correlate(). Both the collector session and the OWD reflector are long-lived
 # daemons, so these managers keep a single instance each with start/stop/status.
 
-_bgp_collector = {'speaker': None, 'events': []}     # correlated asymmetry events
+_bgp_collector = {'speakers': {}, 'events': []}     # name -> BGPSpeaker (multi-carrier)
 _bgp_collector_lock = threading.Lock()
 _owd_reflector = {'reflector': None}
 _owd_lock = threading.Lock()
@@ -13339,46 +13339,81 @@ def _collector_on_update(upd, changed):
     return None
 
 
+def _collector_statuses():
+    return [dict(sp.status(), name=name)
+            for name, sp in _bgp_collector['speakers'].items()]
+
+
 def do_bgp_collector(action='status', peer_ip=None, peer_as=None, local_as=None,
-                     router_id=None, port=179, hold=90):
-    """Manage the receive-only BGP collector session. Actions: start / stop /
-    status / rib. Never advertises a route — it only learns the peer's RIB."""
+                     router_id=None, port=179, hold=90, peers=None, peer=None):
+    """Manage the receive-only BGP collector — MULTI-SESSION: one session per
+    carrier-facing router, each with its own RIB, so a convergence event can name
+    which carrier moved. `peers` is a list of {ip, as, name}; a single peer_ip/
+    peer_as still works (backward compatible). Never advertises a route.
+    Actions: start / stop [peer] / status / rib [peer]."""
     with _bgp_collector_lock:
-        sp = _bgp_collector['speaker']
+        speakers = _bgp_collector['speakers']
         if action == 'start':
-            if sp and sp.state != 'Idle':
-                return {'success': False, 'error': 'collector already running',
-                        'status': sp.status()}
+            plist = list(peers or [])
+            if not plist and peer_ip:
+                plist = [{'ip': peer_ip, 'as': peer_as, 'name': peer_ip}]
+            if not plist:
+                return {'success': False, 'error': 'need peers[] or peer_ip/peer_as'}
             try:
-                ipaddress.ip_address(peer_ip or '')
                 ipaddress.ip_address(router_id or '')
-                peer_as = int(peer_as); local_as = int(local_as)
+                local_as = int(local_as)
                 port = _clamp_int(port, 179, 1, 65535)
                 hold = _clamp_int(hold, 90, 0, 65535)
             except (ValueError, TypeError):
-                return {'success': False, 'error': 'need valid peer_ip, router_id, '
-                        'peer_as, local_as'}
-            if not (0 < peer_as <= 0xFFFFFFFF and 0 < local_as <= 0xFFFFFFFF):
-                return {'success': False, 'error': 'AS numbers out of range'}
-            sp = bgp_speaker.BGPSpeaker(peer_ip, peer_as, local_as, router_id,
-                                        hold_time=hold, port=port,
-                                        on_update=_collector_on_update)
-            sp.start()
-            _bgp_collector['speaker'] = sp
+                return {'success': False, 'error': 'need valid router_id and local_as'}
+            if not (0 < local_as <= 0xFFFFFFFF):
+                return {'success': False, 'error': 'local_as out of range'}
+            started, errs = [], []
+            for pr in plist:
+                pip, pas = pr.get('ip'), pr.get('as')
+                name = str(pr.get('name') or pip)
+                try:
+                    ipaddress.ip_address(pip or '')
+                    pas = int(pas)
+                except (ValueError, TypeError):
+                    errs.append({'peer': name, 'error': 'invalid ip/as'})
+                    continue
+                if not (0 < pas <= 0xFFFFFFFF):
+                    errs.append({'peer': name, 'error': 'as out of range'})
+                    continue
+                ex = speakers.get(name)
+                if ex and ex.state != 'Idle':
+                    started.append(name)
+                    continue                          # already running
+                sp = bgp_speaker.BGPSpeaker(pip, pas, local_as, router_id,
+                                            hold_time=hold, port=port,
+                                            on_update=_collector_on_update)
+                sp.start()
+                speakers[name] = sp
+                started.append(name)
             time.sleep(0.3)
-            return {'success': True, 'status': sp.status()}
+            return {'success': bool(started), 'started': started, 'errors': errs,
+                    'sessions': _collector_statuses()}
         if action == 'stop':
-            if sp:
+            if peer and peer in speakers:
+                speakers[peer].stop()
+                speakers.pop(peer, None)
+                return {'success': True, 'stopped': [peer]}
+            for sp in list(speakers.values()):
                 sp.stop()
-            return {'success': True, 'stopped': True}
+            _bgp_collector['speakers'] = {}
+            return {'success': True, 'stopped': 'all'}
         if action == 'rib':
-            limit = 200
-            return {'success': True,
-                    'rib': sp.rib.snapshot(limit) if sp else {'total': 0, 'routes': []},
-                    'state': sp.state if sp else 'Idle'}
+            per = {name: {'state': sp.state, **{k: sp.rib.snapshot(0)[k]
+                          for k in ('total', 'active', 'flapping')}}
+                   for name, sp in speakers.items()}
+            target_peer = peer if peer in speakers else (
+                next(iter(speakers), None))
+            rib = speakers[target_peer].rib.snapshot(200) if target_peer else {
+                'total': 0, 'routes': []}
+            return {'success': True, 'peer': target_peer, 'peers': per, 'rib': rib}
         # status (default)
-        return {'success': True,
-                'status': sp.status() if sp else {'state': 'Idle', 'peer_ip': None},
+        return {'success': True, 'sessions': _collector_statuses(),
                 'events': _bgp_collector['events'][-20:]}
 
 
@@ -13431,20 +13466,25 @@ def do_path_asymmetry(target, port=path_asymmetry.DEFAULT_PORT, count=20,
         ev = det.add(*s)
         if ev:
             events.append(ev)
-    # correlate events against the live RIB (control-plane truth)
-    rib = None
+    # correlate events against every carrier's live RIB (control-plane truth) —
+    # names which carrier moved for a multi-homed setup.
+    named_ribs = {}
     with _bgp_collector_lock:
-        sp = _bgp_collector['speaker']
-        if sp and sp.state == 'Established':
-            rib = sp.rib
-    correlated = [path_asymmetry.correlate(e, rib) for e in events] if rib else events
+        for name, sp in _bgp_collector['speakers'].items():
+            if sp and sp.state == 'Established':
+                named_ribs[name] = sp.rib
+    if named_ribs:
+        correlated = [path_asymmetry.correlate_multi(e, named_ribs) for e in events]
+    else:
+        correlated = events
     if correlated:
         with _bgp_collector_lock:
             _bgp_collector['events'] = (_bgp_collector['events'] + correlated)[-_COLLECTOR_EVENT_CAP:]
     out = {'success': True, 'target': target, 'port': port,
            'probes_sent': count, 'replies': len(samples),
            'summary': det.summary(), 'events': correlated,
-           'rib_correlation': bool(rib)}
+           'rib_correlation': bool(named_ribs),
+           'carriers': sorted(named_ribs.keys())}
     if not samples:
         out['note'] = ('No reply from the OWD reflector at %s:%d. Run the reflector '
                        'on the target (`python3 path_asymmetry.py reflector %d`) or '
@@ -14427,11 +14467,13 @@ def register_network_diagnostics(app, logger=None):
         action = (data.get('action') or 'status').strip()
         if action not in ('start', 'stop', 'status', 'rib'):
             return _bad('action must be start/stop/status/rib')
-        _log(f"net/bgp-collector {action} peer={data.get('peer_ip')}")
+        _log(f"net/bgp-collector {action} peer={data.get('peer_ip')} "
+             f"peers={len(data.get('peers') or [])}")
         return jsonify(do_bgp_collector(
             action, peer_ip=data.get('peer_ip'), peer_as=data.get('peer_as'),
             local_as=data.get('local_as'), router_id=data.get('router_id'),
-            port=data.get('port', 179), hold=data.get('hold', 90)))
+            port=data.get('port', 179), hold=data.get('hold', 90),
+            peers=data.get('peers'), peer=data.get('peer')))
 
     @app.route('/api/net/owd-reflector', methods=['GET', 'POST'])
     def net_owd_reflector():

--- a/path_asymmetry.py
+++ b/path_asymmetry.py
@@ -280,6 +280,76 @@ def correlate(event, rib):
     return out
 
 
+def correlate_multi(event, named_ribs, window_s=30.0):
+    """Correlate a data-plane event against MULTIPLE carrier RIBs — one BGP
+    session per carrier-facing router. For a multi-homed operator this names
+    *which* carrier's covering prefix churned (confirm) and which are stable, so
+    you know where to open the incident call. Returns the event annotated with a
+    per-carrier breakdown, `carriers_confirmed` / `carriers_stable` lists, an
+    upgraded `verdict`, and a scope hint.
+
+    Scope logic: one carrier moving => churn is in its AS or an upstream peer of
+    it; all covering carriers moving together => upstream of all of them (origin
+    AS or a major shared transit)."""
+    out = dict(event)
+    target = event.get('target')
+    carriers, confirmed, stable, absent = [], [], [], []
+    for name, rib in (named_ribs or {}).items():
+        route = rib.lookup(target) if (rib and target) else None
+        if route is None:
+            carriers.append({'carrier': name, 'status': 'absent'})
+            absent.append(name)
+            continue
+        recent = bool(route['flapping'] or
+                      (route['change_age_s'] is not None and route['change_age_s'] <= window_s))
+        status = 'confirm' if recent else 'stable'
+        carriers.append({'carrier': name, 'status': status, 'prefix': route['prefix'],
+                         'as_path': route['as_path'], 'prev_as_path': route.get('prev_as_path') or [],
+                         'origin_as': route['origin_as'], 'change_age_s': route['change_age_s'],
+                         'flapping': route['flapping'], 'flap_rate': route['flap_rate']})
+        (confirmed if recent else stable).append(name)
+
+    out['carriers'] = carriers
+    out['carriers_confirmed'] = confirmed
+    out['carriers_stable'] = stable
+    covering = confirmed + stable
+
+    if confirmed:
+        out['verdict'] = 'confirmed'
+        tag = []
+        if confirmed:
+            tag.append('%s confirm' % ', '.join(confirmed))
+        if stable:
+            tag.append('%s stable' % ', '.join(stable))
+        detail = []
+        for c in carriers:
+            if c['status'] != 'confirm':
+                continue
+            if c.get('prev_as_path'):
+                detail.append('%s: prefix %s AS-path %s -> %s' % (
+                    c['carrier'], c['prefix'], c['prev_as_path'], c['as_path']))
+            else:
+                detail.append('%s: prefix %s churned %.0fs ago (AS-path %s)' % (
+                    c['carrier'], c['prefix'], c['change_age_s'] or 0, c['as_path']))
+        out['attribution'] = 'confirmed [%s] :: BGP RIB corroborates: %s' % (
+            '; '.join(tag), '; '.join(detail))
+        if len(confirmed) == 1 and len(covering) > 1:
+            out['scope'] = ('single-carrier: churn is in %s or an upstream peer of it'
+                            % confirmed[0])
+        elif len(confirmed) > 1 and len(confirmed) == len(covering):
+            out['scope'] = ('all-carriers: upstream of every carrier — look at the '
+                            'origin AS or a major shared transit')
+        else:
+            out['scope'] = 'multi-carrier: %d of %d covering carriers moved' % (
+                len(confirmed), len(covering))
+    elif covering:
+        out['attribution'] = ('all carriers stable [%s] — asymmetry is data-plane '
+                              '(congestion/TE), not a routing change' % ', '.join(stable))
+    else:
+        out['attribution'] = 'no covering route in any carrier RIB (target off-domain)'
+    return out
+
+
 # --- self-test (no network for the detector; loopback for the wire) --------
 def selftest():
     scen = []
@@ -348,6 +418,41 @@ def selftest():
     hc = passive_hopcount_asymmetry(txt)
     check('passive-hopcount', hc['per_peer_hops'].get('8.8.8.8') == 7
           and hc['per_peer_hops'].get('1.1.1.1') == 5, hc['per_peer_hops'])
+
+    # 5. multi-carrier correlator: Carrier-A's covering prefix just changed its
+    #    AS-path while Carrier-B and Carrier-C stay stable — the event must be
+    #    upgraded to `confirmed` and name Carrier-A as the mover.
+    t0 = time.time()
+    rib_a = bgp_speaker.RIB()
+    rib_a.apply_update({'announced': ['9.9.9.0/24'], 'as_path': [64512, 64520],
+                        'next_hop': '10.0.0.1', 'communities': []}, now=t0 - 300)
+    rib_a.apply_update({'announced': ['9.9.9.0/24'], 'as_path': [64512, 64530],
+                        'next_hop': '10.0.0.1', 'communities': []}, now=t0 - 2)
+    rib_b = bgp_speaker.RIB()
+    rib_b.apply_update({'announced': ['9.9.9.0/24'], 'as_path': [64513, 64540],
+                        'next_hop': '10.0.0.2', 'communities': []}, now=t0 - 3600)
+    rib_c = bgp_speaker.RIB()
+    rib_c.apply_update({'announced': ['9.9.9.0/24'], 'as_path': [64514, 64550],
+                        'next_hop': '10.0.0.3', 'communities': []}, now=t0 - 3600)
+    ev = {'kind': 'asymmetry_detected', 'target': '9.9.9.9', 'asymmetry_ms': 10.0}
+    mc = correlate_multi(ev, {'Carrier-A': rib_a, 'Carrier-B': rib_b, 'Carrier-C': rib_c})
+    check('multi-carrier-confirm',
+          mc['verdict'] == 'confirmed' and mc['carriers_confirmed'] == ['Carrier-A']
+          and set(mc['carriers_stable']) == {'Carrier-B', 'Carrier-C'},
+          '%s conf=%s stable=%s' % (mc.get('verdict'), mc.get('carriers_confirmed'),
+                                    mc.get('carriers_stable')))
+    check('multi-carrier-old-new-path',
+          '[64512, 64520] -> [64512, 64530]' in mc['attribution'], mc['attribution'])
+    check('multi-carrier-scope-single',
+          'single-carrier' in mc.get('scope', ''), mc.get('scope'))
+    # all carriers stable -> not upgraded (data-plane), no false confirm
+    for r in (rib_a, rib_b, rib_c):
+        r.apply_update({'announced': ['9.9.9.0/24'], 'as_path': [1, 2],
+                        'next_hop': '10.0.0.1', 'communities': []}, now=t0 - 3600)
+    stable_ev = correlate_multi(dict(ev), {'Carrier-A': rib_a, 'Carrier-B': rib_b})
+    check('multi-carrier-all-stable-no-confirm',
+          stable_ev.get('verdict') != 'confirmed' and 'all carriers stable' in stable_ev['attribution'],
+          stable_ev.get('attribution'))
 
     return {'success': all(s['pass'] for s in scen), 'scenarios': scen}
 

--- a/python/arp_guard.example.json
+++ b/python/arp_guard.example.json
@@ -1,0 +1,11 @@
+{
+  "garp_window_s": 10.0,
+  "garp_rate_threshold": 5,
+  "garp_breadth_threshold": 4,
+  "flap_window_s": 30.0,
+  "flap_count": 3,
+  "stable_threshold_s": 300.0,
+  "trusted_bindings": {
+    "10.0.0.1": "cc:cc:cc:00:00:0f"
+  }
+}

--- a/python/arp_guard.py
+++ b/python/arp_guard.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""arp_guard.py — layered ARP poisoning / spoofing detector (Ragnar).
+
+Detection only: it never sends a corrective ARP, blocks traffic, or intervenes —
+it watches and alerts. Passive: Scapy is used only as the live-capture front end;
+field extraction is a hand-rolled raw-byte parser (no library dissector), so the
+self-test drives the exact production parse path with no Scapy and no NIC.
+
+A fixed pipeline of four independent, stateful layers scores each observed ARP
+frame; findings about one packet from multiple layers are merged into a single
+alert (highest severity, combined evidence) to avoid alert fatigue during a
+sustained attack.
+
+  1 binding      IP->MAC conflict / rapid flap (arpspoof/ettercap in progress)
+  2 gratuitous   gratuitous-ARP rate to one IP + breadth (subnet-wide poison)
+  3 structural   per-packet field/opcode/consistency sanity (sloppy tooling)
+  4 gateway      trusted IP->MAC pins set out-of-band (gateway impersonation)
+
+Unlike the snapshot-based ARP check in network_diagnostics (which reads the
+resolved neighbour table), this watches the live packet stream, so it sees the
+attack *in progress*. See docs/arp_guard.md.
+"""
+
+import argparse
+import json
+import os
+import struct
+import sys
+import time
+from collections import defaultdict, deque
+
+MODULE = 'arp_guard'
+SEV_RANK = {'info': 0, 'low': 1, 'medium': 2, 'high': 3, 'critical': 4}
+ETH_P_ARP = 0x0806
+ETH_P_8021Q = 0x8100
+BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
+ZERO_IP = '0.0.0.0'
+
+DEFAULTS = {
+    'garp_window_s': 10.0,
+    'garp_rate_threshold': 5,        # gratuitous ARPs to ONE ip in the window
+    'garp_breadth_threshold': 4,     # distinct ips one mac gratuitously claims
+    'flap_window_s': 30.0,
+    'flap_count': 3,                 # binding changes for one ip in the window
+    'stable_threshold_s': 300.0,     # an old binding this stable -> high on change
+    'trusted_bindings': {},          # ip -> mac, pinned OUT OF BAND
+}
+
+
+# ===========================================================================
+# Raw-byte Ethernet + ARP parser
+# ===========================================================================
+def _mac(b, i):
+    return ':'.join('%02x' % x for x in b[i:i + 6])
+
+
+def _ip(b, i):
+    return '%d.%d.%d.%d' % (b[i], b[i + 1], b[i + 2], b[i + 3])
+
+
+def _u16(b, i):
+    return (b[i] << 8) | b[i + 1]
+
+
+def parse_arp(raw):
+    """Parse an Ethernet(/802.1Q) ARP frame into a dict, or None if not ARP.
+    Never raises: a truncated/odd frame is returned with truncated/malformed set
+    so the structural layer can flag it instead of the sniffer dying."""
+    if len(raw) < 14:
+        return None
+    off = 12
+    etype = _u16(raw, 12)
+    if etype == ETH_P_8021Q:
+        if len(raw) < 18:
+            return None
+        off = 16
+        etype = _u16(raw, 16)
+    if etype != ETH_P_ARP:
+        return None
+    a = off + 2
+    d = {'eth_src': _mac(raw, 6), 'eth_dst': _mac(raw, 0),
+         'hwtype': None, 'ptype': None, 'hwlen': None, 'plen': None,
+         'opcode': None, 'sender_mac': None, 'sender_ip': None,
+         'target_mac': None, 'target_ip': None, 'truncated': False,
+         'malformed': None}
+    if len(raw) < a + 8:
+        d['truncated'] = True
+        d['malformed'] = 'ARP header truncated'
+        return d
+    d['hwtype'] = _u16(raw, a)
+    d['ptype'] = _u16(raw, a + 2)
+    d['hwlen'] = raw[a + 4]
+    d['plen'] = raw[a + 5]
+    d['opcode'] = _u16(raw, a + 6)
+    p = a + 8
+    need = p + 2 * d['hwlen'] + 2 * d['plen']
+    if len(raw) < need:
+        d['truncated'] = True
+        d['malformed'] = 'frame shorter than its declared hwlen/plen'
+        return d
+    if d['hwlen'] == 6 and d['plen'] == 4:
+        d['sender_mac'] = _mac(raw, p)
+        d['sender_ip'] = _ip(raw, p + 6)
+        d['target_mac'] = _mac(raw, p + 10)
+        d['target_ip'] = _ip(raw, p + 16)
+    return d
+
+
+def _is_mcast_or_bcast_ip(ip):
+    try:
+        first = int(ip.split('.')[0])
+        return ip == '255.255.255.255' or 224 <= first <= 239
+    except (ValueError, IndexError, AttributeError):
+        return False
+
+
+# ===========================================================================
+# Pipeline
+# ===========================================================================
+class ArpGuard:
+    def __init__(self, config=None, emit=None):
+        c = dict(DEFAULTS)
+        c.update(config or {})
+        self.cfg = c
+        self.emit = emit or (lambda a: None)
+        self.trusted = {k.lower(): v.lower() for k, v in (c.get('trusted_bindings') or {}).items()}
+        # layer 1
+        self._bind = {}                          # ip -> {'mac', 'since', 'flaps': deque}
+        # layer 2
+        self._garp = defaultdict(lambda: deque())    # mac -> deque[(ts, ip)]
+        self.frames = 0
+        self.stats = defaultdict(int)
+
+    @staticmethod
+    def _trim(dq, ts, window, keyed=True):
+        while dq and ts - (dq[0][0] if keyed else dq[0]) > window:
+            dq.popleft()
+
+    def process_packet(self, raw, ts=None):
+        pkt = parse_arp(raw)
+        if pkt is None:
+            return None
+        if ts is None:
+            ts = time.time()
+        self.frames += 1
+        findings = []
+        findings += self._layer3_structural(pkt)
+        # A truncated/malformed frame has no trustworthy addresses; stop after
+        # the structural finding rather than feed junk into the stateful layers.
+        if not pkt.get('malformed'):
+            findings += self._layer4_gateway_trust(pkt, ts)
+            findings += self._layer1_binding(pkt, ts)
+            findings += self._layer2_gratuitous(pkt, ts)
+        if findings:
+            return self._merge_and_emit(pkt, findings, ts)
+        return None
+
+    # -- layer 1: binding conflict / flap ------------------------------------
+    def _layer1_binding(self, pkt, ts):
+        ip, mac = pkt.get('sender_ip'), pkt.get('sender_mac')
+        if not ip or not mac or ip == ZERO_IP:   # 0.0.0.0 = ARP probe, not a claim
+            return []
+        b = self._bind.get(ip)
+        if b is None:
+            self._bind[ip] = {'mac': mac, 'since': ts, 'flaps': deque()}
+            return []
+        if b['mac'] == mac:
+            return []
+        # binding changed
+        stable_for = ts - b['since']
+        b['flaps'].append((ts, mac))
+        self._trim(b['flaps'], ts, self.cfg['flap_window_s'])
+        macs_in_window = {m for _t, m in b['flaps']} | {b['mac']}
+        prev = b['mac']
+        b['mac'], b['since'] = mac, ts
+        if len(b['flaps']) >= self.cfg['flap_count'] and len(macs_in_window) >= 2:
+            return [{'layer': 'binding', 'code': 'binding_flap', 'severity': 'critical',
+                     'detail': '%s is flapping between %d MACs (%d changes/%.0fs) — two '
+                     'hosts racing to answer (active ARP spoofing)'
+                     % (ip, len(macs_in_window), len(b['flaps']), self.cfg['flap_window_s'])}]
+        sev = 'high' if stable_for >= self.cfg['stable_threshold_s'] else 'medium'
+        return [{'layer': 'binding', 'code': 'binding_conflict', 'severity': sev,
+                 'detail': '%s moved from %s to %s (old binding stable %.0fs) — ARP '
+                 'cache poisoning' % (ip, prev, mac, stable_for)}]
+
+    # -- layer 2: gratuitous ARP rate + breadth ------------------------------
+    def _layer2_gratuitous(self, pkt, ts):
+        ip, mac = pkt.get('sender_ip'), pkt.get('sender_mac')
+        # Gratuitous ARP: sender IP == target IP (an unsolicited binding assert).
+        if not ip or not mac or ip == ZERO_IP or pkt.get('target_ip') != ip:
+            return []
+        dq = self._garp[mac]
+        dq.append((ts, ip))
+        self._trim(dq, ts, self.cfg['garp_window_s'])
+        same_ip = sum(1 for _t, i in dq if i == ip)
+        distinct = {i for _t, i in dq}
+        out = []
+        if len(distinct) >= self.cfg['garp_breadth_threshold']:
+            out.append({'layer': 'gratuitous', 'code': 'garp_subnet_poison', 'severity': 'high',
+                        'detail': '%s sent gratuitous ARP for %d distinct IPs in %.0fs — '
+                        'subnet-wide poisoning' % (mac, len(distinct), self.cfg['garp_window_s'])})
+        elif same_ip >= self.cfg['garp_rate_threshold']:
+            out.append({'layer': 'gratuitous', 'code': 'garp_rate_flood', 'severity': 'medium',
+                        'detail': '%s sent %d gratuitous ARPs for %s in %.0fs — targeted '
+                        'poisoning/flood' % (mac, same_ip, ip, self.cfg['garp_window_s'])})
+        return out
+
+    # -- layer 3: structural integrity ---------------------------------------
+    def _layer3_structural(self, pkt):
+        out = []
+
+        def add(sev, code, detail):
+            out.append({'layer': 'structural', 'code': code, 'severity': sev, 'detail': detail})
+
+        if pkt.get('malformed'):
+            add('medium', 'malformed', pkt['malformed'])
+            return out
+        op = pkt.get('opcode')
+        if op not in (1, 2):
+            add('medium', 'bad_opcode', 'invalid ARP opcode %s' % op)
+        if pkt.get('hwtype') != 1:
+            add('low', 'bad_hwtype', 'non-Ethernet hwtype %s' % pkt.get('hwtype'))
+        if pkt.get('ptype') != 0x0800:
+            add('low', 'bad_ptype', 'non-IPv4 ptype 0x%04x' % (pkt.get('ptype') or 0))
+        smac, emac = pkt.get('sender_mac'), pkt.get('eth_src')
+        if smac and emac and smac != emac:
+            add('high', 'src_mismatch',
+                'Ethernet source %s != ARP sender hardware address %s — forged' % (emac, smac))
+        sip = pkt.get('sender_ip')
+        if sip and _is_mcast_or_bcast_ip(sip):
+            add('medium', 'bcast_sender_ip', 'sender IP %s is multicast/broadcast' % sip)
+        if op == 2:                              # reply
+            # A *gratuitous* announcement (sender IP == target IP) is legitimately
+            # broadcast; only a solicited reply to broadcast is anomalous (real
+            # replies are unicast to the requester). Gratuitous-ARP abuse is
+            # caught by the rate/breadth layer, not here.
+            if pkt.get('eth_dst') == BROADCAST_MAC and sip != pkt.get('target_ip'):
+                add('medium', 'broadcast_reply',
+                    'solicited ARP reply sent to broadcast (real replies are unicast)')
+            if sip == ZERO_IP:
+                add('medium', 'zero_reply', 'ARP reply with sender IP 0.0.0.0 (invalid)')
+        # NOTE: opcode 1 (request) with sender 0.0.0.0 is a legitimate ARP probe
+        # (RFC 5227) and is intentionally NOT flagged.
+        return out
+
+    # -- layer 4: trusted-binding pins ---------------------------------------
+    def _layer4_gateway_trust(self, pkt, ts):
+        ip, mac = pkt.get('sender_ip'), pkt.get('sender_mac')
+        if not ip or not mac or ip == ZERO_IP:
+            return []
+        pinned = self.trusted.get(ip.lower())
+        if pinned and mac.lower() != pinned:
+            return [{'layer': 'gateway', 'code': 'trusted_impersonation', 'severity': 'critical',
+                     'detail': 'pinned host %s (trusted %s) is being claimed by %s — '
+                     'gateway/host impersonation' % (ip, pinned, mac)}]
+        return []
+
+    # -- merge ---------------------------------------------------------------
+    def _merge_and_emit(self, pkt, findings, ts):
+        worst = max(findings, key=lambda f: SEV_RANK[f['severity']])
+        alert = {
+            'ts': ts, 'module': MODULE, 'severity': worst['severity'],
+            'sender_ip': pkt.get('sender_ip'), 'sender_mac': pkt.get('sender_mac'),
+            'eth_src': pkt.get('eth_src'), 'opcode': pkt.get('opcode'),
+            'codes': [f['code'] for f in findings],
+            'summary': worst['detail'],
+            'evidence': [{'layer': f['layer'], 'code': f['code'],
+                          'severity': f['severity'], 'detail': f['detail']}
+                         for f in sorted(findings, key=lambda f: -SEV_RANK[f['severity']])],
+        }
+        self.stats[worst['severity']] += 1
+        self.emit(alert)
+        return alert
+
+
+# ===========================================================================
+# Passive gateway learning (reads the kernel neighbour table — no packet sent)
+# ===========================================================================
+def learn_gateway(gateway_ip):
+    """Return the gateway's MAC from /proc/net/arp (already-resolved by the
+    kernel). Passive: sends nothing. Ping the gateway once if there's no entry."""
+    try:
+        with open('/proc/net/arp') as f:
+            for line in f.readlines()[1:]:
+                parts = line.split()
+                if len(parts) >= 4 and parts[0] == gateway_ip and parts[3] != '00:00:00:00:00:00':
+                    return parts[3]
+    except OSError:
+        pass
+    return None
+
+
+# ===========================================================================
+# Live capture / replay (scapy, lazy)
+# ===========================================================================
+def run_live(iface, guard):
+    from scapy.all import sniff
+    sys.stderr.write('arp_guard: passive on %s (arp) — Ctrl-C to stop\n' % iface)
+    sniff(iface=iface, filter='arp or vlan', store=False,
+          prn=lambda p: guard.process_packet(bytes(p), float(getattr(p, 'time', 0)) or time.time()))
+
+
+def run_replay(path, guard):
+    from scapy.all import PcapReader
+    with PcapReader(path) as pr:
+        for p in pr:
+            guard.process_packet(bytes(p), float(getattr(p, 'time', 0)) or time.time())
+
+
+# ===========================================================================
+# CLI
+# ===========================================================================
+def make_emitter(out_fh, echo):
+    def emit(a):
+        line = json.dumps(a)
+        if out_fh:
+            out_fh.write(line + '\n')
+            out_fh.flush()
+        if echo:
+            sys.stderr.write('  !! [%s] %s %s :: %s\n' % (
+                a['severity'], a.get('sender_ip') or '?', ','.join(a['codes']), a['summary']))
+    return emit
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog='arp_guard',
+                                 description='Passive layered ARP poisoning detector (detection-only).')
+    ap.add_argument('-i', '--iface', help='live capture interface')
+    ap.add_argument('--replay', help='replay a pcap instead of live capture')
+    ap.add_argument('-c', '--config', help='JSON config (thresholds + trusted_bindings)')
+    ap.add_argument('--jsonl', '-o', help="JSON-lines output path ('-' = stdout)")
+    ap.add_argument('--echo', action='store_true', help='echo alerts to stderr')
+    ap.add_argument('--learn-gateway', action='store_true',
+                    help='print the gateway MAC from the kernel neighbour table (passive)')
+    ap.add_argument('--gateway-ip', help='gateway IP for --learn-gateway')
+    ap.add_argument('--self-test', action='store_true')
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        import arp_guard_selftest
+        return arp_guard_selftest.run(verbose=True)
+    if args.learn_gateway:
+        if not args.gateway_ip:
+            ap.error('--learn-gateway needs --gateway-ip')
+        mac = learn_gateway(args.gateway_ip)
+        if mac:
+            print('%s is at %s  (copy into trusted_bindings)' % (args.gateway_ip, mac))
+            return 0
+        sys.stderr.write('no neighbour entry for %s — ping it once, then retry\n' % args.gateway_ip)
+        return 1
+
+    cfg = {}
+    if args.config:
+        with open(args.config) as f:
+            cfg = json.load(f)
+    out_fh = sys.stdout if args.jsonl == '-' else (
+        open(args.jsonl, 'a') if args.jsonl else None)
+    guard = ArpGuard(cfg, emit=make_emitter(out_fh, args.echo or not args.jsonl))
+
+    if args.replay:
+        run_replay(args.replay, guard)
+    elif args.iface:
+        if os.geteuid() != 0:
+            sys.stderr.write('error: live capture needs root / CAP_NET_RAW.\n')
+            return 2
+        try:
+            run_live(args.iface, guard)
+        except KeyboardInterrupt:
+            pass
+    else:
+        ap.error('one of --iface, --replay, --learn-gateway or --self-test is required')
+    sys.stderr.write('arp_guard: %d frames, alerts %s\n' % (guard.frames, dict(guard.stats)))
+    if out_fh and out_fh is not sys.stdout:
+        out_fh.close()
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/python/arp_guard_selftest.py
+++ b/python/arp_guard_selftest.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""arp_guard_selftest.py — offline self-test (no root, no Scapy, no NIC).
+
+Builds raw Ethernet+ARP frame bytes in pure Python and feeds them straight into
+ArpGuard.process_packet() — the exact path the live sniffer uses. Includes
+negative controls (baseline traffic, a legit ARP probe, a truncated frame) that
+must NOT alert or crash. Run via `python3 arp_guard.py --self-test`.
+"""
+
+import struct
+import sys
+
+import arp_guard as ag
+
+
+def _macb(s):
+    return bytes(int(x, 16) for x in s.split(':'))
+
+
+def _ipb(s):
+    return bytes(int(x) for x in s.split('.'))
+
+
+def arp(opcode, sender_mac, sender_ip, target_mac, target_ip,
+        eth_src=None, eth_dst='ff:ff:ff:ff:ff:ff', hwtype=1, ptype=0x0800,
+        hwlen=6, plen=4, trunc=None):
+    eth_src = eth_src or sender_mac
+    frame = _macb(eth_dst) + _macb(eth_src) + struct.pack('!H', ag.ETH_P_ARP)
+    frame += struct.pack('!HHBBH', hwtype, ptype, hwlen, plen, opcode)
+    frame += _macb(sender_mac) + _ipb(sender_ip) + _macb(target_mac) + _ipb(target_ip)
+    if trunc is not None:
+        frame = frame[:trunc]
+    return frame
+
+
+REQ, REPLY = 1, 2
+A_MAC, B_MAC, GW_MAC, ATT_MAC = ('aa:aa:aa:00:00:01', 'bb:bb:bb:00:00:02',
+                                 'cc:cc:cc:00:00:0f', 'de:ad:be:ef:00:99')
+
+
+class H:
+    def __init__(self, verbose):
+        self.n = self.fail = 0
+        self.verbose = verbose
+
+    def ck(self, name, cond):
+        self.n += 1
+        if not cond:
+            self.fail += 1
+        if self.verbose:
+            print('  [%s] %s' % ('PASS' if cond else 'FAIL', name))
+
+
+def _guard(cfg=None):
+    alerts = []
+    return ag.ArpGuard(cfg or {}, emit=alerts.append), alerts
+
+
+def run(verbose=True):
+    h = H(verbose)
+
+    # 1. baseline traffic is silent: a normal request + unicast reply.
+    g, al = _guard()
+    g.process_packet(arp(REQ, A_MAC, '10.0.0.5', '00:00:00:00:00:00', '10.0.0.1'), ts=1)
+    g.process_packet(arp(REPLY, GW_MAC, '10.0.0.1', A_MAC, '10.0.0.5',
+                         eth_dst=A_MAC), ts=1.1)
+    h.ck('baseline traffic is silent', not al)
+
+    # 2. a legitimate ARP probe (opcode 1, sender 0.0.0.0) must NOT alert.
+    g, al = _guard()
+    g.process_packet(arp(REQ, A_MAC, '0.0.0.0', '00:00:00:00:00:00', '10.0.0.77'), ts=1)
+    h.ck('legit ARP probe is silent', not al)
+
+    # 3. gateway impersonation (trusted pin) -> CRITICAL.
+    g, al = _guard({'trusted_bindings': {'10.0.0.1': GW_MAC}})
+    g.process_packet(arp(REPLY, ATT_MAC, '10.0.0.1', A_MAC, '10.0.0.5', eth_dst=A_MAC), ts=1)
+    h.ck('gateway impersonation -> critical',
+         al and al[0]['severity'] == 'critical' and 'trusted_impersonation' in al[0]['codes'])
+
+    # 4. subnet-wide gratuitous-ARP flood (one MAC, many IPs) -> breadth.
+    g, al = _guard({'garp_breadth_threshold': 4})
+    for i in range(1, 6):
+        ipx = '10.0.0.%d' % i
+        g.process_packet(arp(REPLY, ATT_MAC, ipx, ATT_MAC, ipx), ts=1 + i * 0.1)
+    h.ck('subnet-wide GARP flood -> breadth',
+         any('garp_subnet_poison' in a['codes'] for a in al))
+
+    # 5. single-target gratuitous-ARP rate flood.
+    g, al = _guard({'garp_rate_threshold': 5, 'garp_breadth_threshold': 99})
+    for i in range(6):
+        g.process_packet(arp(REPLY, ATT_MAC, '10.0.0.1', ATT_MAC, '10.0.0.1'), ts=1 + i * 0.1)
+    h.ck('single-target GARP rate flood',
+         any('garp_rate_flood' in a['codes'] for a in al))
+
+    # 6. Ethernet-source vs ARP-sender-hardware mismatch.
+    g, al = _guard()
+    g.process_packet(arp(REPLY, A_MAC, '10.0.0.5', B_MAC, '10.0.0.9',
+                         eth_src=ATT_MAC, eth_dst=B_MAC), ts=1)
+    h.ck('eth/arp source mismatch -> high',
+         al and 'src_mismatch' in al[0]['codes'] and al[0]['severity'] == 'high')
+
+    # 7. broadcast reply anomaly (opcode 2 to ff:ff:ff:ff:ff:ff).
+    g, al = _guard()
+    g.process_packet(arp(REPLY, A_MAC, '10.0.0.5', B_MAC, '10.0.0.9',
+                         eth_dst='ff:ff:ff:ff:ff:ff'), ts=1)
+    h.ck('broadcast reply flagged', al and 'broadcast_reply' in al[0]['codes'])
+
+    # 8. invalid 0.0.0.0 reply.
+    g, al = _guard()
+    g.process_packet(arp(REPLY, A_MAC, '0.0.0.0', B_MAC, '10.0.0.9', eth_dst=B_MAC), ts=1)
+    h.ck('invalid 0.0.0.0 reply flagged', al and 'zero_reply' in al[0]['codes'])
+
+    # 9. rapid MAC flapping (one IP bounces between two MACs).
+    g, al = _guard({'flap_count': 3})
+    macs = [A_MAC, ATT_MAC, A_MAC, ATT_MAC]
+    for i, m in enumerate(macs):
+        g.process_packet(arp(REPLY, m, '10.0.0.5', B_MAC, '10.0.0.9', eth_dst=B_MAC), ts=1 + i)
+    h.ck('rapid MAC flapping -> critical',
+         any(a['severity'] == 'critical' and 'binding_flap' in a['codes'] for a in al))
+
+    # 10. a frame truncated shorter than its declared field lengths: no crash,
+    #     flagged malformed, and the stateful layers are NOT fed junk.
+    g, al = _guard()
+    try:
+        r = g.process_packet(arp(REPLY, A_MAC, '10.0.0.5', B_MAC, '10.0.0.9', trunc=30), ts=1)
+        h.ck('truncated frame handled (malformed, no crash)',
+             r is not None and 'malformed' in r['codes'])
+    except Exception:
+        h.ck('truncated frame handled (malformed, no crash)', False)
+    h.ck('truncated frame did not poison binding table', not g._bind)
+
+    # extra: a stable binding conflict (not flapping) is medium/high, and a
+    # non-ARP frame returns None.
+    g, al = _guard({'stable_threshold_s': 100})
+    g.process_packet(arp(REPLY, A_MAC, '10.0.0.5', B_MAC, '10.0.0.9', eth_dst=B_MAC), ts=1)
+    g.process_packet(arp(REPLY, ATT_MAC, '10.0.0.5', B_MAC, '10.0.0.9', eth_dst=B_MAC), ts=500)
+    h.ck('long-stable binding change -> high',
+         any('binding_conflict' in a['codes'] and a['severity'] == 'high' for a in al))
+    h.ck('non-ARP frame -> None',
+         ag.parse_arp(_macb('11:22:33:44:55:66') * 2 + b'\x08\x00' + b'\x00' * 30) is None)
+    # gratuitous single announce (normal, e.g. after DHCP) must stay silent
+    g, al = _guard()
+    g.process_packet(arp(REPLY, A_MAC, '10.0.0.5', A_MAC, '10.0.0.5', eth_dst='ff:ff:ff:ff:ff:ff'), ts=1)
+    h.ck('single gratuitous announce is silent', not al)
+
+    total = h.n
+    passed = total - h.fail
+    print('arp_guard self-test: %d/%d %s' % (passed, total, 'OK' if h.fail == 0 else 'FAILED'))
+    return 0 if h.fail == 0 else 1
+
+
+if __name__ == '__main__':
+    sys.exit(run(verbose=True))

--- a/scripts/arp-guard.service
+++ b/scripts/arp-guard.service
@@ -1,0 +1,51 @@
+[Unit]
+# Ragnar arp_guard — dedicated passive layered ARP-poisoning monitor.
+# OPT-IN. Runs arp_guard.py on the segment interface, RX-only — it never sends a
+# corrective ARP or any packet. Granted CAP_NET_RAW + CAP_NET_ADMIN (raw capture
+# + promiscuous) and nothing else.
+#   sudo useradd --system --no-create-home --shell /usr/sbin/nologin arpmon
+#   sudo mkdir -p /var/log/arp-guard && sudo chown arpmon:arpmon /var/log/arp-guard
+#   sudo install -Dm644 python/arp_guard.example.json /etc/ragnar/arp_guard.json
+#   sudo cp scripts/arp-guard.service /etc/systemd/system/
+#   sudoedit /etc/systemd/system/arp-guard.service   # set RAGNAR_ARP_IFACE
+#   sudo systemctl enable --now arp-guard
+#   journalctl -u arp-guard -f
+Description=Ragnar arp_guard passive ARP-poisoning monitor
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=arpmon
+Group=arpmon
+WorkingDirectory=/home/ragnar/Ragnar/python
+Environment=RAGNAR_ARP_IFACE=eth0
+ExecStartPre=/bin/mkdir -p /var/log/arp-guard
+ExecStart=/usr/bin/python3 /home/ragnar/Ragnar/python/arp_guard.py \
+    -i ${RAGNAR_ARP_IFACE} -c /etc/ragnar/arp_guard.json \
+    --jsonl /var/log/arp-guard/alerts.jsonl
+Restart=on-failure
+RestartSec=5
+
+# --- least privilege: sniff only ------------------------------------------
+AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN
+NoNewPrivileges=yes
+RestrictAddressFamilies=AF_PACKET AF_UNIX
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/var/log/arp-guard
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+MemoryDenyWriteExecute=yes
+LockPersonality=yes
+MemoryMax=128M
+
+[Install]
+WantedBy=multi-user.target

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -1407,6 +1407,9 @@
                         <p class="text-xs text-amber-300/90 mb-2">Checks for ARP spoofing / MITM — the default gateway's MAC changed from the trusted baseline, or one MAC answering for many IPs (subnet impersonation).</p>
                         <p class="text-sm text-gray-400 mb-3">Reads the kernel neighbour table (no capture). The first check learns the gateway's MAC as the trusted baseline; after a legitimate router change, click "Trust current gateway" to re-learn it.</p>
                         <div class="flex flex-wrap gap-2">
+                            <select id="arp-check-iface" onfocus="_arpFillIfaces()" title="Interface to check — scopes to that segment's gateway + neighbours (for a multi-homed box); Auto uses the default route" class="w-full sm:w-auto bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-gray-300">
+                                <option value="">Auto (default route)</option>
+                            </select>
                             <button onclick="runArpCheck()" class="w-full sm:w-auto bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Check ARP</button>
                             <button onclick="netIntegrityTrustGateway()" class="w-full sm:w-auto bg-slate-700 hover:bg-slate-600 text-gray-200 px-4 py-2 rounded text-sm whitespace-nowrap" title="Set the current gateway MAC as the trusted baseline — use after a legitimate router/gateway change">Trust current gateway</button>
                         </div>
@@ -6609,7 +6612,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260716-wifi-la"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260716-arp-iface"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -4471,15 +4471,32 @@ const _ARP_VERDICT_STYLE = {
     spoofed:    ['bg-red-950/60 border-red-800 text-red-300', '🛑 ARP spoofing / MITM detected'],
     unknown:    ['bg-slate-800 border-slate-700 text-slate-400', '— Could not determine (no gateway / no ARP reply)'],
 };
+function _arpFillIfaces() {
+    const sel = document.getElementById('arp-check-iface');
+    if (!sel || sel.dataset.filled === '1') return Promise.resolve();
+    return fetchAPI('/api/net/interfaces').then(x => {
+        (x.interfaces || []).forEach(i => {
+            const o = document.createElement('option');
+            o.value = i.name;
+            const tag = i.type === 'wifi' ? ' (WiFi)' : i.type === 'ethernet' ? ' (LAN)' : (i.type ? ' (' + i.type + ')' : '');
+            o.textContent = i.name + tag;
+            sel.appendChild(o);
+        });
+        sel.dataset.filled = '1';
+    }).catch(() => {});
+}
 async function runArpCheck() {
     const out = document.getElementById('arp-results');
     if (!out) return;
     const btn = (typeof event !== 'undefined' && event && event.target) ? event.target : null;
+    const ifaceSel = document.getElementById('arp-check-iface');
+    const iface = ifaceSel && ifaceSel.value ? ifaceSel.value : '';
     _ndBusy(btn, true, 'Checking…');
     out.classList.remove('hidden');
     out.innerHTML = '<p class="text-sm text-gray-400">Reading neighbour table…</p>';
     try {
-        const d = await fetchAPI('/api/net/arp-check');
+        _arpFillIfaces();
+        const d = await fetchAPI('/api/net/arp-check' + (iface ? '?interface=' + encodeURIComponent(iface) : ''));
         if (!d || d.success === false) {
             out.innerHTML = '<p class="text-sm text-red-400">Error: ' + escapeHtml((d && d.error) || 'failed') + '</p>';
             return;
@@ -4489,6 +4506,7 @@ async function runArpCheck() {
         const mismatch = gw.baseline && gw.mac && gw.baseline !== gw.mac;
         let html = `<div class="mb-2 px-3 py-2 rounded border ${cls} text-sm">${label}</div>`;
         html += '<table class="min-w-full text-sm text-gray-300 whitespace-nowrap"><tbody>' +
+            `<tr class="border-t border-slate-800"><td class="px-3 py-1.5 text-gray-500">Interface</td><td class="px-3 py-1.5 font-mono">${escapeHtml(d.interface || 'default route')}</td></tr>` +
             `<tr class="border-t border-slate-800"><td class="px-3 py-1.5 text-gray-500">Gateway</td><td class="px-3 py-1.5 font-mono">${escapeHtml(gw.ip || '—')}</td></tr>` +
             `<tr class="border-t border-slate-800"><td class="px-3 py-1.5 text-gray-500">Current MAC</td><td class="px-3 py-1.5 font-mono ${mismatch ? 'text-red-400' : ''}">${escapeHtml(gw.mac || '—')}</td></tr>` +
             `<tr class="border-t border-slate-800"><td class="px-3 py-1.5 text-gray-500">Trusted MAC</td><td class="px-3 py-1.5 font-mono">${escapeHtml(gw.baseline || '—')}${gw.learned ? ' <span class="text-xs text-gray-500">(learned now)</span>' : ''}</td></tr>` +


### PR DESCRIPTION
This pull request introduces several important enhancements and fixes across the ARP poisoning detection, BGP collector, and OSPF parsing subsystems. The main themes are improved multi-homing and multi-carrier support, more robust protocol parsing, and the addition of a new layered ARP guard tool. These changes increase diagnostic accuracy, flexibility, and resilience against real-world network attacks.

**ARP Poisoning Detection and Interface Scoping:**

* The ARP check (`do_arp_check`) now supports scoping to a specific interface, using that segment's default gateway and neighbor table for more accurate results on multi-homed hosts. The verdict output and neighbor analysis are all correctly limited to the selected interface. [[1]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL490-R496) [[2]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL558-R573) [[3]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL589-R600) [[4]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL605-R616)
* The documentation is updated to explain interface scoping and to introduce and describe the new standalone `arp_guard` tool, which performs layered, passive ARP spoofing detection with JSON-line alerts and hardened daemon support. [[1]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaL329-R345) [[2]](diffhunk://#diff-4c588bc343619b8b7a834d5d06c89bca29f8cfc626d2856b16bdab77c4f274cbR1-R100)

**BGP Collector Multi-Carrier and Correlator Improvements:**

* The BGP collector now supports multi-carrier operation, running one session per carrier-facing router. The correlator produces per-carrier breakdowns, showing which carrier moved during a convergence/asymmetry event, and includes previous AS-path tracking for more precise attribution. Documentation and API endpoints are updated accordingly. [[1]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaL1707-R1730) [[2]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaL1721-R1760) [[3]](diffhunk://#diff-5c3c7a25837a990bf6ffe3817c33c7281e0c570964826baed5e246ec463d5769L252-R254) [[4]](diffhunk://#diff-5c3c7a25837a990bf6ffe3817c33c7281e0c570964826baed5e246ec463d5769R271-R274) [[5]](diffhunk://#diff-5c3c7a25837a990bf6ffe3817c33c7281e0c570964826baed5e246ec463d5769R325) [[6]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL13297-R13340)

**OSPF Parsing Robustness and Regression Guard:**

* OSPF parsing logic is improved to correctly associate sequence/age/advertising-router metadata with LSA headers, handling both real tcpdump and self-test formats. A regression test is added to ensure no ghost LSAs are created and sequence numbers are parsed from real captures. [[1]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaR12127-R12135) [[2]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL12135-R12176) [[3]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL12495-R12553)

These changes collectively improve the toolset's accuracy, extensibility, and resilience for real-world, multi-homed, and multi-carrier environments.