### PR TITLE
wifi-analyzer: filter AP list by Wi-Fi generation (7/6E/6/5/4/legacy)

### DIFF
--- a/docs/wifi-analyzer.md
+++ b/docs/wifi-analyzer.md
@@ -45,10 +45,12 @@ the Alfa AWUS036AXM and 2.4/5 GHz on the Pi's onboard radio automatically.
 ## AP inventory, networks & export
 
 The AP table is sortable on 9 columns (SSID, Vendor, Band, Channel, Width, Rate,
-Signal, Security, Utilisation), with a **search** box and an **issues-only**
-filter. Generation and security are shown as inline badges (Wi‑Fi 6E, 802.1X,
-PMF, WPS, 11k/v/r). A **Networks** view collapses BSSIDs that share an SSID into
-one logical network (bands, AP count, best signal). **Export CSV** dumps the full
+Signal, Security, Utilisation), with a **search** box, an **issues-only**
+filter, and a **generation filter** (Wi‑Fi 7 / 6E / 6 / 5 / 4 / legacy — applies
+to both the AP and Networks views). Generation and security are shown as inline
+badges (Wi‑Fi 6E, 802.1X, PMF, WPS, 11k/v/r). A **Networks** view collapses
+BSSIDs that share an SSID into one logical network (bands, AP count, best
+signal). **Export CSV** dumps the full
 enriched inventory for offline analysis.
 
 ---

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -2137,6 +2137,15 @@
                                 <button id="wifi-view-nets" onclick="wifiSetApView('nets')" class="px-2.5 py-1 text-xs text-slate-300 hover:bg-slate-700">Networks</button>
                             </div>
                             <input id="wifi-ap-search" oninput="wifiRenderTable()" placeholder="filter SSID / vendor / BSSID" class="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-xs flex-1 min-w-[140px]">
+                            <select id="wifi-ap-std" onchange="wifiRenderTable()" title="filter by Wi-Fi generation" class="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-xs text-gray-300">
+                                <option value="">all gens</option>
+                                <option value="Wi-Fi 7">Wi-Fi 7</option>
+                                <option value="Wi-Fi 6E">Wi-Fi 6E</option>
+                                <option value="Wi-Fi 6">Wi-Fi 6</option>
+                                <option value="Wi-Fi 5">Wi-Fi 5</option>
+                                <option value="Wi-Fi 4">Wi-Fi 4</option>
+                                <option value="legacy">Legacy (a/b/g)</option>
+                            </select>
                             <label class="flex items-center gap-1 text-xs text-gray-400 cursor-pointer select-none"><input type="checkbox" id="wifi-ap-issues" onchange="wifiRenderTable()" class="accent-amber-500"> issues only</label>
                             <button onclick="wifiExportCsv()" class="bg-slate-700 hover:bg-slate-600 text-gray-200 px-2.5 py-1 rounded text-xs">Export CSV</button>
                         </div>
@@ -6663,7 +6672,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260718-wids-pivot2"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260719-wifi-gen-filter"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -1429,9 +1429,11 @@ function wifiRenderTable() {
     if (_wifiState.apView === 'nets') return wifiRenderNets();
     const q = (document.getElementById('wifi-ap-search').value || '').toLowerCase();
     const issuesOnly = document.getElementById('wifi-ap-issues').checked;
+    const std = (document.getElementById('wifi-ap-std') || {}).value || '';
     let aps = d.aps.filter(a =>
         (!q || (a.ssid || '').toLowerCase().includes(q) || (a.vendor || '').toLowerCase().includes(q) || a.bssid.includes(q))
-        && (!issuesOnly || (a.security_findings && a.security_findings.length)));
+        && (!issuesOnly || (a.security_findings && a.security_findings.length))
+        && (!std || a.standard === std));
     const k = _wifiState.sortKey, dir = _wifiState.sortDir;
     aps = aps.slice().sort((x, y) => {
         let a = x[k], b = y[k];
@@ -1471,7 +1473,9 @@ function wifiRenderTable() {
 function wifiRenderNets() {
     const d = _wifiState.data; if (!d || !d.groups) return;
     const q = (document.getElementById('wifi-ap-search').value || '').toLowerCase();
-    let nets = d.groups.networks.filter(n => !q || n.ssid.toLowerCase().includes(q));
+    const std = (document.getElementById('wifi-ap-std') || {}).value || '';
+    let nets = d.groups.networks.filter(n =>
+        (!q || n.ssid.toLowerCase().includes(q)) && (!std || n.standard === std));
     const el = document.getElementById('wifi-nets-view');
     document.getElementById('wifi-ap-count').textContent = `(${nets.length} networks · ${d.groups.device_count} devices)`;
     el.innerHTML = nets.map(n => `<div class="flex items-center justify-between gap-2 py-1.5 border-b border-slate-800/50">


### PR DESCRIPTION
Adds a generation dropdown next to the AP search box; filters both the APs table and the collapsed Networks view on the parsed 'standard' field. JS cache-buster bumped; docs updated.