### PR TITLE
installer: fix stall after iputils-ping — debconf prompt in iperf3 bl…

### DIFF
--- a/install_ragnar.sh
+++ b/install_ragnar.sh
@@ -186,7 +186,9 @@ detect_platform() {
         debian|ubuntu|raspbian)
             PKG_MGR="apt"
             UPDATE_CMD="apt-get update -y"
-            INSTALL_CMD="apt-get install -y"
+            # noninteractive: packages like iperf3 ask debconf questions that
+            # block forever when output is redirected (-y does not answer them)
+            INSTALL_CMD="DEBIAN_FRONTEND=noninteractive apt-get install -y"
             PKG_PRESENT_CMD="dpkg -s"
             ;;
         fedora|rhel|centos|rocky|almalinux)
@@ -210,7 +212,7 @@ detect_platform() {
         *)
             PKG_MGR="apt"
             UPDATE_CMD="apt-get update -y"
-            INSTALL_CMD="apt-get install -y"
+            INSTALL_CMD="DEBIAN_FRONTEND=noninteractive apt-get install -y"
             PKG_PRESENT_CMD="dpkg -s"
             log "WARNING" "Unknown distro; defaulting to apt commands"
             ;;


### PR DESCRIPTION
…ocked apt

apt-get install -y still lets debconf ask questions (iperf3 on Raspberry Pi OS bookworm asks whether to start the daemon), and with installer output redirected to /dev/null the hidden prompt blocked forever. Run apt installs with DEBIAN_FRONTEND=noninteractive, same as update_ragnar.sh already does.