### PR TITLE
wifi defense: SSID column in airtime table; all three tables pivot to…

### DIFF
--- a/docs/wifi-defense.md
+++ b/docs/wifi-defense.md
@@ -121,7 +121,8 @@ You can also run it directly: `python3 wifi_defense.py dedicate --interface wlan
 ### Pivot to the Spectrum Analyzer
 
 Every BSSID in a detection card (evil twin / duplicate SSID, KARMA, the source
-MAC of a deauth attacker) and every row of the **Access Points seen** table is
+MAC of a deauth attacker) and every row of the **Access Points seen**,
+**Airtime & link quality** and **Client isolation observer** tables is
 clickable — it jumps to **Network → WiFi Analyzer**, selects that AP and marks
 it in the spectrum with a red dashed **⚠ WIDS** locator (band filter is widened
 to *All* so it can't be hidden). A red *"Flagged by WiFi Defense"* banner above
@@ -154,11 +155,13 @@ Detection-only; the only state written is the trusted-AP baseline.
 
 A separate passive diagnostic (the "why is it slow" view). Capture all 802.11
 frames — ideally on a **fixed channel** (airtime % is only meaningful when not
-hopping) — and get, per AP: **airtime %** (estimated on-air time / capture time),
-**retry rate** (retransmit flag), the **PHY-rate spread** (min/median/max Mbps),
-plus **roaming churn** (clients re-associating/authing repeatedly). Findings flag
-high retry (≥30%), airtime hogs (≥50%) and unstable roaming. Route
-`GET /api/wifidef/airtime`; analysis is a pure function covered by selftest.
+hopping) — and get, per AP: the **SSID** (named from beacons/probe responses
+heard in the capture; a BSSID that only sent data frames shows —), **airtime %**
+(estimated on-air time / capture time), **retry rate** (retransmit flag), the
+**PHY-rate spread** (min/median/max Mbps), plus **roaming churn** (clients
+re-associating/authing repeatedly). Findings flag high retry (≥30%), airtime
+hogs (≥50%) and unstable roaming. Route `GET /api/wifidef/airtime`; analysis is
+a pure function covered by selftest.
 
 ## Client isolation observer
 

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -2398,7 +2398,7 @@
             <div class="glass rounded-xl p-4 mt-5">
                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-3">
                     <div>
-                        <h3 class="font-semibold text-sm">Airtime &amp; link quality</h3>
+                        <h3 class="font-semibold text-sm">Airtime &amp; link quality <span class="text-[11px] text-gray-500 font-normal">— click a row to inspect it in the Spectrum Analyzer</span></h3>
                         <p class="text-[11px] text-gray-500 mt-0.5 max-w-2xl">Passive per-AP <strong>airtime %</strong>, <strong>retry rate</strong> and <strong>PHY-rate</strong> spread, plus roaming churn — the "why is it slow" view. Best on a <strong>fixed channel</strong> (airtime % is only meaningful when not hopping).</p>
                     </div>
                     <div class="flex flex-wrap items-end gap-2">
@@ -2412,9 +2412,9 @@
                 <div class="overflow-x-auto">
                     <table class="w-full text-sm">
                         <thead><tr class="text-left text-gray-400 border-b border-slate-800">
-                            <th class="py-1 pr-2">BSSID</th><th class="py-1 pr-2">Frames</th><th class="py-1 pr-2">Retry %</th><th class="py-1 pr-2">Airtime %</th><th class="py-1 pr-2">Rate min/med/max</th><th class="py-1 pr-2">RSSI</th>
+                            <th class="py-1 pr-2">SSID</th><th class="py-1 pr-2">BSSID</th><th class="py-1 pr-2">Frames</th><th class="py-1 pr-2">Retry %</th><th class="py-1 pr-2">Airtime %</th><th class="py-1 pr-2">Rate min/med/max</th><th class="py-1 pr-2">RSSI</th>
                         </tr></thead>
-                        <tbody id="wifidef-at-tbody"><tr><td colspan="6" class="py-4 text-center text-gray-500">Press <span class="text-gray-300">Analyze airtime</span> (needs monitor mode).</td></tr></tbody>
+                        <tbody id="wifidef-at-tbody"><tr><td colspan="7" class="py-4 text-center text-gray-500">Press <span class="text-gray-300">Analyze airtime</span> (needs monitor mode).</td></tr></tbody>
                     </table>
                 </div>
                 <div id="wifidef-at-roam" class="mt-2 text-xs text-gray-400"></div>
@@ -2424,7 +2424,7 @@
             <div class="glass rounded-xl p-4 mt-5">
                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-3">
                     <div>
-                        <h3 class="font-semibold text-sm">Client isolation observer</h3>
+                        <h3 class="font-semibold text-sm">Client isolation observer <span class="text-[11px] text-gray-500 font-normal">— click a row to inspect it in the Spectrum Analyzer</span></h3>
                         <p class="text-[11px] text-gray-500 mt-0.5 max-w-2xl">Audits whether an AP or mesh enforces <strong>client isolation</strong> — purely passively, from cleartext 802.11 headers (works on encrypted networks; payloads are never read). If the AP is seen <strong>relaying unicast frames between two of its own wireless clients</strong>, isolation is <strong>OFF</strong>; if clients address each other (or broadcast) but the AP relays nothing back, it's <strong>blocking</strong>. A multi-node SSID gets a mesh rollup incl. <strong>cross-node forwarding</strong>. Best on a <strong>fixed channel</strong> — catching a request <em>and</em> its relay needs to dwell on the BSS's channel.</p>
                     </div>
                     <div class="flex flex-wrap items-end gap-2">
@@ -6663,7 +6663,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260718-wids-pivot"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260718-wids-pivot2"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -2921,7 +2921,7 @@ function _wifidefUpdateRunUI() {
 // Must match wifi_defense.py `_BUILD`. If the running service reports something
 // else, the webapp is executing an OLD wifi_defense module (service not restarted
 // after a git pull) — the #1 cause of "the fix didn't work in the web UI".
-const WIFIDEF_BUILD = '20260713-dedicated';
+const WIFIDEF_BUILD = '20260718-airtime-ssid';
 
 function _wifidefFillIfaces() {
     fetch('/api/wifidef/interfaces').then(r => r.json()).then(d => {
@@ -3149,12 +3149,13 @@ function wifidefRenderAirtime(d) {
     }).join('') || '<span class="text-green-400 text-xs">✓ No link-quality issues in this capture.</span>';
     const tb = document.getElementById('wifidef-at-tbody');
     const aps = d.aps || [];
-    if (!aps.length) { tb.innerHTML = '<tr><td colspan="6" class="py-4 text-center text-gray-500">No frames captured (wrong channel? adapter idle?).</td></tr>'; }
+    if (!aps.length) { tb.innerHTML = '<tr><td colspan="7" class="py-4 text-center text-gray-500">No frames captured (wrong channel? adapter idle?).</td></tr>'; }
     else tb.innerHTML = aps.map(a => {
         const retryCol = a.retry_pct >= 30 ? 'text-red-400' : a.retry_pct >= 15 ? 'text-amber-400' : 'text-gray-300';
         const airCol = a.airtime_pct >= 50 ? 'text-orange-400' : 'text-gray-300';
         const rate = a.rate_med != null ? `${a.rate_min}/${a.rate_med}/${a.rate_max}` : '—';
-        return `<tr class="border-b border-slate-800/50">
+        return `<tr class="border-b border-slate-800/50 cursor-pointer hover:bg-slate-800/40" title="Open in Spectrum Analyzer" onclick="wifiPivotFromDefense('${a.bssid}','${encodeURIComponent(a.ssid || '').replace(/'/g, '%27')}')">
+            <td class="py-1 pr-2">${a.ssid ? _esc(a.ssid) : '<span class="text-gray-600">—</span>'}</td>
             <td class="py-1 pr-2 font-mono text-[11px]">${a.bssid}</td>
             <td class="py-1 pr-2">${a.frames} <span class="text-gray-600 text-[10px]">(${a.data_frames} data)</span></td>
             <td class="py-1 pr-2 ${retryCol}">${a.retry_pct}%</td>
@@ -3213,7 +3214,7 @@ function wifidefRenderIsolation(d) {
     const bss = d.bss || [];
     if (!bss.length) {
         tb.innerHTML = '<tr><td colspan="7" class="py-4 text-center text-gray-500">No data frames captured — wrong channel, or the air is idle.</td></tr>';
-    } else tb.innerHTML = bss.map(b => `<tr class="border-b border-slate-800/50">
+    } else tb.innerHTML = bss.map(b => `<tr class="border-b border-slate-800/50 cursor-pointer hover:bg-slate-800/40" title="Open in Spectrum Analyzer" onclick="wifiPivotFromDefense('${b.bssid}','${encodeURIComponent(b.ssid || '').replace(/'/g, '%27')}')">
             <td class="py-1 pr-2">${b.ssid ? _esc(b.ssid) : '<span class="text-gray-600">—</span>'}</td>
             <td class="py-1 pr-2 font-mono text-[11px]">${b.bssid}</td>
             <td class="py-1 pr-2">${b.clients}</td>

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -49,7 +49,7 @@ _STATE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 # the web UI (WIFIDEF_BUILD in ragnar_modern.js). The UI compares them and warns
 # if the running (long-lived) webapp still has an OLD wifi_defense module loaded,
 # i.e. the service wasn't restarted after a git pull. Kills stale-service guesswork.
-_BUILD = "20260713-dedicated"
+_BUILD = "20260718-airtime-ssid"
 
 # Detection thresholds (per capture window)
 _DEAUTH_FLOOD_MIN = 15      # deauth+disassoc frames => flood
@@ -650,7 +650,7 @@ def _frame_rate_mbps(rt):
 
 def _airtime_event(pkt):
     """Normalize ANY 802.11 frame for airtime/retry/roaming stats (or None)."""
-    from scapy.all import Dot11
+    from scapy.all import Dot11, Dot11Elt
     if not pkt.haslayer(Dot11):
         return None
     d = pkt.getlayer(Dot11)
@@ -664,6 +664,18 @@ def _airtime_event(pkt):
         "bytes": len(bytes(d)),
         "rate_mbps": None, "rssi": None,
     }
+    # Beacons / probe responses name the BSS — lets the report show an SSID
+    # column instead of bare BSSIDs.
+    if d.type == 0 and d.subtype in (5, 8):
+        el = pkt.getlayer(Dot11Elt)
+        while el is not None and isinstance(el, Dot11Elt):
+            if el.ID == 0:
+                try:
+                    ev["ssid"] = el.info.decode(errors="replace") or None
+                except Exception:
+                    pass
+                break
+            el = el.payload.getlayer(Dot11Elt)
     try:
         from scapy.all import RadioTap
         if pkt.haslayer(RadioTap):
@@ -696,10 +708,12 @@ def analyze_airtime(events, seconds=None):
         b = e.get("bssid")
         # Airtime/retry keyed on the AP (BSSID) for data + mgmt frames.
         if b:
-            ap = aps.setdefault(b, {"bssid": b, "frames": 0, "retries": 0,
-                                    "airtime_us": 0.0, "rates": [], "rssi": None,
-                                    "data_frames": 0})
+            ap = aps.setdefault(b, {"bssid": b, "ssid": None, "frames": 0,
+                                    "retries": 0, "airtime_us": 0.0, "rates": [],
+                                    "rssi": None, "data_frames": 0})
             ap["frames"] += 1
+            if e.get("ssid"):
+                ap["ssid"] = e["ssid"]
             if e.get("retry"):
                 ap["retries"] += 1
             if e["type"] == 2:               # data


### PR DESCRIPTION
… analyzer

The Airtime & link quality table was the only WiFi Defense table without an SSID column — the airtime frame parser now names the BSS from beacons and probe responses heard in the capture (data-only BSSIDs show —), and analyze_airtime carries it per AP. Rows of the airtime and client isolation tables are now clickable like the Access Points seen table: each pivots to Network → WiFi Analyzer with the BSSID selected and highlighted in the spectrum. Build stamp bumped on both sides (_BUILD / WIFIDEF_BUILD = 20260718-airtime-ssid) since the airtime payload gained a field. selftest 63/63.