### PR TITLE
wifiwatch: WPA handshake/PMKID harvest, WPA3 downgrade, PNL leak

### DIFF
--- a/docs/wifiwatch.md
+++ b/docs/wifiwatch.md
@@ -3,8 +3,8 @@
 `wifiwatch` is a standalone, **passive-only (RX-only)** wireless IDS — the deep,
 daemon-shaped companion to the integrated [WiFi Defense](wifi-defense.md) WIDS.
 It never transmits: no probe requests, no association, no deauth — nothing on
-air. It sniffs 802.11 management frames in monitor mode and flags four attack
-classes.
+air. It sniffs 802.11 management frames (plus EAPOL data frames) in monitor mode
+and flags AP/RF attacks **and** the WPA client/handshake layer.
 
 The 802.11 + radiotap parsing is **raw-byte** (no Scapy dissectors), so
 `--self-test` and `--replay` of a pcap run with no radio and the self-test needs
@@ -13,7 +13,7 @@ key off each frame's **capture timestamp** (not wall clock), so a replayed
 capture timestamps each alert to when the attack actually happened.
 
 - **Test floor:** Raspberry Pi Zero 2 W + Alfa AWUS036AXM (mt7921u).
-- **Self-test:** 30/30 (`python3 python/wifiwatch.py --self-test`).
+- **Self-test:** 51/51 (`python3 python/wifiwatch.py --self-test`).
 - **Deps:** Python 3.8+, Scapy (live capture only), `iw`.
 
 ## Detectors
@@ -24,6 +24,11 @@ capture timestamps each alert to when the attack actually happened.
 | `beacon_flood` | fake-AP storms (mdk3/mdk4 beacon mode) | subtype 8 |
 | `evil_twin` | rogue APs / evil twins (allowlist) | subtype 8 / 5 |
 | `karma_mana` | KARMA / MANA rogue APs | subtype 5 / 4 |
+| `pmkid_harvest` | EAPOL **M1 carrying a PMKID** — clientless offline-crack handle | EAPOL-Key (data) |
+| `handshake_harvest` | full **4-way handshake right after a deauth** — deauth-and-capture | deauth + EAPOL |
+| `wpa3_transition` | one AP offering **SAE + PSK together** — downgradeable | RSN in beacon/probe-resp |
+| `wpa_downgrade` | a known **WPA3 SSID reappearing WPA2-PSK-only** — WPA3 strip | RSN in beacon/probe-resp |
+| `pnl_leak` | a client **broadcasting its saved-network list** in directed probes | subtype 4 |
 
 - **deauth_flood** — thresholds per scope: broadcast **6 / 5 s** (critical),
   per-BSSID (deauth+disassoc) **25 / 5 s** (critical), targeted **12 / 5 s**
@@ -37,6 +42,31 @@ capture timestamps each alert to when the attack actually happened.
   allowlist → **critical**. An unlisted SSID from ≥ 2 BSSIDs → **info** (allowlist
   it to promote real threats to critical and silence the guesswork).
 - **karma_mana** — one BSSID answering ≥ 5 distinct SSIDs.
+
+### WPA client / handshake layer
+
+You cannot see a silent sniffer passively, but you *can* see the two things that
+put a **crackable handshake on the air**:
+
+- **pmkid_harvest** (critical) — an EAPOL **M1 that carries a PMKID KDE**. That
+  is exactly what `hcxdumptool`-style clientless attacks pull to crack a PSK
+  offline; a PMKID on the air is a standing exposure.
+- **handshake_harvest** (critical) — a client is **deauthed** and then completes
+  **≥ 2 of the 4** EAPOL messages within `handshake_deauth_window` (10 s). That
+  deauth-then-reconnect sequence is the classic forced-handshake capture; a
+  handshake with no preceding deauth is normal roaming and stays quiet.
+- **wpa3_transition** (info) — one BSSID advertising **SAE and PSK together**.
+  A WPA3 client can be steered down to WPA2-PSK, whose handshake cracks offline.
+  It's a property of the real AP's config, so informational — a hardening note.
+- **wpa_downgrade** (critical) — an SSID seen advertising **SAE** now appearing
+  from a BSSID offering **PSK only**. That's an evil twin stripping WPA3 — a live
+  downgrade, not a config choice.
+- **pnl_leak** (warning) — a **non-randomized** client MAC that directs probe
+  requests at `pnl_min_ssids` (4) or more distinct SSIDs is broadcasting its
+  Preferred Network List — the precise input an evil-twin/KARMA rig needs to
+  impersonate a network the device will auto-join. Probes from a
+  locally-administered (privacy-randomized) MAC are ignored: they aren't a stable
+  device to track and modern phones rotate them by design.
 
 ## Event schema (web-UI ready)
 
@@ -64,7 +94,7 @@ census). Tunable to `0` in a known-clean environment.
 ## Run
 
 ```bash
-python3 python/wifiwatch.py --self-test                       # 30/30, no root/Scapy
+python3 python/wifiwatch.py --self-test                       # 51/51, no root/Scapy
 sudo python3 python/wifiwatch.py --iface wlan1 --echo         # live, echo to stderr
 sudo python3 python/wifiwatch.py --iface wlan1 --jsonl /var/lib/ragnar/wifiwatch/events.jsonl
 python3 python/wifiwatch.py --replay attack.pcap --echo       # replay a capture (no radio)

--- a/python/wifiwatch.py
+++ b/python/wifiwatch.py
@@ -2,9 +2,15 @@
 """wifiwatch.py — passive 802.11 attack monitor (Ragnar).
 
 Passive-only (RX-only) wireless IDS: it never transmits — no probes, no assoc,
-no deauth. It sniffs 802.11 management frames in monitor mode and flags four
-attack classes: deauth/disassoc floods, beacon (fake-AP) floods, evil twins,
-and KARMA/MANA rogue APs.
+no deauth. It sniffs 802.11 management frames (and EAPOL data frames) in monitor
+mode and flags:
+  * deauth/disassoc floods, beacon (fake-AP) floods, evil twins, KARMA/MANA;
+  * WPA client/handshake attacks — a PMKID-bearing EAPOL M1 (clientless harvest)
+    and a full 4-way handshake right after a deauth (deauth-and-capture);
+  * WPA3 downgrade — a transition-mode AP offering SAE+PSK together, or a known
+    WPA3 SSID reappearing WPA2-PSK-only (an evil twin stripping WPA3);
+  * PNL leak — a client broadcasting its saved-network list in directed probes,
+    the input an evil-twin/KARMA rig needs.
 
 The 802.11 + radiotap parsing is raw-byte (no Scapy dissectors), so `--self-test`
 and `--replay` of a pcap run with no radio and the self-test needs no Scapy at
@@ -40,6 +46,12 @@ def _u16(b, i):
 
 def _u32(b, i):
     return struct.unpack_from('<I', b, i)[0]
+
+
+def _be16(b, i):
+    """Big-endian u16 — EAPOL-Key fields are network byte order, unlike the
+    little-endian radiotap/802.11 fields _u16 reads."""
+    return (b[i] << 8) | b[i + 1]
 
 
 def _s8(v):
@@ -146,7 +158,10 @@ def _parse_rsn(v):
         i = 2 + 4                                    # version + group cipher
         pcnt = _u16(v, i); i += 2 + 4 * pcnt         # pairwise ciphers
         acnt = _u16(v, i); i += 2
-        akms = [_u32(v, i + 4 * k) & 0xff for k in range(acnt)]
+        # An AKM suite is OUI(3) + type(1); the selector is the *last* byte
+        # (00-0F-AC <type>), not the first — reading it little-endian & 0xff
+        # would yield the OUI byte 0x00 for every suite.
+        akms = [v[i + 4 * k + 3] for k in range(acnt) if i + 4 * k + 3 < len(v)]
         i += 4 * acnt
         caps = _u16(v, i) if i + 2 <= len(v) else 0
         return {'akms': akms, 'mfpc': bool(caps & 0x80), 'mfpr': bool(caps & 0x40)}
@@ -154,27 +169,112 @@ def _parse_rsn(v):
         return {'akms': [], 'mfpc': False, 'mfpr': False}
 
 
+def _parse_eapol(body):
+    """Given the 802.11 data-frame payload (after the MAC header), return the
+    4-way-handshake message info if it is an EAPOL-Key frame, else None.
+
+    Layout: LLC/SNAP (AA AA 03 00 00 00) + ethertype 0x888E, then EAPOL header
+    (version, type, length), then — for type 3, EAPOL-Key — the Key Descriptor.
+    The message number falls out of the Key Information bits, and M1 may carry a
+    PMKID KDE in its key data (the clientless-harvest handle)."""
+    if len(body) < 8 or body[:6] != b'\xaa\xaa\x03\x00\x00\x00':
+        return None
+    if body[6:8] != b'\x88\x8e':                     # not EAPOL
+        return None
+    e = body[8:]
+    if len(e) < 4 or e[1] != 3:                      # EAPOL type 3 = EAPOL-Key
+        return None
+    k = e[4:]                                        # Key Descriptor
+    if len(k) < 3:
+        return None
+    info = _be16(k, 1)                               # Key Information (network order)
+    mic = bool(info & 0x0100)
+    secure = bool(info & 0x0200)
+    ack = bool(info & 0x0080)
+    install = bool(info & 0x0040)
+    pairwise = bool(info & 0x0008)
+    if ack and not mic:
+        msg = 1
+    elif mic and not ack and not secure:
+        msg = 2
+    elif ack and mic and secure:
+        msg = 3
+    elif mic and not ack and secure:
+        msg = 4
+    else:
+        msg = 0
+    pmkid = False
+    # Key Data Length sits at a fixed offset; M1's key data may hold a PMKID KDE
+    # (DD <len> 00-0F-AC 04 <16-byte PMKID>).
+    if len(k) >= 97:
+        kdl = _be16(k, 93)                           # Key Data Length (network order)
+        kd = k[95:95 + kdl]
+        i = 0
+        while i + 6 <= len(kd):
+            if kd[i] == 0xdd and kd[i + 2:i + 5] == b'\x00\x0f\xac' and kd[i + 5] == 0x04:
+                pmkid = True
+                break
+            i += 2 + (kd[i + 1] if i + 1 < len(kd) else 0)
+    return {'msg': msg, 'pmkid': pmkid, 'pairwise': pairwise}
+
+
+def _data_hdrlen(fc0, fc1):
+    """MAC-header length for a data frame: 24 base, +6 for a 4-address (WDS)
+    frame, +2 for the QoS control field on a QoS-data subtype."""
+    to_ds = bool(fc1 & 0x01)
+    from_ds = bool(fc1 & 0x02)
+    subtype = (fc0 >> 4) & 0xf
+    n = 24
+    if to_ds and from_ds:
+        n += 6
+    if subtype & 0x08:                               # QoS data
+        n += 2
+    return n, to_ds, from_ds
+
+
 def parse_dot11(buf):
-    """Parse an 802.11 management frame (no radiotap). Returns a dict or None."""
+    """Parse an 802.11 management or data frame (no radiotap). Returns a dict or
+    None. Management frames carry SSID/RSN/reason; data frames are parsed only
+    far enough to surface an EAPOL 4-way-handshake message."""
     if len(buf) < 24:
         return None
     fc0, fc1 = buf[0], buf[1]
     ftype = (fc0 >> 2) & 0x3
     subtype = (fc0 >> 4) & 0xf
-    if ftype != 0:                                   # management only
-        return None
-    out = {'subtype': subtype, 'protected': bool(fc1 & 0x40),
-           'da': _mac(buf, 4), 'sa': _mac(buf, 10), 'bssid': _mac(buf, 16),
-           'ssid': None, 'reason': None, 'rsn': None}
-    body = buf[24:]
-    if subtype in (8, 5):                            # beacon / probe-resp
-        _parse_ies(body, 12, out)                    # skip fixed params
-    elif subtype == 4:                               # probe-req
-        _parse_ies(body, 0, out)
-    elif subtype in (10, 12):                        # disassoc / deauth
-        if len(body) >= 2:
-            out['reason'] = _u16(body, 0)
-    return out
+    if ftype == 0:                                   # management
+        out = {'ftype': 0, 'subtype': subtype, 'protected': bool(fc1 & 0x40),
+               'da': _mac(buf, 4), 'sa': _mac(buf, 10), 'bssid': _mac(buf, 16),
+               'ssid': None, 'reason': None, 'rsn': None, 'eapol': None}
+        body = buf[24:]
+        if subtype in (8, 5):                        # beacon / probe-resp
+            _parse_ies(body, 12, out)                # skip fixed params
+        elif subtype == 4:                           # probe-req
+            _parse_ies(body, 0, out)
+        elif subtype in (10, 12):                    # disassoc / deauth
+            if len(body) >= 2:
+                out['reason'] = _u16(body, 0)
+        return out
+    if ftype == 2:                                   # data — EAPOL only
+        if subtype & 0x04 and not (subtype & 0x08):  # Null data: no payload
+            return None
+        hdrlen, to_ds, from_ds = _data_hdrlen(fc0, fc1)
+        if len(buf) < hdrlen:
+            return None
+        a1, a2, a3 = _mac(buf, 4), _mac(buf, 10), _mac(buf, 16)
+        # Resolve station/BSSID/direction from the DS bits.
+        if to_ds and not from_ds:                    # STA -> AP
+            bssid, sa, da, to_ap = a1, a2, a3, True
+        elif from_ds and not to_ds:                  # AP -> STA
+            bssid, sa, da, to_ap = a2, a3, a1, False
+        else:                                        # IBSS / WDS
+            bssid, sa, da, to_ap = a3, a2, a1, None
+        out = {'ftype': 2, 'subtype': subtype, 'protected': bool(fc1 & 0x40),
+               'da': da, 'sa': sa, 'bssid': bssid, 'to_ap': to_ap,
+               'ssid': None, 'reason': None, 'rsn': None, 'eapol': None}
+        if not out['protected']:                     # 4-way handshake is unencrypted
+            out['eapol'] = _parse_eapol(buf[hdrlen:])
+        return out
+    return None                                      # control frames ignored
 
 
 def parse_frame(raw):
@@ -200,11 +300,21 @@ DEFAULTS = {
     'beacon_new_bssid_burst': 18, 'beacon_window': 8.0,
     'beacon_warmup_sec': 30.0, 'beacon_la_ratio': 0.5,
     'karma_ssid_min': 5,
+    # -- client / handshake protection (gap: WPA harvest, downgrade, PNL leak) --
+    'handshake_deauth_window': 10.0,  # deauth->handshake correlation window (s)
+    'handshake_msg_min': 2,           # distinct EAPOL msgs after a deauth to flag
+    'pnl_min_ssids': 4,               # distinct SSIDs a client leaks before flagging
+    'pnl_window': 300.0,              # PNL leak accounting window (s)
     'refractory_sec': 5.0,
     'allowlist': {},                                 # ssid -> [bssids]
 }
 SUBTYPE_NAME = {4: 'probe_req', 5: 'probe_resp', 8: 'beacon', 10: 'disassoc',
                 12: 'deauth'}
+
+# RSN AKM suite selectors (last byte of the 00-0F-AC OUI+type).
+AKM_PSK = {2, 6}                          # WPA2-Personal (PSK, PSK-SHA256)
+AKM_SAE = {8, 9, 24}                      # WPA3-Personal (SAE, FT-SAE, SAE-EXT)
+AKM_ENTERPRISE = {1, 3, 5, 11, 12, 13}   # 802.1X variants
 
 
 class WifiWatch:
@@ -226,6 +336,11 @@ class WifiWatch:
         self._beaconed = defaultdict(set)            # bssid -> ssids beaconed
         self._probe_reqs = deque()                   # (ts, ssid) directed probes
         self._refractory = {}                        # (detector, scope) -> ts
+        # client / handshake protection state
+        self._recent_deauth = {}                     # station -> last deauth ts
+        self._handshake = defaultdict(dict)          # station -> {msg: ts}
+        self._ssid_akm = defaultdict(set)            # ssid -> AKM suites ever seen
+        self._pnl = defaultdict(lambda: deque())     # station -> deque((ts, ssid))
         self.frames = 0
         self.stats = defaultdict(int)
 
@@ -266,6 +381,10 @@ class WifiWatch:
             f['freq'] = freq
             f['band'] = band_of(freq)
             f['channel'] = channel_of(freq)
+        if f.get('ftype') == 2:                      # data frame → EAPOL only
+            if f.get('eapol'):
+                self._on_eapol(f, ts)
+            return
         st = f['subtype']
         if st == 8:
             self._on_beacon(f, ts)
@@ -291,6 +410,7 @@ class WifiWatch:
                 self._new_bssids.append((ts, bssid))
         self._eval_beacon_flood(f, ts)
         self._eval_evil_twin(f, ts, ssid, bssid)
+        self._eval_downgrade(f, ts, ssid, bssid)
 
     def _eval_beacon_flood(self, f, ts):
         self._trim(self._new_bssids, ts, self.cfg['beacon_window'], keyed=True)
@@ -350,12 +470,113 @@ class WifiWatch:
                 'detail': {'ssid_count': n,
                            'ssids': sorted(self._ap_ssids[bssid])[:12]}}, ts)
         self._eval_evil_twin(f, ts, ssid, bssid)
+        self._eval_downgrade(f, ts, ssid, bssid)
 
     def _on_probe_req(self, f, ts):
         ssid = f.get('ssid')
         if ssid:                                     # directed probe (has SSID)
             self._probe_reqs.append((ts, ssid))
             self._trim(self._probe_reqs, ts, 30.0, keyed=True)
+            self._eval_pnl_leak(f, ts, ssid)
+
+    # -- PNL leak: a client broadcasting its saved-network list ---------------
+    def _eval_pnl_leak(self, f, ts, ssid):
+        """A device that directs probe requests at named SSIDs is broadcasting
+        its Preferred Network List — the exact input an evil-twin/KARMA rig
+        needs. Track distinct leaked SSIDs per client and flag once it exposes
+        enough of its PNL to be worth impersonating."""
+        sta = f['sa']
+        if sta == BROADCAST or is_locally_administered(sta):
+            return                                   # randomized MAC — not a stable device
+        dq = self._pnl[sta]
+        if not any(s == ssid for _t, s in dq):
+            dq.append((ts, ssid))
+        while dq and ts - dq[0][0] > self.cfg['pnl_window']:
+            dq.popleft()
+        ssids = sorted({s for _t, s in dq})
+        if len(ssids) >= self.cfg['pnl_min_ssids']:
+            self._fire('pnl_leak', sta, 'warning', {
+                'band': f['band'], 'channel': f['channel'], 'bssid': None,
+                'station': sta, 'ssid': ssid, 'signal_dbm': f['signal'],
+                'summary': '%s is leaking its saved-network list: %d SSIDs (%s) — '
+                           'evil-twin bait' % (sta, len(ssids),
+                           ', '.join(ssids[:6]) + ('…' if len(ssids) > 6 else '')),
+                'detail': {'station': sta, 'ssid_count': len(ssids),
+                           'ssids': ssids[:16],
+                           'window_sec': self.cfg['pnl_window']}}, ts)
+
+    # -- WPA3 downgrade / transition-mode exposure ---------------------------
+    def _eval_downgrade(self, f, ts, ssid, bssid):
+        """Two WPA3-era exposures, both read from the advertised RSN AKM suites:
+
+        * transition mode — one BSSID offering SAE *and* PSK together. A WPA3
+          client can be steered down to WPA2-PSK, whose handshake cracks offline.
+          Informational: it is a property of the real AP's config.
+        * active downgrade — an SSID we have seen offer SAE now appearing from a
+          BSSID that offers *only* PSK (no SAE). That is an evil twin stripping
+          WPA3, i.e. a live downgrade attack. Critical."""
+        rsn = f.get('rsn')
+        if not ssid or not rsn:
+            return
+        akms = set(rsn.get('akms') or [])
+        if not akms:
+            return
+        has_sae = bool(akms & AKM_SAE)
+        has_psk = bool(akms & AKM_PSK)
+        self._ssid_akm[ssid] |= akms
+        if has_sae and has_psk:
+            self._fire('wpa3_transition', ssid, 'info', {
+                'band': f['band'], 'channel': f['channel'], 'bssid': bssid,
+                'ssid': ssid, 'signal_dbm': f['signal'],
+                'summary': "SSID '%s' (%s) offers WPA3-SAE and WPA2-PSK together — "
+                           'downgradeable transition mode' % (ssid, bssid),
+                'detail': {'akms': sorted(akms), 'mfpr': rsn.get('mfpr'),
+                           'reason': 'transition_mode'}}, ts)
+        elif has_psk and not has_sae and (self._ssid_akm[ssid] & AKM_SAE):
+            # This SSID has been seen as SAE elsewhere but this BSSID is PSK-only.
+            self._fire('wpa_downgrade', ssid, 'critical', {
+                'band': f['band'], 'channel': f['channel'], 'bssid': bssid,
+                'ssid': ssid, 'signal_dbm': f['signal'],
+                'summary': "SSID '%s' is WPA3-SAE elsewhere but %s offers WPA2-PSK "
+                           'only — WPA3-strip downgrade / evil twin' % (ssid, bssid),
+                'detail': {'akms': sorted(akms), 'reason': 'wpa3_stripped'}}, ts)
+
+    # -- WPA handshake / PMKID harvest ---------------------------------------
+    def _on_eapol(self, f, ts):
+        """4-way-handshake exposure. Passively we cannot see a silent sniffer,
+        but we can see the two things that put a crackable handshake on the air:
+        an M1 carrying a PMKID (clientless-harvest handle), and a full handshake
+        that follows a deauth to the same client (deauth-and-capture)."""
+        eap = f['eapol']
+        msg = eap.get('msg')
+        # The station is the non-AP side of the exchange.
+        sta = f['sa'] if f.get('to_ap') else f['da']
+        bssid = f['bssid']
+        if msg == 1 and eap.get('pmkid'):
+            self._fire('pmkid_harvest', bssid, 'critical', {
+                'band': f['band'], 'channel': f['channel'], 'bssid': bssid,
+                'station': sta, 'ssid': None, 'signal_dbm': f['signal'],
+                'summary': '%s sent an EAPOL M1 with a PMKID — WPA/WPA2 PMKID is '
+                           'harvestable (offline-crackable) from %s' % (bssid, bssid),
+                'detail': {'msg': 1, 'pmkid': True, 'station': sta}}, ts)
+        if not msg:
+            return
+        hs = self._handshake[sta]
+        hs[msg] = ts
+        for m in list(hs):                           # forget a stale, partial handshake
+            if ts - hs[m] > self.cfg['handshake_deauth_window']:
+                del hs[m]
+        deauth_ts = self._recent_deauth.get(sta)
+        if (deauth_ts is not None
+                and ts - deauth_ts <= self.cfg['handshake_deauth_window']
+                and len(hs) >= self.cfg['handshake_msg_min']):
+            self._fire('handshake_harvest', sta, 'critical', {
+                'band': f['band'], 'channel': f['channel'], 'bssid': bssid,
+                'station': sta, 'ssid': None, 'signal_dbm': f['signal'],
+                'summary': '%s was deauthed then completed %d/4 EAPOL messages — '
+                           'forced-reconnect handshake capture' % (sta, len(hs)),
+                'detail': {'station': sta, 'msgs': sorted(hs),
+                           'deauth_lead_s': round(ts - deauth_ts, 2)}}, ts)
 
     # -- deauth / disassoc flood --------------------------------------------
     def _on_deauth(self, f, ts):
@@ -364,6 +585,10 @@ class WifiWatch:
         dst = f['da']
         protected = f['protected']
         reason = f.get('reason')
+        # Remember a client that was just deauthed — a 4-way handshake arriving
+        # for it shortly after is the classic deauth-and-capture harvest.
+        if dst != BROADCAST:
+            self._recent_deauth[dst] = ts
         common = {'band': f['band'], 'channel': f['channel'], 'bssid': bssid,
                   'ssid': None, 'signal_dbm': f['signal']}
         if dst == BROADCAST:

--- a/python/wifiwatch_selftest.py
+++ b/python/wifiwatch_selftest.py
@@ -42,13 +42,78 @@ def proberesp(bssid, ssid):
     return radiotap() + _dot11(5, '00:11:22:33:44:55', bssid, bssid, body)
 
 
-def probereq(ssid):
-    return radiotap() + _dot11(4, 'ff:ff:ff:ff:ff:ff', '00:11:22:33:44:55',
+def probereq(ssid, src='00:11:22:33:44:55'):
+    return radiotap() + _dot11(4, 'ff:ff:ff:ff:ff:ff', src,
                                'ff:ff:ff:ff:ff:ff', _ie(0, ssid.encode()))
 
 
 def deauth(src, dst, reason=7, protected=False, subtype=12):
     return radiotap() + _dot11(subtype, dst, src, src, struct.pack('<H', reason), protected)
+
+
+def _rsn(akm_types, mfpc=False, mfpr=False):
+    """RSN element body: CCMP group+pairwise, the given AKM suites, PMF caps."""
+    caps = (0x80 if mfpc else 0) | (0x40 if mfpr else 0)
+    body = b'\x01\x00'                                # version
+    body += b'\x00\x0f\xac\x04'                       # group cipher CCMP
+    body += b'\x01\x00' + b'\x00\x0f\xac\x04'         # 1 pairwise cipher CCMP
+    body += struct.pack('<H', len(akm_types))
+    for t in akm_types:
+        body += b'\x00\x0f\xac' + bytes([t])          # 00-0F-AC AKM suites
+    body += struct.pack('<H', caps)
+    return body
+
+
+def beacon_rsn(bssid, ssid, akm_types, freq=2437, mfpc=False, mfpr=False):
+    body = (b'\x00' * 8 + b'\x64\x00' + b'\x01\x00' + _ie(0, ssid.encode())
+            + _ie(48, _rsn(akm_types, mfpc, mfpr)))
+    return radiotap(freq) + _dot11(8, 'ff:ff:ff:ff:ff:ff', bssid, bssid, body)
+
+
+def _data(a1, a2, a3, payload, to_ds, from_ds, qos=False, protected=False):
+    subtype = 8 if qos else 0
+    fc0 = (2 << 2) | (subtype << 4)                   # type 2 = data
+    fc1 = (0x01 if to_ds else 0) | (0x02 if from_ds else 0) | (0x40 if protected else 0)
+    hdr = bytes([fc0, fc1, 0, 0]) + _mac(a1) + _mac(a2) + _mac(a3) + b'\x00\x00'
+    if qos:
+        hdr += b'\x00\x00'
+    return hdr
+
+
+# EAPOL Key Information bits (network order).
+_KI = {'mic': 0x0100, 'secure': 0x0200, 'ack': 0x0080, 'install': 0x0040,
+       'pairwise': 0x0008}
+
+
+def eapol(bssid, station, msg, pmkid=False, from_ap=None):
+    """Build a data frame carrying EAPOL-Key message `msg` (1-4). M1/M3 flow
+    AP->STA, M2/M4 STA->AP. Key Information is big-endian on the wire."""
+    if from_ap is None:
+        from_ap = msg in (1, 3)
+    info = _KI['pairwise']
+    if msg == 1:
+        info |= _KI['ack']
+    elif msg == 2:
+        info |= _KI['mic']
+    elif msg == 3:
+        info |= _KI['ack'] | _KI['mic'] | _KI['secure'] | _KI['install']
+    elif msg == 4:
+        info |= _KI['mic'] | _KI['secure']
+    kd = b''
+    if pmkid:
+        kd = bytes([0xdd, 0x14]) + b'\x00\x0f\xac\x04' + b'\x11' * 16   # PMKID KDE
+    # Key Descriptor: type(1) info(2,BE) keylen(2) replay(8) nonce(32) iv(16)
+    # rsc(8) reserved(8) mic(16) key_data_len(2,BE) key_data(N)
+    k = (bytes([2]) + struct.pack('>H', info) + b'\x00\x10' + b'\x00' * 8
+         + b'\x00' * 32 + b'\x00' * 16 + b'\x00' * 8 + b'\x00' * 8 + b'\x00' * 16
+         + struct.pack('>H', len(kd)) + kd)
+    eap = bytes([2, 3]) + struct.pack('>H', len(k)) + k                # EAPOL-Key
+    payload = b'\xaa\xaa\x03\x00\x00\x00\x88\x8e' + eap                # LLC/SNAP + EAPOL
+    if from_ap:                                                       # AP -> STA
+        hdr = _data(station, bssid, bssid, payload, to_ds=False, from_ds=True, qos=True)
+    else:                                                            # STA -> AP
+        hdr = _data(bssid, station, bssid, payload, to_ds=True, from_ds=False, qos=True)
+    return radiotap() + hdr + payload
 
 
 class H:
@@ -194,6 +259,93 @@ def run(verbose=True):
         wt.handle(deauth('aa:bb:cc:00:00:01', w.BROADCAST), ts=500 + i * 0.5)
     n_alerts = sum(1 for e in evs if e['detector'] == 'deauth_flood')
     h.ck('refractory rate-limits alerts (not one per frame)', 1 <= n_alerts <= 8)
+
+    # ---- EAPOL parser -----------------------------------------------------
+    f = w.parse_frame(eapol('aa:bb:cc:00:00:01', 'dd:ee:ff:00:00:09', 1))
+    h.ck('parse data frame ftype', f and f['ftype'] == 2)
+    h.ck('parse EAPOL M1', f and f['eapol'] and f['eapol']['msg'] == 1)
+    f2 = w.parse_frame(eapol('aa:bb:cc:00:00:01', 'dd:ee:ff:00:00:09', 2))
+    h.ck('parse EAPOL M2 (STA->AP)', f2 and f2['eapol']['msg'] == 2 and f2['to_ap'] is True)
+    f3 = w.parse_frame(eapol('aa:bb:cc:00:00:01', 'dd:ee:ff:00:00:09', 3))
+    h.ck('parse EAPOL M3', f3 and f3['eapol']['msg'] == 3)
+    f4 = w.parse_frame(eapol('aa:bb:cc:00:00:01', 'dd:ee:ff:00:00:09', 4))
+    h.ck('parse EAPOL M4', f4 and f4['eapol']['msg'] == 4)
+    fp = w.parse_frame(eapol('aa:bb:cc:00:00:01', 'dd:ee:ff:00:00:09', 1, pmkid=True))
+    h.ck('parse PMKID KDE in M1', fp and fp['eapol']['pmkid'] is True)
+    h.ck('no PMKID false-positive on plain M1', f and f['eapol']['pmkid'] is False)
+
+    # ---- PMKID harvest ----------------------------------------------------
+    wt, evs = _watch({'beacon_warmup_sec': 0})
+    wt.handle(eapol('aa:bb:cc:00:00:01', 'dd:ee:ff:00:00:09', 1, pmkid=True), ts=1)
+    ph = [e for e in evs if e['detector'] == 'pmkid_harvest']
+    h.ck('PMKID M1 -> pmkid_harvest critical', ph and ph[0]['severity'] == 'critical')
+    # a normal M1 without a PMKID must not trip it
+    wt, evs = _watch({'beacon_warmup_sec': 0})
+    wt.handle(eapol('aa:bb:cc:00:00:01', 'dd:ee:ff:00:00:09', 1), ts=1)
+    h.ck('plain M1 -> no pmkid_harvest',
+         not any(e['detector'] == 'pmkid_harvest' for e in evs))
+
+    # ---- deauth-and-capture handshake harvest -----------------------------
+    sta = 'dd:ee:ff:00:00:09'
+    wt, evs = _watch({'beacon_warmup_sec': 0})
+    wt.handle(deauth('aa:bb:cc:00:00:01', sta), ts=100)            # forced reconnect
+    for m in (1, 2, 3, 4):
+        wt.handle(eapol('aa:bb:cc:00:00:01', sta, m), ts=100.5 + m * 0.1)
+    hh = [e for e in evs if e['detector'] == 'handshake_harvest']
+    h.ck('deauth then 4-way -> handshake_harvest critical', hh and hh[0]['severity'] == 'critical')
+    h.ck('handshake_harvest reports messages', hh and len(hh[0]['detail']['msgs']) >= 2)
+    # a handshake with no preceding deauth is normal roaming -> quiet
+    wt, evs = _watch({'beacon_warmup_sec': 0})
+    for m in (1, 2, 3, 4):
+        wt.handle(eapol('aa:bb:cc:00:00:01', sta, m), ts=200 + m * 0.1)
+    h.ck('handshake without deauth -> no harvest alert',
+         not any(e['detector'] == 'handshake_harvest' for e in evs))
+    # deauth long before the handshake is outside the window -> quiet
+    wt, evs = _watch({'beacon_warmup_sec': 0, 'handshake_deauth_window': 10.0})
+    wt.handle(deauth('aa:bb:cc:00:00:01', sta), ts=300)
+    for m in (1, 2, 3, 4):
+        wt.handle(eapol('aa:bb:cc:00:00:01', sta, m), ts=320 + m * 0.1)
+    h.ck('stale deauth outside window -> no harvest',
+         not any(e['detector'] == 'handshake_harvest' for e in evs))
+
+    # ---- WPA3 downgrade / transition --------------------------------------
+    wt, evs = _watch({'beacon_warmup_sec': 0})
+    wt.handle(beacon_rsn('aa:aa:aa:00:00:01', 'SecureNet', [8, 2]), ts=1)   # SAE+PSK
+    tr = [e for e in evs if e['detector'] == 'wpa3_transition']
+    h.ck('SAE+PSK beacon -> wpa3_transition info', tr and tr[0]['severity'] == 'info')
+    # SSID seen as SAE, then a PSK-only BSSID appears -> active downgrade
+    wt, evs = _watch({'beacon_warmup_sec': 0})
+    wt.handle(beacon_rsn('aa:aa:aa:00:00:01', 'SecureNet', [8], mfpc=True, mfpr=True), ts=1)
+    wt.handle(beacon_rsn('66:66:66:66:66:66', 'SecureNet', [2]), ts=2)      # PSK-only twin
+    dg = [e for e in evs if e['detector'] == 'wpa_downgrade']
+    h.ck('WPA3 SSID reappearing PSK-only -> wpa_downgrade critical',
+         dg and dg[0]['severity'] == 'critical')
+    # a pure WPA3 network is not a downgrade
+    wt, evs = _watch({'beacon_warmup_sec': 0})
+    wt.handle(beacon_rsn('aa:aa:aa:00:00:01', 'PureWPA3', [8], mfpc=True, mfpr=True), ts=1)
+    h.ck('pure SAE network -> no downgrade/transition alert',
+         not any(e['detector'] in ('wpa_downgrade', 'wpa3_transition') for e in evs))
+
+    # ---- PNL leak ---------------------------------------------------------
+    wt, evs = _watch({'beacon_warmup_sec': 0, 'pnl_min_ssids': 4})
+    for s in ['HomeNet', 'Office', 'Starbucks', 'AirportFree', 'Hotel']:
+        wt.handle(probereq(s, src='11:22:33:44:55:66'), ts=1)
+    pl = [e for e in evs if e['detector'] == 'pnl_leak']
+    h.ck('client leaking 5 SSIDs -> pnl_leak', pl and pl[0]['severity'] == 'warning')
+    h.ck('pnl_leak lists the SSIDs', pl and pl[0]['detail']['ssid_count'] >= 4)
+    h.ck('pnl_leak names the station', pl and pl[0]['station'] == '11:22:33:44:55:66')
+    # a device probing for just one saved net is normal
+    wt, evs = _watch({'beacon_warmup_sec': 0, 'pnl_min_ssids': 4})
+    for _ in range(6):
+        wt.handle(probereq('HomeNet', src='11:22:33:44:55:66'), ts=1)
+    h.ck('single-SSID probe -> no pnl_leak',
+         not any(e['detector'] == 'pnl_leak' for e in evs))
+    # a randomized (locally-administered) MAC is not tracked as a device
+    wt, evs = _watch({'beacon_warmup_sec': 0, 'pnl_min_ssids': 4})
+    for s in ['A', 'B', 'C', 'D', 'E']:
+        wt.handle(probereq(s, src='02:11:22:33:44:55'), ts=1)   # LA bit set
+    h.ck('randomized-MAC probes -> no pnl_leak (privacy MAC)',
+         not any(e['detector'] == 'pnl_leak' for e in evs))
 
     total = h.n
     passed = total - h.fail


### PR DESCRIPTION
Closes the WiFi client/handshake gap: wifi_defense/wifiwatch caught AP/RF attacks (deauth/beacon/evil-twin/KARMA) but nothing on the layer that actually gets a WPA key cracked. Extends the standalone wifiwatch — no new tool.

New detectors:
- pmkid_harvest (crit): EAPOL M1 carrying a PMKID KDE — clientless offline-crack handle on the air.
- handshake_harvest (crit): a client deauthed then completing >=2/4 EAPOL msgs within 10s — deauth-and-capture. A handshake with no preceding deauth (normal roaming) stays quiet.
- wpa3_transition (info) / wpa_downgrade (crit): SAE+PSK on one BSSID is a downgradeable transition AP; a known-SAE SSID reappearing PSK-only is a live WPA3-strip evil twin.
- pnl_leak (warn): a non-randomized client MAC directing probes at >=4 SSIDs is broadcasting its Preferred Network List — evil-twin bait. Privacy-randomized (LA-bit) MACs are ignored.

Parser: parse 802.11 data frames far enough to decode EAPOL-Key (message number from Key Information, PMKID KDE in M1), with DS-bit-aware station/BSSID/direction resolution. Two byte-level bugs fixed and caught by the tests:
- EAPOL Key Information + Key-Data-Length are big-endian (network order); the radiotap/802.11 _u16 is little-endian. Added _be16 and used it, so message classification is correct on real captures rather than only self-consistent.
- _parse_rsn read the AKM suite type as the OUI's first byte (00) instead of the selector's last byte, so every AKM parsed as 0. Latent since no detector consumed akms before; the downgrade detectors are the first to.

Self-test 51/51 (was 30/30): EAPOL M1-M4 + PMKID parse, each new detector, and the negative controls (plain M1, handshake without deauth, stale deauth outside window, pure-SAE net, single-SSID probe, randomized-MAC probes). Regression: watchtower 31/31, ndpwatch 24/24 still green; new detectors normalize cleanly through Watchtower.