### PR TITLE
Ndp

### DIFF
--- a/docs/ndpwatch.md
+++ b/docs/ndpwatch.md
@@ -1,0 +1,101 @@
+# ndpwatch — passive IPv6 Neighbor Discovery attack monitor
+
+`ndpwatch` (`python/ndpwatch.py`) is the **IPv6 counterpart to
+[arp_guard](arp_guard.md)**. IPv6 has no ARP — hosts resolve neighbours and
+discover routers via ICMPv6 **Neighbor Discovery** (RS/RA/NS/NA/Redirect) — and
+the same MITM threat model maps over:
+
+| ARP attack | NDP equivalent |
+|---|---|
+| ARP-reply spoofing (poison IP→MAC) | **NA spoofing** (parasite6) — poison the neighbour cache |
+| gateway impersonation | **rogue RA** (fake_router6) — advertise yourself as the router / inject a SLAAC prefix |
+| gratuitous-ARP flood | **RA / prefix / NS flood** (flood_router6) |
+| — | **DAD DoS** (defend every tentative address), **spoofed ICMPv6 Redirect** |
+
+**Detection only** — it never sends an ND packet or corrects anything. **Passive:**
+Scapy is only the live-capture front end; field extraction is a hand-rolled
+**raw-byte parser** (Ethernet → IPv6 → ICMPv6 ND + options), so `--self-test` and
+pcap `--replay` need no NIC/IPv6 kernel and the self-test needs no Scapy.
+
+- **Test floor:** Raspberry Pi Zero 2 W.
+- **Self-test:** 24/24 (`python3 python/ndpwatch.py --self-test`).
+- **Deps:** Python 3.8+, Scapy (live capture only).
+
+## Findings (stable codes)
+
+| Code | Sev | Fires when |
+|---|---|---|
+| `NDP-001` | critical | NA overriding a learned neighbour binding (cache poison) |
+| `NDP-002` | high | override-flag NA flood for one target (active poisoning) |
+| `NDP-003` | critical | target IPv6 flapping between MACs (two hosts racing) |
+| `NDP-004` | medium | NA Router (R) flag inconsistent for a host/router |
+| `NDP-005` | high | ND link-layer option ≠ Ethernet source (forged) |
+| `NDP-006` | critical | RA from a router not in the trusted set (rogue gateway) |
+| `NDP-007` | high | trusted gateway RA with router-lifetime 0 (kill default route) |
+| `NDP-008` | high | RA advertises a prefix outside the baseline (SLAAC hijack) |
+| `NDP-009` | high | RA router-preference High from an untrusted source |
+| `NDP-010` | high | RA RDNSS (DNS) option from an untrusted router (DNS hijack) |
+| `NDP-011` | medium | RA MTU implausibly low / changed (PMTU blackhole) |
+| `NDP-012` | high | Router Advertisement flood |
+| `NDP-013` | medium | one source soliciting many distinct targets (NS sweep) |
+| `NDP-014` | high | answering NS for tentative (DAD) addresses (DAD DoS) |
+| `NDP-015` | medium | Router Solicitation flood |
+| `NDP-016` | high | ICMPv6 Redirect not from the first-hop router (spoofed) |
+| `NDP-017` | high | ND with IPv6 Hop Limit ≠ 255 (off-link injection) |
+| `NDP-018` | medium | malformed / truncated ND message |
+| `NDP-019` | high | distinct-target flood approaching `neigh_max` (table pressure) |
+| `NDP-020` | high | a router link-local speaking ND that is not the pinned gateway |
+
+Findings from multiple codes about one packet are **merged into a single alert**
+(highest severity + `evidence[]`) — a rogue RA typically fires
+NDP-006/008/009/010/020 at once. `NDP-017` (Hop Limit 255) is the ND analog of
+arp_guard's structural checks: RFC 4861 requires ND to arrive at Hop Limit 255,
+so anything else is off-link injection.
+
+## Run
+
+```bash
+python3 python/ndpwatch.py --self-test                  # 24/24, no root/Scapy/IPv6
+sudo python3 python/ndpwatch.py -i eth0 --echo          # live, echo to stderr
+sudo python3 python/ndpwatch.py -i eth0 -c ndpwatch.json --jsonl /var/log/ndpwatch/alerts.jsonl
+python3 python/ndpwatch.py --replay attack.pcap --echo  # replay a capture (no NIC)
+```
+
+The rogue-RA / NDP-006/007/008/016/020 detectors need a **trusted set** — pin your
+real routers (link-local + MAC) in `trusted_routers` and their SLAAC prefixes in
+`trusted_prefixes`. Pin **out of band** (from the router/controller), not
+auto-learned at boot: if an attacker is already active, auto-learning blesses
+them. Without a trusted set, the flood/structural/binding detectors still work.
+
+## Alerts
+
+One JSON object per line: `ts`, `module`, `severity`, `type` (RS/RA/NS/NA/
+Redirect), `src`, `eth_src`, `target`, `codes[]`, `summary`, `evidence[]`.
+
+## systemd
+
+`scripts/ndpwatch.service` runs as a dedicated non-root `ndpmon` user with only
+`CAP_NET_RAW`/`CAP_NET_ADMIN`, `ProtectSystem=strict`, `MemoryMax=128M`; alerts
+land in `/var/log/ndpwatch/alerts.jsonl`.
+
+## Validation lab
+
+`ndpwatch-lab.sh` (+ `ndp_inject.py`, `conftest_packets.py`) builds a
+network-namespace topology with a real RA daemon and kernel SLAAC/DAD, then runs
+learn → benign (must stay silent) → attack (drives the live capture path). It
+needs **IPv6 in the kernel**, so run it on the Pi or a privileged host — not a CI
+container with IPv6 compiled out. The offline conformance harness feeds the
+injector's exact packets through ndpwatch's parser with no interface.
+
+## Relation to the integrated NDP Watch
+
+Ragnar also has an integrated **NDP Watch** (`do_ndp_watch` in
+`network_diagnostics.py`) — a short tcpdump capture classified into the suite
+verdict ladder, wired into the web UI and the Network Integrity Monitor.
+`ndpwatch` is the standalone continuous daemon: a raw-byte parser, 20 coded
+findings with merged alerts, JSON-lines, pcap replay, and a hardened unit.
+
+## Same-broadcast-domain only
+
+Like ARP/ND itself, it sees only what reaches its interface — the attack traffic,
+the victim, or a SPAN/mirror. Place it accordingly.

--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -1109,6 +1109,13 @@ parse checks), and — when [Scapy](https://scapy.net) is installed — crafts a
 Neighbor Advertisement (with the target link-layer address option) into a pcap and
 parses it back through `tcpdump -e`, exercising the capture→parse path end to end.
 
+For a **standalone continuous daemon** — the IPv6 counterpart to
+[arp_guard](arp_guard.md), with a raw-byte ND parser, **20 coded findings**
+(`NDP-001…020`: NA cache-poison/flap, rogue-RA, prefix/RDNSS hijack,
+router-preference, RA/RS/NS floods, DAD-DoS, spoofed Redirect, hop-limit-≠-255,
+…) merged per packet, JSON-lines, and pcap `--replay` — see
+[ndpwatch](ndpwatch.md) (`python/ndpwatch.py`).
+
 - Endpoint: `GET /api/net/ndp-watch` `{interface, seconds}`,
   `POST /api/net/ndp-baseline` `{action: reset}` · binary: `tcpdump`
 

--- a/ndpwatch-lab.sh
+++ b/ndpwatch-lab.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# ndpwatch-lab.sh — network-namespace validation lab for ndpwatch, mirroring the
+# FRR labs used for isiswatch / eigrpwatch / ospfwatch.
+#
+#   ndp-gw (radvd/FRR)  ndp-vic (kernel SLAAC)  ndp-atk (inject)  ndp-mon (ndpwatch)
+#         gw0 ─┐            vic0 ─┐                 atk0 ─┐           mon0 ─┐
+#              └────────────── bridge ndp-br0 (root ns, snooping off) ──────┘
+#
+# One bridge in the root ns with multicast snooping OFF, so all ND multicast
+# floods to the monitor — a SPAN-like passive tap (also how you'd deploy for
+# real). No uplink; nothing routes off it. NEEDS IPv6 IN THE KERNEL — run on the
+# Pi or a privileged host/VM, not a CI container with IPv6 compiled out.
+#
+# Validates what the self-tests cannot: the FALSE-POSITIVE GATE (a real RA daemon
+# + genuine kernel SLAAC/DAD must make ndpwatch emit NOTHING) and the LIVE
+# CAPTURE PATH (real sniff -> parse -> icmp6 BPF -> promiscuous multicast rx).
+set -u
+
+BR=ndp-br0
+REPO="$(cd "$(dirname "$0")" && pwd)"
+NDPWATCH="${NDPWATCH:-$REPO/python/ndpwatch.py}"
+INJECT="$REPO/python/ndp_inject.py"
+GW_RA_DAEMON="${GW_RA_DAEMON:-radvd}"        # radvd | frr
+NODES=(gw vic atk mon)
+GW_LLA="fe80::1"; GW_MAC="02:00:00:00:00:01"; PREFIX="2001:db8:0:1::/64"
+LABDIR=/run/ndpwatch-lab
+CFG=/run/ndpwatch-lab/ndpwatch.json
+CAP=/run/ndpwatch-lab/mon.jsonl
+
+die()  { echo "error: $*" >&2; exit 1; }
+info() { echo ">> $*"; }
+need_root() { [ "$(id -u)" -eq 0 ] || die "must run as root (netns + IPv6 need CAP_NET_ADMIN)"; }
+check_ipv6() { [ -e /proc/net/if_inet6 ] || die "kernel IPv6 is disabled — run on a host with IPv6"; }
+
+do_setup() {
+    need_root; check_ipv6
+    ip link show "$BR" >/dev/null 2>&1 && die "lab already up? run '$0 teardown' first"
+    command -v scapy >/dev/null 2>&1 || python3 -c 'import scapy' 2>/dev/null || \
+        die "python3-scapy required (pip install scapy)"
+    mkdir -p "$LABDIR"
+    info "bridge $BR (multicast snooping off) + netns ${NODES[*]}"
+    ip link add "$BR" type bridge
+    echo 0 > "/sys/class/net/$BR/bridge/multicast_snooping" 2>/dev/null || true
+    ip link set "$BR" up
+    for node in "${NODES[@]}"; do
+        ip netns add "ndp-$node"
+        ip link add "${node}0" netns "ndp-$node" type veth peer name "${node}-br"
+        ip link set "${node}-br" master "$BR"; ip link set "${node}-br" up
+        ip -n "ndp-$node" link set lo up
+        ip -n "ndp-$node" link set "${node}0" up
+    done
+    # Pin the gateway identity so the learned baseline + injector agree.
+    ip -n ndp-gw link set gw0 addr "$GW_MAC"
+    ip netns exec ndp-gw sysctl -qw "net.ipv6.conf.gw0.addr_gen_mode=1" 2>/dev/null || true
+    ip -n ndp-gw addr add "$GW_LLA/64" dev gw0 nodad 2>/dev/null || ip -n ndp-gw addr add "$GW_LLA/64" dev gw0
+    ip netns exec ndp-gw sysctl -qw net.ipv6.conf.gw0.forwarding=1
+    # Victim does real kernel SLAAC/DAD off the RA.
+    ip netns exec ndp-vic sysctl -qw net.ipv6.conf.vic0.accept_ra=2
+    # Write the ndpwatch config with the pinned gateway + prefix baseline.
+    cat > "$CFG" <<EOF
+{ "trusted_routers": ["$GW_LLA", "$GW_MAC"], "trusted_prefixes": ["$PREFIX"],
+  "flap_count": 3, "na_override_count": 8, "ra_flood_count": 10,
+  "rs_flood_count": 20, "ns_sweep_count": 20, "dad_defend_count": 3 }
+EOF
+    info "up. now: $0 baseline   (start the RA daemon + ndpwatch)"
+}
+
+_start_radvd() {
+    local conf="$LABDIR/radvd.conf"
+    cat > "$conf" <<EOF
+interface gw0 {
+    AdvSendAdvert on;
+    MinRtrAdvInterval 3; MaxRtrAdvInterval 5;
+    prefix $PREFIX { AdvOnLink on; AdvAutonomous on; };
+};
+EOF
+    command -v radvd >/dev/null 2>&1 || die "radvd not installed (apt install radvd) — or GW_RA_DAEMON=frr"
+    ip netns exec ndp-gw radvd -C "$conf" -p "$LABDIR/radvd.pid" -m logfile -l "$LABDIR/radvd.log" -n &
+    echo $! > "$LABDIR/radvd.wrap.pid"
+}
+
+do_baseline() {
+    need_root
+    ip link show "$BR" >/dev/null 2>&1 || die "run '$0 setup' first"
+    info "starting RA daemon ($GW_RA_DAEMON) on gw0"
+    [ "$GW_RA_DAEMON" = radvd ] && _start_radvd || die "GW_RA_DAEMON=frr not wired in this minimal lab; use radvd"
+    info "starting ndpwatch on mon0 -> $CAP"
+    ip netns exec ndp-mon python3 "$NDPWATCH" -i mon0 -c "$CFG" --jsonl "$CAP" &
+    echo $! > "$LABDIR/mon.pid"
+    sleep 2
+    info "baseline running. give SLAAC/DAD ~10s, then: $0 benign"
+}
+
+do_benign() {
+    need_root
+    info "benign phase: real RA + kernel SLAAC/DAD for 12s — ndpwatch must stay SILENT"
+    : > "$CAP" 2>/dev/null || true
+    ip -n ndp-vic addr flush dev vic0 scope global 2>/dev/null || true
+    ip netns exec ndp-vic sysctl -qw net.ipv6.conf.vic0.accept_ra=2 >/dev/null
+    ip -n ndp-vic link set vic0 down; ip -n ndp-vic link set vic0 up   # trigger RS + SLAAC + DAD
+    sleep 12
+    local n; n=$(wc -l < "$CAP" 2>/dev/null || echo 0)
+    if [ "$n" -eq 0 ]; then
+        info "PASS: no false positives on genuine RA/SLAAC/DAD ($n alerts)"
+    else
+        echo "FAIL: $n alert(s) on benign traffic — false positive:" >&2
+        cat "$CAP" >&2
+    fi
+}
+
+do_attack() {
+    need_root
+    ip link show "$BR" >/dev/null 2>&1 || die "run '$0 setup && $0 baseline' first"
+    : > "$CAP" 2>/dev/null || true
+    info "attack phase: injecting every scenario from ndp-atk"
+    for s in $(python3 "$INJECT" --list | awk '{print $1}'); do
+        info "  inject $s"
+        ip netns exec ndp-atk python3 "$INJECT" --iface atk0 --scenario "$s"
+        sleep 0.5
+    done
+    sleep 1
+    do_report
+}
+
+do_report() {
+    [ -f "$CAP" ] || die "no capture yet (run '$0 baseline' then '$0 attack')"
+    info "alerts captured on mon0:"
+    python3 - "$CAP" <<'PY'
+import json, sys
+codes = set()
+for line in open(sys.argv[1]):
+    line = line.strip()
+    if not line:
+        continue
+    a = json.loads(line)
+    codes.update(a.get('codes', []))
+    print('  [%s] %s :: %s' % (a['severity'], ','.join(a['codes']), a['summary']))
+print('distinct codes seen live: %d -> %s' % (len(codes), ' '.join(sorted(codes))))
+PY
+}
+
+do_teardown() {
+    need_root
+    info "tearing down"
+    for p in "$LABDIR"/*.pid "$LABDIR"/*.wrap.pid; do
+        [ -f "$p" ] && kill "$(cat "$p")" 2>/dev/null
+    done
+    for node in "${NODES[@]}"; do
+        ip netns pids "ndp-$node" 2>/dev/null | xargs -r kill 2>/dev/null
+        ip netns del "ndp-$node" 2>/dev/null
+    done
+    ip link del "$BR" 2>/dev/null
+    rm -rf "$LABDIR"
+    info "down."
+}
+
+usage() {
+    cat <<EOF
+Usage: sudo $0 <command>
+  setup      build the bridge + 4 namespaces (gw/vic/atk/mon), pin the gateway
+  baseline   start the RA daemon (radvd) + ndpwatch on mon0
+  benign     genuine RA + kernel SLAAC/DAD — ndpwatch MUST emit nothing (FP gate)
+  attack     inject every ndp_inject scenario; report the codes seen live
+  report     re-print the captured alerts + distinct codes
+  teardown   destroy everything
+  all        setup -> baseline -> benign -> attack -> report -> teardown
+Env: GW_RA_DAEMON=radvd|frr   NDPWATCH=/path/to/ndpwatch.py
+EOF
+}
+
+cmd=${1:-}; shift || true
+case "$cmd" in
+    setup)    do_setup ;;
+    baseline) do_baseline ;;
+    benign)   do_benign ;;
+    attack)   do_attack ;;
+    report)   do_report ;;
+    teardown) do_teardown ;;
+    all)      do_setup; do_baseline; sleep 10; do_benign; do_attack; do_teardown ;;
+    ''|-h|--help|help) usage ;;
+    *) usage; exit 1 ;;
+esac

--- a/python/conftest_packets.py
+++ b/python/conftest_packets.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""conftest_packets.py — offline packet conformance for ndpwatch.
+
+Runs the ndp_inject injector's EXACT packets through ndpwatch's real raw-byte
+parser + engine, with no interface. Proves the injected packets are wire-correct
+and that Scapy's serialization agrees with ndpwatch's independent parser on every
+offset — the offline half of the validation (the live half is `ndpwatch-lab.sh`).
+Runs on any box (no root, no IPv6 kernel needed):
+
+    $ python3 conftest_packets.py
+    conformance: 17/17 attacks produced their required codes
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import ndp_inject as inj      # noqa: E402
+import ndpwatch as n          # noqa: E402
+
+
+def run(verbose=True):
+    scen = inj.scenarios()
+    passed = 0
+    for name in sorted(scen):
+        codes, pkts = inj.build(name)
+        fired = set()
+        g = n.NdpWatch(inj.LAB_CONFIG, emit=lambda a: fired.update(a['codes']))
+        for i, p in enumerate(pkts):
+            g.process_packet(bytes(p), ts=100 + i * 0.1)
+        ok = all(c in fired for c in codes)
+        passed += 1 if ok else 0
+        if verbose:
+            print('  [%s] %-18s expect=%s fired=%s'
+                  % ('PASS' if ok else 'FAIL', name, codes, sorted(fired)))
+    total = len(scen)
+    print('conformance: %d/%d attacks produced their required codes' % (passed, total))
+    return 0 if passed == total else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(run())

--- a/python/ndp_inject.py
+++ b/python/ndp_inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""ndp_inject.py — LAB-ONLY adversarial IPv6 Neighbor Discovery generator.
+
+**Not part of ndpwatch.** ndpwatch is passive and has no transmit primitives;
+this is a separate file precisely so that invariant stays intact. It TRANSMITS
+forged ND on one named interface to prove the passive detector fires on real
+on-wire attacks — meant only for the throwaway namespaces `ndpwatch-lab.sh`
+creates (an isolated bridge with no path to any real network). NEVER point it at
+a production segment.
+
+Each scenario maps to the `NDP-0xx` code(s) it must produce (against the lab's
+pinned gateway/prefix baseline). `--dry-run` builds the packets and runs them
+back through the real ndpwatch parser+engine — the offline conformance path
+`conftest_packets.py` uses — with no transmit and no interface.
+"""
+
+import argparse
+import sys
+
+# Lab identities — must match ndpwatch-lab.sh's pinned gateway + prefix.
+GW_IP, GW_MAC = 'fe80::1', '02:00:00:00:00:01'
+VIC_IP, VIC_MAC = '2001:db8:0:1::5', 'aa:aa:aa:00:00:05'
+ATK_IP, ATK_MAC = 'fe80::66', 'de:ad:be:ef:00:66'
+GOOD_PFX, BAD_PFX = '2001:db8:0:1::', '2001:db8:bad::'
+
+LAB_CONFIG = {'trusted_routers': [GW_IP, GW_MAC],
+              'trusted_prefixes': [GOOD_PFX + '/64'],
+              'flap_count': 3, 'na_override_count': 8, 'ra_flood_count': 10,
+              'rs_flood_count': 20, 'ns_sweep_count': 20, 'dad_defend_count': 3}
+
+
+def _scapy():
+    from scapy.all import Ether, IPv6
+    from scapy.all import (ICMPv6ND_NA, ICMPv6ND_NS, ICMPv6ND_RA, ICMPv6ND_RS,
+                           ICMPv6ND_Redirect, ICMPv6NDOptDstLLAddr,
+                           ICMPv6NDOptSrcLLAddr, ICMPv6NDOptPrefixInfo,
+                           ICMPv6NDOptMTU, ICMPv6NDOptRDNSS)
+    return locals()
+
+
+# --- scenario builders: each returns a list of scapy packets ----------------
+def _b(S, name):
+    E, I = S['Ether'], S['IPv6']
+    builders = {}
+
+    def na(target, ip_src, mac, tlla=True, O=1, R=0, hlim=255, dst='ff02::1'):
+        p = E(src=mac) / I(src=ip_src, dst=dst, hlim=hlim) / S['ICMPv6ND_NA'](tgt=target, R=R, S=0, O=O)
+        if tlla:
+            p /= S['ICMPv6NDOptDstLLAddr'](lladdr=mac)
+        return p
+
+    def ns(target, ip_src, mac, hlim=255):
+        return E(src=mac) / I(src=ip_src, dst='ff02::1:ff00:5', hlim=hlim) / S['ICMPv6ND_NS'](tgt=target)
+
+    def ra(ip_src, mac, lifetime=1800, prf=0, opts=None, hlim=255):
+        p = E(src=mac) / I(src=ip_src, dst='ff02::1', hlim=hlim) / S['ICMPv6ND_RA'](routerlifetime=lifetime, prf=prf)
+        for o in (opts or []):
+            p /= o
+        return p
+
+    def rs(ip_src, mac, hlim=255):
+        return E(src=mac) / I(src=ip_src, dst='ff02::2', hlim=hlim) / S['ICMPv6ND_RS']()
+
+    def redirect(ip_src, mac, hlim=255):
+        return E(src=mac) / I(src=ip_src, dst=VIC_IP, hlim=hlim) / S['ICMPv6ND_Redirect'](tgt=ATK_IP, dst='2001:db8::9')
+
+    PIO_GOOD = S['ICMPv6NDOptPrefixInfo'](prefix=GOOD_PFX, prefixlen=64)
+    PIO_BAD = S['ICMPv6NDOptPrefixInfo'](prefix=BAD_PFX, prefixlen=64)
+    MTU_LOW = S['ICMPv6NDOptMTU'](mtu=1200)
+    RDNSS_BAD = S['ICMPv6NDOptRDNSS'](dns=[BAD_PFX + '53'])
+
+    builders['na-spoof'] = (['NDP-001'], lambda: [
+        na(VIC_IP, VIC_IP, VIC_MAC), na(VIC_IP, ATK_IP, ATK_MAC)])
+    builders['na-override-flood'] = (['NDP-002'], lambda: (
+        [na(VIC_IP, VIC_IP, VIC_MAC)] + [na(VIC_IP, ATK_IP, ATK_MAC) for _ in range(9)]))
+    builders['na-flap'] = (['NDP-003'], lambda: [
+        na(VIC_IP, VIC_IP, VIC_MAC), na(VIC_IP, ATK_IP, ATK_MAC),
+        na(VIC_IP, VIC_IP, VIC_MAC), na(VIC_IP, ATK_IP, ATK_MAC)])
+    builders['na-router-flip'] = (['NDP-004'], lambda: [
+        na(GW_IP, GW_IP, GW_MAC, R=1), na(GW_IP, GW_IP, GW_MAC, R=0)])
+    builders['lla-mismatch'] = (['NDP-005'], lambda: [
+        _lla_mismatch(S, na)])
+    builders['rogue-ra'] = (['NDP-006', 'NDP-020'], lambda: [ra(ATK_IP, ATK_MAC, opts=[PIO_GOOD])])
+    builders['ra-demotion'] = (['NDP-007'], lambda: [ra(GW_IP, GW_MAC, lifetime=0, opts=[PIO_GOOD])])
+    builders['ra-prefix'] = (['NDP-008'], lambda: [ra(GW_IP, GW_MAC, opts=[PIO_BAD])])
+    builders['ra-pref-high'] = (['NDP-009'], lambda: [ra(ATK_IP, ATK_MAC, prf=1, opts=[PIO_GOOD])])
+    builders['ra-rdnss'] = (['NDP-010'], lambda: [ra(ATK_IP, ATK_MAC, opts=[PIO_GOOD, RDNSS_BAD])])
+    builders['ra-mtu'] = (['NDP-011'], lambda: [ra(GW_IP, GW_MAC, opts=[PIO_GOOD, MTU_LOW])])
+    builders['ra-flood'] = (['NDP-012'], lambda: [ra(ATK_IP, ATK_MAC) for _ in range(11)])
+    builders['ns-sweep'] = (['NDP-013'], lambda: [
+        ns('2001:db8::%d' % (i + 1), ATK_IP, ATK_MAC) for i in range(21)])
+    builders['dad-dos'] = (['NDP-014'], lambda: (
+        [ns('2001:db8::dad', '::', VIC_MAC)] +
+        [na('2001:db8::dad', ATK_IP, ATK_MAC) for _ in range(4)]))
+    builders['rs-flood'] = (['NDP-015'], lambda: [
+        rs('fe80::%d' % (i + 10), 'aa:aa:aa:00:%02x:05' % i) for i in range(21)])
+    builders['redirect'] = (['NDP-016'], lambda: [redirect(ATK_IP, ATK_MAC)])
+    builders['bad-hoplimit'] = (['NDP-017'], lambda: [na(VIC_IP, ATK_IP, ATK_MAC, hlim=64)])
+    return builders
+
+
+def _lla_mismatch(S, na):
+    # NA whose TLLA option carries a MAC different from the Ethernet source.
+    p = na('2001:db8::7', ATK_IP, ATK_MAC, tlla=False)
+    p /= S['ICMPv6NDOptDstLLAddr'](lladdr='11:11:11:11:11:11')
+    return p
+
+
+def scenarios():
+    return _b(_scapy(), None)
+
+
+def build(name):
+    b = scenarios()
+    if name not in b:
+        raise SystemExit('unknown scenario: %s (see --list)' % name)
+    codes, fn = b[name]
+    return codes, fn()
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description='LAB-ONLY adversarial IPv6 ND generator.')
+    ap.add_argument('--iface', help='TX interface (a lab namespace veth only)')
+    ap.add_argument('--scenario', help='attack scenario name')
+    ap.add_argument('--list', action='store_true', help='list scenarios + their codes')
+    ap.add_argument('--dry-run', action='store_true',
+                    help='build + run through the real ndpwatch parser; do NOT transmit')
+    ap.add_argument('--all', action='store_true', help='(dry-run) run every scenario')
+    args = ap.parse_args(argv)
+
+    if args.list:
+        for name, (codes, _fn) in sorted(scenarios().items()):
+            print('%-18s -> %s' % (name, ', '.join(codes)))
+        return 0
+
+    names = sorted(scenarios()) if args.all else ([args.scenario] if args.scenario else [])
+    if not names:
+        ap.error('--scenario NAME (or --all / --list) required')
+
+    if args.dry_run or args.all:
+        sys.path.insert(0, __import__('os').path.dirname(__import__('os').path.abspath(__file__)))
+        import ndpwatch as n
+        rc = 0
+        for name in names:
+            codes, pkts = build(name)
+            fired = set()
+            g = n.NdpWatch(LAB_CONFIG, emit=lambda a: fired.update(a['codes']))
+            for i, p in enumerate(pkts):
+                g.process_packet(bytes(p), ts=100 + i * 0.1)
+            ok = all(c in fired for c in codes)
+            rc |= 0 if ok else 1
+            print('%-18s %s expect=%s fired=%s' % (name, 'OK ' if ok else 'FAIL',
+                  codes, sorted(fired)))
+        return rc
+
+    if not args.iface:
+        ap.error('--scenario needs --iface to transmit (or use --dry-run)')
+    from scapy.all import sendp
+    codes, pkts = build(args.scenario)
+    print('[inject] %s (%s) x%d on %s' % (args.scenario, ','.join(codes), len(pkts), args.iface))
+    sendp(pkts, iface=args.iface, verbose=False)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/python/ndpwatch.example.json
+++ b/python/ndpwatch.example.json
@@ -1,0 +1,11 @@
+{
+  "trusted_routers": ["fe80::1", "02:00:00:00:00:01"],
+  "trusted_prefixes": ["2001:db8:0:1::/64"],
+  "ra_flood_window_s": 10.0, "ra_flood_count": 10,
+  "rs_flood_window_s": 10.0, "rs_flood_count": 20,
+  "ns_sweep_window_s": 10.0, "ns_sweep_count": 20,
+  "na_override_window_s": 10.0, "na_override_count": 8,
+  "dad_defend_window_s": 10.0, "dad_defend_count": 3,
+  "flap_window_s": 30.0, "flap_count": 3,
+  "low_mtu": 1280, "neigh_max": 20000, "table_window_s": 30.0
+}

--- a/python/ndpwatch.py
+++ b/python/ndpwatch.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""ndpwatch.py — passive IPv6 Neighbor Discovery attack monitor (Ragnar).
+
+The IPv6 counterpart to arp_guard: IPv6 has no ARP — hosts resolve neighbours
+and discover routers via ICMPv6 Neighbor Discovery (RS/RA/NS/NA/Redirect), and
+the same MITM threat model maps over (NA-spoofing == ARP-spoofing; rogue RA ==
+gateway impersonation; RA/prefix floods; DAD DoS; spoofed Redirects).
+
+Detection only — it never sends an ND packet or corrects anything. Passive:
+Scapy is only the live-capture front end; field extraction is a hand-rolled
+raw-byte parser (no dissector), so `--self-test`/`--replay` need no NIC/IPv6 and
+the self-test needs no Scapy. Findings carry a stable NDP-0xx code; findings
+about one packet are merged into a single alert (highest severity + evidence).
+
+See docs/ndpwatch.md.
+"""
+
+import argparse
+import ipaddress
+import json
+import os
+import struct
+import sys
+import time
+from collections import defaultdict, deque
+
+MODULE = 'ndpwatch'
+SEV_RANK = {'info': 0, 'low': 1, 'medium': 2, 'high': 3, 'critical': 4}
+
+ETH_P_IPV6 = 0x86DD
+ETH_P_8021Q = 0x8100
+IPPROTO_ICMPV6 = 58
+# ND ICMPv6 types
+RS, RA, NS, NA, REDIRECT = 133, 134, 135, 136, 137
+# ND option types
+OPT_SLLA, OPT_TLLA, OPT_PIO, OPT_MTU, OPT_ROUTE, OPT_RDNSS = 1, 2, 3, 5, 24, 25
+UNSPECIFIED = '::'
+
+# Stable finding codes (severity, one-line meaning). 18 are reachable on the wire
+# (an injector can produce them); NDP-018 (malformed) and NDP-019 (table
+# pressure) are parser-robustness / sustained-flood cases.
+CODES = {
+    'NDP-001': ('critical', 'NA overriding a learned neighbour binding (cache poison)'),
+    'NDP-002': ('high', 'override-flag NA flood for one target (active poisoning)'),
+    'NDP-003': ('critical', 'target IPv6 flapping between MACs (two hosts racing)'),
+    'NDP-004': ('medium', 'NA Router (R) flag inconsistent for a host/router'),
+    'NDP-005': ('high', 'ND option link-layer addr != Ethernet source (forged)'),
+    'NDP-006': ('critical', 'RA from a router not in the trusted set (rogue gateway)'),
+    'NDP-007': ('high', 'trusted gateway RA with router-lifetime 0 (kill default route)'),
+    'NDP-008': ('high', 'RA advertises a prefix outside the baseline (SLAAC hijack)'),
+    'NDP-009': ('high', 'RA router-preference High from an untrusted source'),
+    'NDP-010': ('high', 'RA RDNSS (DNS) option from an untrusted router (DNS hijack)'),
+    'NDP-011': ('medium', 'RA MTU implausibly low / changed (PMTU blackhole)'),
+    'NDP-012': ('high', 'Router Advertisement flood (RA rate over threshold)'),
+    'NDP-013': ('medium', 'one source soliciting many distinct targets (NS sweep)'),
+    'NDP-014': ('high', 'answering NS for tentative (DAD) addresses (DAD DoS)'),
+    'NDP-015': ('medium', 'Router Solicitation flood'),
+    'NDP-016': ('high', 'ICMPv6 Redirect not from the first-hop router (spoofed)'),
+    'NDP-017': ('high', 'ND message with IPv6 Hop Limit != 255 (off-link injection)'),
+    'NDP-018': ('medium', 'malformed / truncated ND message'),
+    'NDP-019': ('high', 'distinct-target flood approaching neigh_max (table pressure)'),
+    'NDP-020': ('high', 'a router link-local speaking ND that is not the pinned gateway'),
+}
+
+DEFAULTS = {
+    'trusted_routers': [],          # link-local src IPs or MACs of legit routers
+    'trusted_prefixes': [],         # prefixes routers may advertise (CIDR)
+    'ra_flood_window_s': 10.0, 'ra_flood_count': 10,
+    'rs_flood_window_s': 10.0, 'rs_flood_count': 20,
+    'ns_sweep_window_s': 10.0, 'ns_sweep_count': 20,      # distinct targets / source
+    'na_override_window_s': 10.0, 'na_override_count': 8,
+    'dad_defend_window_s': 10.0, 'dad_defend_count': 3,
+    'flap_window_s': 30.0, 'flap_count': 3,
+    'low_mtu': 1280, 'neigh_max': 20000, 'table_window_s': 30.0,
+}
+
+
+# ===========================================================================
+# Raw-byte Ethernet + IPv6 + ICMPv6 ND parser
+# ===========================================================================
+def _mac(b, i):
+    return ':'.join('%02x' % x for x in b[i:i + 6])
+
+
+def _ip6(b, i):
+    return str(ipaddress.IPv6Address(bytes(b[i:i + 16])))
+
+
+def _u16(b, i):
+    return (b[i] << 8) | b[i + 1]
+
+
+def _u32(b, i):
+    return struct.unpack_from('!I', b, i)[0]
+
+
+def _parse_options(b, i):
+    """Walk ND options from offset i. Returns dict + a 'malformed' flag."""
+    opts = {'slla': None, 'tlla': None, 'prefixes': [], 'mtu': None,
+            'rdnss': [], 'route_info': [], 'malformed': False}
+    n = len(b)
+    while i + 2 <= n:
+        otype = b[i]
+        olen = b[i + 1]                              # in units of 8 bytes
+        if olen == 0:
+            opts['malformed'] = True
+            break
+        total = olen * 8
+        if i + total > n:
+            opts['malformed'] = True
+            break
+        val = b[i:i + total]
+        if otype == OPT_SLLA and total >= 8:
+            opts['slla'] = _mac(val, 2)
+        elif otype == OPT_TLLA and total >= 8:
+            opts['tlla'] = _mac(val, 2)
+        elif otype == OPT_PIO and total >= 32:
+            opts['prefixes'].append({
+                'prefix': str(ipaddress.IPv6Address(bytes(val[16:32]))),
+                'prefix_len': val[2], 'flags': val[3],
+                'valid': _u32(val, 4), 'preferred': _u32(val, 8)})
+        elif otype == OPT_MTU and total >= 8:
+            opts['mtu'] = _u32(val, 4)
+        elif otype == OPT_RDNSS and total >= 16:
+            cnt = (total - 8) // 16
+            opts['rdnss'] = [str(ipaddress.IPv6Address(bytes(val[8 + 16 * k:24 + 16 * k])))
+                             for k in range(cnt)]
+        elif otype == OPT_ROUTE:
+            opts['route_info'].append(True)
+        i += total
+    return opts
+
+
+def parse_ndp(raw):
+    """Parse an Ethernet(/802.1Q) IPv6 ICMPv6 ND frame, or None if not ND.
+    Never raises: truncation/garbage returns malformed set for NDP-018."""
+    if len(raw) < 14:
+        return None
+    off = 12
+    etype = _u16(raw, 12)
+    if etype == ETH_P_8021Q:
+        if len(raw) < 18:
+            return None
+        off = 16
+        etype = _u16(raw, 16)
+    if etype != ETH_P_IPV6:
+        return None
+    ip = off + 2
+    d = {'eth_src': _mac(raw, 6), 'eth_dst': _mac(raw, 0), 'src': None, 'dst': None,
+         'hop_limit': None, 'type': None, 'code': None, 'target': None,
+         'dest': None, 'na_flags': 0, 'ra': None, 'opts': None,
+         'truncated': False, 'malformed': None}
+    if len(raw) < ip + 40:
+        d['truncated'] = True
+        d['malformed'] = 'IPv6 header truncated'
+        return d
+    next_hdr = raw[ip + 6]
+    d['hop_limit'] = raw[ip + 7]
+    d['src'] = _ip6(raw, ip + 8)
+    d['dst'] = _ip6(raw, ip + 24)
+    if next_hdr != IPPROTO_ICMPV6:
+        return None                                  # ext headers / not ICMPv6
+    ic = ip + 40
+    if len(raw) < ic + 4:
+        d['truncated'] = True
+        d['malformed'] = 'ICMPv6 header truncated'
+        return d
+    itype = raw[ic]
+    if itype not in (RS, RA, NS, NA, REDIRECT):
+        return None
+    d['type'] = itype
+    d['code'] = raw[ic + 1]
+    body = ic + 4
+    try:
+        if itype == RS:
+            d['opts'] = _parse_options(raw, body + 4)
+        elif itype == RA:
+            if len(raw) < body + 12:
+                raise ValueError('RA body short')
+            d['ra'] = {'cur_hop_limit': raw[body], 'flags': raw[body + 1],
+                       'router_lifetime': _u16(raw, body + 2),
+                       'reachable': _u32(raw, body + 4),
+                       'retrans': _u32(raw, body + 8),
+                       'preference': (raw[body + 1] >> 3) & 0x3}   # prf field
+            d['opts'] = _parse_options(raw, body + 12)
+        elif itype == NS:
+            if len(raw) < body + 20:
+                raise ValueError('NS body short')
+            d['target'] = _ip6(raw, body + 4)
+            d['opts'] = _parse_options(raw, body + 20)
+        elif itype == NA:
+            if len(raw) < body + 20:
+                raise ValueError('NA body short')
+            d['na_flags'] = raw[body]                # R(0x80) S(0x40) O(0x20)
+            d['target'] = _ip6(raw, body + 4)
+            d['opts'] = _parse_options(raw, body + 20)
+        elif itype == REDIRECT:
+            if len(raw) < body + 36:
+                raise ValueError('Redirect body short')
+            d['target'] = _ip6(raw, body + 4)
+            d['dest'] = _ip6(raw, body + 20)
+            d['opts'] = _parse_options(raw, body + 36)
+    except (ValueError, IndexError, struct.error) as e:
+        d['malformed'] = 'ND body: %s' % e
+        return d
+    if d['opts'] and d['opts'].get('malformed'):
+        d['malformed'] = 'ND option overruns message'
+    return d
+
+
+def _in_prefixes(pfx, plen, trusted):
+    try:
+        net = ipaddress.ip_network('%s/%d' % (pfx, plen), strict=False)
+        for t in trusted:
+            tn = ipaddress.ip_network(t, strict=False)
+            if net.subnet_of(tn) or net == tn:
+                return True
+    except (ValueError, TypeError):
+        return False
+    return False
+
+
+# ===========================================================================
+# Engine
+# ===========================================================================
+class NdpWatch:
+    def __init__(self, config=None, emit=None):
+        c = dict(DEFAULTS)
+        c.update(config or {})
+        self.cfg = c
+        self.emit = emit or (lambda a: None)
+        self.trusted_routers = {str(x).lower() for x in (c.get('trusted_routers') or [])}
+        self.trusted_prefixes = list(c.get('trusted_prefixes') or [])
+        # state
+        self._nbr = {}                               # target -> {'mac', 'since', 'flaps'}
+        self._na_override = defaultdict(deque)       # target -> ts
+        self._ra_times = deque()                     # ts of RAs
+        self._rs_times = deque()                     # ts of RS
+        self._ns_targets = defaultdict(deque)        # src -> (ts, target)
+        self._dad_defend = defaultdict(deque)        # target -> ts (answers to :: NS)
+        self._pending_dad = {}                       # target -> ts (a DAD NS seen)
+        self._gw_ra_mtu = {}                         # router -> last mtu
+        self._table = deque()                        # (ts, target) distinct-target pressure
+        self.frames = 0
+        self.stats = defaultdict(int)
+
+    @staticmethod
+    def _trim(dq, ts, window, keyed=True):
+        while dq and ts - (dq[0][0] if keyed else dq[0]) > window:
+            dq.popleft()
+
+    def _is_trusted_router(self, pkt):
+        return (pkt['src'].lower() in self.trusted_routers or
+                pkt['eth_src'].lower() in self.trusted_routers or
+                (pkt['opts'] and (pkt['opts'].get('slla') or '').lower() in self.trusted_routers))
+
+    def process_packet(self, raw, ts=None):
+        pkt = parse_ndp(raw)
+        if pkt is None:
+            return None
+        if ts is None:
+            ts = time.time()
+        self.frames += 1
+        f = []
+        if pkt.get('malformed'):
+            f.append(('NDP-018', pkt['malformed']))
+            return self._merge(pkt, f, ts)
+        f += self._structural(pkt, ts)
+        t = pkt['type']
+        if t == NA:
+            f += self._on_na(pkt, ts)
+        elif t == NS:
+            f += self._on_ns(pkt, ts)
+        elif t == RA:
+            f += self._on_ra(pkt, ts)
+        elif t == RS:
+            f += self._on_rs(pkt, ts)
+        elif t == REDIRECT:
+            f += self._on_redirect(pkt, ts)
+        f += self._table_pressure(pkt, ts)
+        if f:
+            return self._merge(pkt, f, ts)
+        return None
+
+    # -- structural ----------------------------------------------------------
+    def _structural(self, pkt, ts):
+        out = []
+        # RFC 4861: all ND messages MUST have IPv6 Hop Limit 255. Anything else
+        # is off-link injection (a router/host too many hops away).
+        if pkt['hop_limit'] is not None and pkt['hop_limit'] != 255:
+            out.append(('NDP-017', 'ND %s arrived with Hop Limit %d (must be 255) — '
+                        'off-link injection' % (_TNAME[pkt['type']], pkt['hop_limit'])))
+        # ND option link-layer address must match the Ethernet source.
+        opts = pkt['opts'] or {}
+        lla = opts.get('slla') or opts.get('tlla')
+        if lla and pkt['eth_src'] and lla.lower() != pkt['eth_src'].lower():
+            out.append(('NDP-005', 'ND link-layer option %s != Ethernet source %s — forged'
+                        % (lla, pkt['eth_src'])))
+        return out
+
+    # -- NA: cache poison / flap / override flood / router flip --------------
+    def _on_na(self, pkt, ts):
+        out = []
+        target = pkt['target']
+        mac = (pkt['opts'] or {}).get('tlla') or pkt['eth_src']
+        if not target or target == UNSPECIFIED or not mac:
+            return out
+        override = bool(pkt['na_flags'] & 0x20)
+        router = bool(pkt['na_flags'] & 0x80)
+        b = self._nbr.get(target)
+        if b is None:
+            self._nbr[target] = {'mac': mac, 'since': ts, 'flaps': deque(), 'router': router}
+        elif b['mac'] != mac:
+            b['flaps'].append((ts, mac))
+            self._trim(b['flaps'], ts, self.cfg['flap_window_s'])
+            macs = {m for _t, m in b['flaps']} | {b['mac']}
+            b['mac'], b['since'] = mac, ts
+            if len(b['flaps']) >= self.cfg['flap_count'] and len(macs) >= 2:
+                out.append(('NDP-003', '%s is flapping between %d MACs — two hosts racing '
+                            '(active NA spoofing)' % (target, len(macs))))
+            else:
+                out.append(('NDP-001', '%s neighbour binding overridden to %s%s — cache '
+                            'poisoning' % (target, mac, ' (override flag)' if override else '')))
+        else:
+            if b.get('router') != router:
+                out.append(('NDP-004', '%s NA Router (R) flag changed — role confusion' % target))
+            b['router'] = router
+        if override:
+            dq = self._na_override[target]
+            dq.append(ts)
+            self._trim(dq, ts, self.cfg['na_override_window_s'], keyed=False)
+            if len(dq) >= self.cfg['na_override_count']:
+                out.append(('NDP-002', '%s override NA flood (%d in %.0fs) — active poisoning'
+                            % (target, len(dq), self.cfg['na_override_window_s'])))
+        # answering a DAD probe for a tentative address the segment is claiming
+        if target in self._pending_dad:
+            dq = self._dad_defend[target]
+            dq.append(ts)
+            self._trim(dq, ts, self.cfg['dad_defend_window_s'], keyed=False)
+            if len(dq) >= self.cfg['dad_defend_count']:
+                out.append(('NDP-014', 'repeated NA defending DAD target %s — Duplicate '
+                            'Address Detection DoS (nothing can configure)' % target))
+        return out
+
+    # -- NS: sweep + DAD tracking --------------------------------------------
+    def _on_ns(self, pkt, ts):
+        out = []
+        src, target = pkt['src'], pkt['target']
+        if src == UNSPECIFIED and target:            # DAD probe (tentative addr)
+            self._pending_dad[target] = ts
+            return out
+        if src and target:
+            dq = self._ns_targets[src]
+            dq.append((ts, target))
+            self._trim(dq, ts, self.cfg['ns_sweep_window_s'])
+            if len({t for _s, t in dq}) >= self.cfg['ns_sweep_count']:
+                out.append(('NDP-013', '%s solicited %d distinct targets in %.0fs — NS sweep '
+                            '(scan / cache exhaustion)' % (src, len({t for _s, t in dq}),
+                            self.cfg['ns_sweep_window_s'])))
+        return out
+
+    # -- RA: rogue router / prefix / RDNSS / MTU / demotion / flood ----------
+    def _on_ra(self, pkt, ts):
+        out = []
+        ra = pkt['ra'] or {}
+        trusted = self._is_trusted_router(pkt)
+        self._ra_times.append(ts)
+        self._trim(self._ra_times, ts, self.cfg['ra_flood_window_s'], keyed=False)
+        if len(self._ra_times) >= self.cfg['ra_flood_count']:
+            out.append(('NDP-012', 'Router Advertisement flood (%d in %.0fs) — control-plane DoS'
+                        % (len(self._ra_times), self.cfg['ra_flood_window_s'])))
+        if self.trusted_routers and not trusted:
+            out.append(('NDP-006', 'RA from %s (%s) not in the trusted router set — rogue '
+                        'gateway / fake_router6' % (pkt['src'], pkt['eth_src'])))
+            out.append(('NDP-020', 'router link-local %s speaking ND is not the pinned gateway'
+                        % pkt['src']))
+            if ra.get('preference') == 1:            # 01 = High
+                out.append(('NDP-009', 'rogue RA advertises router-preference High — winning '
+                            'the default-router election'))
+        if trusted and ra.get('router_lifetime') == 0:
+            out.append(('NDP-007', 'trusted gateway RA with router-lifetime 0 — a spoofed RA '
+                        'killing the real default route'))
+        for p in (pkt['opts'] or {}).get('prefixes', []):
+            if self.trusted_prefixes and not _in_prefixes(p['prefix'], p['prefix_len'],
+                                                          self.trusted_prefixes):
+                out.append(('NDP-008', 'RA advertises prefix %s/%d outside the baseline — '
+                            'SLAAC prefix hijack' % (p['prefix'], p['prefix_len'])))
+        if (pkt['opts'] or {}).get('rdnss') and self.trusted_routers and not trusted:
+            out.append(('NDP-010', 'untrusted RA carries RDNSS %s — DNS hijack via RA'
+                        % ', '.join(pkt['opts']['rdnss'][:2])))
+        mtu = (pkt['opts'] or {}).get('mtu')
+        if mtu is not None and mtu < self.cfg['low_mtu']:
+            out.append(('NDP-011', 'RA MTU %d below the IPv6 minimum %d — PMTU blackhole'
+                        % (mtu, self.cfg['low_mtu'])))
+        return out
+
+    def _on_rs(self, pkt, ts):
+        self._rs_times.append(ts)
+        self._trim(self._rs_times, ts, self.cfg['rs_flood_window_s'], keyed=False)
+        if len(self._rs_times) >= self.cfg['rs_flood_count']:
+            return [('NDP-015', 'Router Solicitation flood (%d in %.0fs)'
+                     % (len(self._rs_times), self.cfg['rs_flood_window_s']))]
+        return []
+
+    def _on_redirect(self, pkt, ts):
+        # A legitimate Redirect comes only from the current first-hop router.
+        if self.trusted_routers and not self._is_trusted_router(pkt):
+            return [('NDP-016', 'ICMPv6 Redirect from %s, not the first-hop router — traffic '
+                     'redirection' % pkt['src'])]
+        return []
+
+    def _table_pressure(self, pkt, ts):
+        tgt = pkt.get('target')
+        if not tgt or tgt == UNSPECIFIED:
+            return []
+        self._table.append((ts, tgt))
+        self._trim(self._table, ts, self.cfg['table_window_s'])
+        if len({t for _s, t in self._table}) >= self.cfg['neigh_max']:
+            return [('NDP-019', 'distinct ND targets in %.0fs approaching neigh_max %d — '
+                     'neighbour-table exhaustion' % (self.cfg['table_window_s'],
+                     self.cfg['neigh_max']))]
+        return []
+
+    # -- merge ---------------------------------------------------------------
+    def _merge(self, pkt, findings, ts):
+        seen, uniq = set(), []
+        for code, detail in findings:
+            if code not in seen:
+                seen.add(code)
+                uniq.append((code, detail))
+        worst = max(uniq, key=lambda c: SEV_RANK[CODES[c[0]][0]])
+        alert = {
+            'ts': ts, 'module': MODULE, 'severity': CODES[worst[0]][0],
+            'type': _TNAME.get(pkt.get('type')), 'src': pkt.get('src'),
+            'eth_src': pkt.get('eth_src'), 'target': pkt.get('target'),
+            'codes': [c for c, _ in uniq], 'summary': worst[1],
+            'evidence': [{'code': c, 'severity': CODES[c][0], 'detail': d}
+                         for c, d in sorted(uniq, key=lambda x: -SEV_RANK[CODES[x[0]][0]])],
+        }
+        self.stats[alert['severity']] += 1
+        self.emit(alert)
+        return alert
+
+
+_TNAME = {RS: 'RS', RA: 'RA', NS: 'NS', NA: 'NA', REDIRECT: 'Redirect'}
+
+
+# ===========================================================================
+# Live capture / replay (scapy, lazy)
+# ===========================================================================
+def run_live(iface, guard):
+    from scapy.all import sniff
+    sys.stderr.write('ndpwatch: passive on %s (icmp6 ND) — Ctrl-C to stop\n' % iface)
+    try:
+        sniff(iface=iface, filter='icmp6', store=False,
+              prn=lambda p: guard.process_packet(bytes(p), float(getattr(p, 'time', 0)) or time.time()))
+    except Exception:                                # libpcap/BPF absent: no filter
+        sniff(iface=iface, store=False,
+              prn=lambda p: guard.process_packet(bytes(p), float(getattr(p, 'time', 0)) or time.time()))
+
+
+def run_replay(path, guard):
+    from scapy.all import PcapReader
+    with PcapReader(path) as pr:
+        for p in pr:
+            guard.process_packet(bytes(p), float(getattr(p, 'time', 0)) or time.time())
+
+
+def make_emitter(out_fh, echo):
+    def emit(a):
+        if out_fh:
+            out_fh.write(json.dumps(a) + '\n')
+            out_fh.flush()
+        if echo:
+            sys.stderr.write('  !! [%s] %s %s :: %s\n' % (a['severity'], a.get('type') or '',
+                             ','.join(a['codes']), a['summary']))
+    return emit
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog='ndpwatch',
+                                 description='Passive IPv6 Neighbor Discovery attack monitor (detection-only).')
+    ap.add_argument('-i', '--iface', help='live capture interface')
+    ap.add_argument('--replay', help='replay a pcap instead of live capture')
+    ap.add_argument('-c', '--config', help='JSON config (trusted_routers/prefixes + thresholds)')
+    ap.add_argument('--jsonl', '-o', help="JSON-lines output path ('-' = stdout)")
+    ap.add_argument('--echo', action='store_true', help='echo alerts to stderr')
+    ap.add_argument('--self-test', action='store_true')
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        import ndpwatch_selftest
+        return ndpwatch_selftest.run(verbose=True)
+
+    cfg = {}
+    if args.config:
+        with open(args.config) as f:
+            cfg = json.load(f)
+    out_fh = sys.stdout if args.jsonl == '-' else (open(args.jsonl, 'a') if args.jsonl else None)
+    guard = NdpWatch(cfg, emit=make_emitter(out_fh, args.echo or not args.jsonl))
+
+    if args.replay:
+        run_replay(args.replay, guard)
+    elif args.iface:
+        if os.geteuid() != 0:
+            sys.stderr.write('error: live capture needs root / CAP_NET_RAW.\n')
+            return 2
+        try:
+            run_live(args.iface, guard)
+        except KeyboardInterrupt:
+            pass
+    else:
+        ap.error('one of --iface, --replay or --self-test is required')
+    sys.stderr.write('ndpwatch: %d frames, alerts %s\n' % (guard.frames, dict(guard.stats)))
+    if out_fh and out_fh is not sys.stdout:
+        out_fh.close()
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/python/ndpwatch_selftest.py
+++ b/python/ndpwatch_selftest.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""ndpwatch_selftest.py — offline self-test (no root, no Scapy, no IPv6 kernel).
+
+Builds raw Ethernet+IPv6+ICMPv6 ND frame bytes in pure Python and drives them
+through NdpWatch.process_packet() — the exact path the live sniffer uses —
+exercising every NDP-0xx finding code plus negative controls (benign NA/RA, a
+DAD probe, a non-ND echo) that must stay silent. Run via
+`python3 ndpwatch.py --self-test`.
+"""
+
+import ipaddress
+import struct
+import sys
+
+import ndpwatch as n
+
+
+def _macb(s):
+    return bytes(int(x, 16) for x in s.split(':'))
+
+
+def _ip6b(s):
+    return ipaddress.IPv6Address(s).packed
+
+
+def eth(payload, src='de:ad:be:ef:00:99', dst='33:33:00:00:00:01'):
+    return _macb(dst) + _macb(src) + struct.pack('!H', n.ETH_P_IPV6) + payload
+
+
+def ipv6(payload, src, dst, hlim=255):
+    hdr = struct.pack('!I', 0x60000000) + struct.pack('!H', len(payload))
+    hdr += bytes([n.IPPROTO_ICMPV6, hlim]) + _ip6b(src) + _ip6b(dst)
+    return hdr + payload
+
+
+def _icmp6(itype, body):
+    return bytes([itype, 0]) + b'\x00\x00' + body
+
+
+def opt_lla(otype, mac):
+    return bytes([otype, 1]) + _macb(mac)
+
+
+def opt_pio(prefix, plen=64, valid=2592000, preferred=604800, flags=0xc0):
+    return bytes([n.OPT_PIO, 4, plen, flags]) + struct.pack('!II', valid, preferred) \
+        + b'\x00\x00\x00\x00' + _ip6b(prefix)
+
+
+def opt_mtu(mtu):
+    return bytes([n.OPT_MTU, 1]) + b'\x00\x00' + struct.pack('!I', mtu)
+
+
+def opt_rdnss(addr, lifetime=600):
+    return bytes([n.OPT_RDNSS, 3]) + b'\x00\x00' + struct.pack('!I', lifetime) + _ip6b(addr)
+
+
+def na(target, src='fe80::99', tlla='de:ad:be:ef:00:99', R=0, S=0, O=1,
+       eth_src='de:ad:be:ef:00:99', hlim=255):
+    flags = (R << 7) | (S << 6) | (O << 5)
+    body = bytes([flags, 0, 0, 0]) + _ip6b(target)
+    if tlla:
+        body += opt_lla(n.OPT_TLLA, tlla)
+    return eth(ipv6(_icmp6(n.NA, body), src, 'ff02::1', hlim), src=eth_src)
+
+
+def ns(target, src='fe80::5', slla=None, eth_src='aa:aa:aa:00:00:05', hlim=255):
+    body = b'\x00\x00\x00\x00' + _ip6b(target)
+    if slla:
+        body += opt_lla(n.OPT_SLLA, slla)
+    return eth(ipv6(_icmp6(n.NS, body), src, 'ff02::1:ff00:5', hlim), src=eth_src)
+
+
+def ra(src='fe80::66', eth_src='de:ad:be:ef:00:66', lifetime=1800, prf=0,
+       opts=b'', hlim=255):
+    flags = (prf & 0x3) << 3
+    body = bytes([64, flags]) + struct.pack('!H', lifetime) + b'\x00' * 8 + opts
+    return eth(ipv6(_icmp6(n.RA, body), src, 'ff02::1', hlim), src=eth_src)
+
+
+def rs(src='fe80::5', eth_src='aa:aa:aa:00:00:05', hlim=255):
+    return eth(ipv6(_icmp6(n.RS, b'\x00\x00\x00\x00'), src, 'ff02::2', hlim), src=eth_src)
+
+
+def redirect(src='fe80::66', eth_src='de:ad:be:ef:00:66', hlim=255):
+    body = b'\x00\x00\x00\x00' + _ip6b('fe80::66') + _ip6b('2001:db8::9')
+    return eth(ipv6(_icmp6(n.REDIRECT, body), src, 'fe80::5', hlim), src=eth_src)
+
+
+class H:
+    def __init__(self, verbose):
+        self.n = self.fail = 0
+        self.verbose = verbose
+
+    def ck(self, name, cond):
+        self.n += 1
+        if not cond:
+            self.fail += 1
+        if self.verbose:
+            print('  [%s] %s' % ('PASS' if cond else 'FAIL', name))
+
+
+def _w(cfg=None):
+    al = []
+    return n.NdpWatch(cfg or {}, emit=al.append), al
+
+
+def _codes(al):
+    return {c for a in al for c in a['codes']}
+
+
+TRUSTED = {'trusted_routers': ['fe80::1', '02:00:00:00:00:01'],
+           'trusted_prefixes': ['2001:db8:0:1::/64']}
+
+
+def run(verbose=True):
+    h = H(verbose)
+
+    # ---- parser sanity ----------------------------------------------------
+    p = n.parse_ndp(na('fe80::1'))
+    h.ck('parse NA type/target', p and p['type'] == n.NA and p['target'] == 'fe80::1')
+    p = n.parse_ndp(ra(opts=opt_pio('2001:db8:0:1::') + opt_mtu(1500)))
+    h.ck('parse RA lifetime/pio/mtu',
+         p and p['ra']['router_lifetime'] == 1800
+         and p['opts']['prefixes'][0]['prefix'] == '2001:db8:0:1::'
+         and p['opts']['mtu'] == 1500)
+    h.ck('parse non-ND -> None',
+         n.parse_ndp(eth(ipv6(bytes([128, 0, 0, 0, 0, 0]), 'fe80::1', 'fe80::2'))) is None)
+
+    # ---- NDP-001 cache poison --------------------------------------------
+    g, al = _w()
+    g.process_packet(na('2001:db8::5', tlla='aa:aa:aa:00:00:05', eth_src='aa:aa:aa:00:00:05'), ts=1)
+    g.process_packet(na('2001:db8::5', tlla='de:ad:be:ef:00:99', eth_src='de:ad:be:ef:00:99'), ts=2)
+    h.ck('NDP-001 NA cache poison', 'NDP-001' in _codes(al))
+
+    # ---- NDP-002 override flood ------------------------------------------
+    g, al = _w({'na_override_count': 8})
+    g.process_packet(na('2001:db8::5', tlla='aa:aa:aa:00:00:05', eth_src='aa:aa:aa:00:00:05'), ts=1)
+    for i in range(9):
+        g.process_packet(na('2001:db8::5', tlla='de:ad:be:ef:00:99', eth_src='de:ad:be:ef:00:99', O=1), ts=2 + i * 0.1)
+    h.ck('NDP-002 override NA flood', 'NDP-002' in _codes(al))
+
+    # ---- NDP-003 flap ----------------------------------------------------
+    g, al = _w({'flap_count': 3})
+    for i in range(4):
+        m = 'aa:aa:aa:00:00:05' if i % 2 == 0 else 'de:ad:be:ef:00:99'
+        g.process_packet(na('2001:db8::5', tlla=m, eth_src=m), ts=1 + i)
+    h.ck('NDP-003 binding flap -> critical',
+         any('NDP-003' in a['codes'] and a['severity'] == 'critical' for a in al))
+
+    # ---- NDP-004 router flag flip ----------------------------------------
+    g, al = _w()
+    g.process_packet(na('2001:db8::1', tlla='02:00:00:00:00:01', eth_src='02:00:00:00:00:01', R=1), ts=1)
+    g.process_packet(na('2001:db8::1', tlla='02:00:00:00:00:01', eth_src='02:00:00:00:00:01', R=0), ts=2)
+    h.ck('NDP-004 router flag flip', 'NDP-004' in _codes(al))
+
+    # ---- NDP-005 LLA/eth mismatch ----------------------------------------
+    g, al = _w()
+    g.process_packet(na('2001:db8::7', tlla='11:11:11:11:11:11', eth_src='de:ad:be:ef:00:99'), ts=1)
+    h.ck('NDP-005 LLA != eth source', 'NDP-005' in _codes(al))
+
+    # ---- NDP-006 rogue RA + NDP-020 untrusted router ---------------------
+    g, al = _w(TRUSTED)
+    g.process_packet(ra(src='fe80::66', eth_src='de:ad:be:ef:00:66',
+                        opts=opt_pio('2001:db8:0:1::')), ts=1)
+    h.ck('NDP-006 rogue RA', 'NDP-006' in _codes(al))
+    h.ck('NDP-020 untrusted router', 'NDP-020' in _codes(al))
+
+    # ---- NDP-007 gateway demotion (trusted RA lifetime 0) ----------------
+    g, al = _w(TRUSTED)
+    g.process_packet(ra(src='fe80::1', eth_src='02:00:00:00:00:01', lifetime=0,
+                        opts=opt_pio('2001:db8:0:1::')), ts=1)
+    h.ck('NDP-007 gateway demotion', 'NDP-007' in _codes(al))
+
+    # ---- NDP-008 prefix hijack -------------------------------------------
+    g, al = _w({'trusted_routers': ['fe80::1'], 'trusted_prefixes': ['2001:db8:0:1::/64']})
+    g.process_packet(ra(src='fe80::1', eth_src='02:00:00:00:00:01',
+                        opts=opt_pio('2001:db8:bad::')), ts=1)
+    h.ck('NDP-008 prefix hijack', 'NDP-008' in _codes(al))
+
+    # ---- NDP-009 preference High (rogue) ---------------------------------
+    g, al = _w(TRUSTED)
+    g.process_packet(ra(src='fe80::66', eth_src='de:ad:be:ef:00:66', prf=1,
+                        opts=opt_pio('2001:db8:0:1::')), ts=1)
+    h.ck('NDP-009 preference High', 'NDP-009' in _codes(al))
+
+    # ---- NDP-010 RDNSS spoof (untrusted) ---------------------------------
+    g, al = _w(TRUSTED)
+    g.process_packet(ra(src='fe80::66', eth_src='de:ad:be:ef:00:66',
+                        opts=opt_pio('2001:db8:0:1::') + opt_rdnss('2001:db8:bad::53')), ts=1)
+    h.ck('NDP-010 RDNSS spoof', 'NDP-010' in _codes(al))
+
+    # ---- NDP-011 MTU anomaly ---------------------------------------------
+    g, al = _w({'trusted_routers': ['fe80::1'], 'trusted_prefixes': ['2001:db8:0:1::/64']})
+    g.process_packet(ra(src='fe80::1', eth_src='02:00:00:00:00:01',
+                        opts=opt_pio('2001:db8:0:1::') + opt_mtu(1200)), ts=1)
+    h.ck('NDP-011 low MTU', 'NDP-011' in _codes(al))
+
+    # ---- NDP-012 RA flood ------------------------------------------------
+    g, al = _w({'ra_flood_count': 10})
+    for i in range(11):
+        g.process_packet(ra(src='fe80::66', eth_src='de:ad:be:ef:00:66'), ts=1 + i * 0.1)
+    h.ck('NDP-012 RA flood', 'NDP-012' in _codes(al))
+
+    # ---- NDP-013 NS sweep -------------------------------------------------
+    g, al = _w({'ns_sweep_count': 20})
+    for i in range(21):
+        g.process_packet(ns('2001:db8::%d' % (i + 1), src='fe80::66', eth_src='de:ad:be:ef:00:66'), ts=1 + i * 0.05)
+    h.ck('NDP-013 NS sweep', 'NDP-013' in _codes(al))
+
+    # ---- NDP-014 DAD DoS --------------------------------------------------
+    g, al = _w({'dad_defend_count': 3})
+    g.process_packet(ns('2001:db8::dad', src='::', eth_src='aa:aa:aa:00:00:05'), ts=1)  # DAD probe
+    for i in range(4):
+        g.process_packet(na('2001:db8::dad', tlla='de:ad:be:ef:00:99', eth_src='de:ad:be:ef:00:99'), ts=2 + i * 0.1)
+    h.ck('NDP-014 DAD DoS', 'NDP-014' in _codes(al))
+
+    # ---- NDP-015 RS flood -------------------------------------------------
+    g, al = _w({'rs_flood_count': 20})
+    for i in range(21):
+        g.process_packet(rs(src='fe80::%d' % (i + 10), eth_src='aa:aa:aa:00:%02x:05' % i), ts=1 + i * 0.05)
+    h.ck('NDP-015 RS flood', 'NDP-015' in _codes(al))
+
+    # ---- NDP-016 spoofed redirect ----------------------------------------
+    g, al = _w(TRUSTED)
+    g.process_packet(redirect(src='fe80::66', eth_src='de:ad:be:ef:00:66'), ts=1)
+    h.ck('NDP-016 spoofed redirect', 'NDP-016' in _codes(al))
+
+    # ---- NDP-017 bad hop limit -------------------------------------------
+    g, al = _w()
+    g.process_packet(na('2001:db8::5', tlla='de:ad:be:ef:00:99', eth_src='de:ad:be:ef:00:99', hlim=64), ts=1)
+    h.ck('NDP-017 bad hop limit', 'NDP-017' in _codes(al))
+
+    # ---- NDP-018 malformed ------------------------------------------------
+    g, al = _w()
+    r = g.process_packet(na('2001:db8::5')[:48], ts=1)     # truncated
+    h.ck('NDP-018 malformed (no crash)', r is not None and 'NDP-018' in r['codes'])
+
+    # ---- NDP-019 table pressure ------------------------------------------
+    g, al = _w({'neigh_max': 25, 'table_window_s': 60})
+    for i in range(26):
+        g.process_packet(ns('2001:db8:%x::1' % i, src='fe80::5', eth_src='aa:aa:aa:00:00:05'), ts=1 + i * 0.01)
+    h.ck('NDP-019 table pressure', 'NDP-019' in _codes(al))
+
+    # ---- negative controls -----------------------------------------------
+    g, al = _w(TRUSTED)
+    # benign NA (first sighting), benign RA from trusted router with baseline prefix
+    g.process_packet(na('2001:db8:0:1::5', tlla='aa:aa:aa:00:00:05', eth_src='aa:aa:aa:00:00:05'), ts=1)
+    g.process_packet(ra(src='fe80::1', eth_src='02:00:00:00:00:01', lifetime=1800,
+                        opts=opt_pio('2001:db8:0:1::') + opt_mtu(1500)), ts=2)
+    g.process_packet(ns('2001:db8:0:1::9', src='fe80::1', slla='02:00:00:00:00:01', eth_src='02:00:00:00:00:01'), ts=3)
+    g.process_packet(ns('2001:db8:0:1::7', src='::', eth_src='aa:aa:aa:00:00:05'), ts=4)  # DAD probe alone
+    h.ck('benign NA/RA/NS/DAD are silent', not al)
+
+    total = h.n
+    passed = total - h.fail
+    print('ndpwatch self-test: %d/%d %s' % (passed, total, 'OK' if h.fail == 0 else 'FAILED'))
+    return 0 if h.fail == 0 else 1
+
+
+if __name__ == '__main__':
+    sys.exit(run(verbose=True))

--- a/scripts/ndpwatch.service
+++ b/scripts/ndpwatch.service
@@ -1,0 +1,50 @@
+[Unit]
+# Ragnar ndpwatch — dedicated passive IPv6 Neighbor Discovery attack monitor.
+# OPT-IN. RX-only: it never sends an ND packet. Granted CAP_NET_RAW + CAP_NET_ADMIN
+# (raw capture + promiscuous) and nothing else — the IPv6 counterpart to arp_guard.
+#   sudo useradd --system --no-create-home --shell /usr/sbin/nologin ndpmon
+#   sudo mkdir -p /var/log/ndpwatch && sudo chown ndpmon:ndpmon /var/log/ndpwatch
+#   sudo install -Dm644 python/ndpwatch.example.json /etc/ragnar/ndpwatch.json
+#   sudo cp scripts/ndpwatch.service /etc/systemd/system/
+#   sudoedit /etc/systemd/system/ndpwatch.service   # set RAGNAR_NDP_IFACE
+#   sudo systemctl enable --now ndpwatch
+#   journalctl -u ndpwatch -f
+Description=Ragnar ndpwatch passive IPv6 ND attack monitor
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ndpmon
+Group=ndpmon
+WorkingDirectory=/home/ragnar/Ragnar/python
+Environment=RAGNAR_NDP_IFACE=eth0
+ExecStartPre=/bin/mkdir -p /var/log/ndpwatch
+ExecStart=/usr/bin/python3 /home/ragnar/Ragnar/python/ndpwatch.py \
+    -i ${RAGNAR_NDP_IFACE} -c /etc/ragnar/ndpwatch.json \
+    --jsonl /var/log/ndpwatch/alerts.jsonl
+Restart=on-failure
+RestartSec=5
+
+# --- least privilege: sniff only ------------------------------------------
+AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN
+NoNewPrivileges=yes
+RestrictAddressFamilies=AF_PACKET AF_UNIX
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/var/log/ndpwatch
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+MemoryDenyWriteExecute=yes
+LockPersonality=yes
+MemoryMax=128M
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This pull request introduces `ndpwatch`, a passive IPv6 Neighbor Discovery (NDP) attack monitor, along with a full validation lab and supporting tools. The main additions are comprehensive documentation, a standalone lab harness (`ndpwatch-lab.sh`), an offline conformance test (`conftest_packets.py`), a lab-only adversarial packet injector (`ndp_inject.py`), and an example configuration. Together, these provide a robust framework for detecting, validating, and testing NDP-based attacks in IPv6 networks.

**Key changes:**

### New tool: Passive IPv6 NDP attack monitor

- Added `ndpwatch`, a passive daemon for detecting IPv6 NDP-based attacks, with a raw-byte parser, 20 coded findings, JSON-lines output, pcap replay, and systemd integration. The documentation (`docs/ndpwatch.md`) details the threat model, detection capabilities, findings, configuration, and operational guidance.

### Validation and testing lab

- Introduced `ndpwatch-lab.sh`, a network-namespace-based validation lab that builds a virtual topology with real RA daemons and kernel SLAAC/DAD, running live and benign traffic to verify both detection and false-positive rates. The lab includes commands for setup, baseline, benign testing, attack injection, reporting, and teardown.
- Added `python/ndp_inject.py`, a lab-only tool that generates and transmits adversarial NDP packets for each attack scenario, mapping to the expected NDP findings. It supports dry-run mode for offline conformance.
- Added `python/conftest_packets.py`, an offline conformance test that runs the injector’s packets through `ndpwatch`’s parser to ensure wire-format correctness and detection accuracy without requiring root or kernel IPv6.

### Configuration and integration

- Provided an example configuration file (`python/ndpwatch.example.json`) for trusted routers, prefixes, and detection thresholds.
- Updated `docs/nettools.md` to reference `ndpwatch` as the standalone continuous daemon for IPv6 NDP monitoring, distinguishing it from the integrated quick-check tool.

These changes collectively deliver a complete, tested, and documented solution for passive IPv6 NDP attack detection and validation.