### PR TITLE
nettools: ARP Scan card gets interface dropdown like the other L2/L3 …

### DIFF
--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -829,11 +829,14 @@ column showing:
 > guaranteed "no power".
 
 ### ARP Scan
-Sweeps the local segment with ARP to enumerate **live hosts** on a chosen
-interface, returning IP, MAC and (where known) NIC vendor for each responder.
-The fastest way to inventory a subnet you're attached to. Results export to CSV.
+Sweeps the local segment with ARP to enumerate **live hosts**, returning IP,
+MAC and (where known) NIC vendor for each responder. The fastest way to
+inventory a subnet you're attached to. An **interface selector**
+(Auto / WiFi / LAN) targets the sweep at a chosen segment — Auto prefers a
+link-up wired port, falling back to the default-route interface. Results
+export to CSV.
 
-- Endpoint: `GET /api/net/arp-scan?interface=<iface>` · binary: `arp-scan`
+- Endpoint: `GET /api/net/arp-scan[?interface=<iface>]` · binary: `arp-scan`
 
 > This is an **inventory** sweep, not a security check. For ARP **spoofing /
 > poisoning** detection (gateway-MAC watch + subnet impersonation), see

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -632,11 +632,15 @@ def _parse_lldp_iface(local_if, info):
     }
 
 
-def do_arp_scan(interface):
+def do_arp_scan(interface=None):
     if not _have('arp-scan'):
         return {'success': False,
                 'error': 'arp-scan is not installed. Click Install to add it.',
                 'missing_tool': 'arp-scan', 'hosts': []}
+    interface = _capture_iface(interface)
+    if not interface:
+        return {'success': False, 'hosts': [],
+                'error': 'No suitable interface found — pick one explicitly.'}
     res = _run(['arp-scan', f'--interface={interface}', '--localnet'], timeout=40)
     if res['rc'] == 127:
         return {'success': False, 'error': res['err'] or 'arp-scan not found',
@@ -14204,10 +14208,10 @@ def register_network_diagnostics(app, logger=None):
     @app.route('/api/net/arp-scan', methods=['GET'])
     def net_arp_scan():
         iface = (request.args.get('interface') or '').strip()
-        if not _valid_iface(iface):
-            return _bad('Invalid or missing interface')
-        _log(f"net/arp-scan {iface}")
-        return jsonify(do_arp_scan(iface))
+        if iface and not _valid_iface(iface):
+            return _bad('Invalid interface')
+        _log(f"net/arp-scan {iface or 'auto'}")
+        return jsonify(do_arp_scan(iface or None))
 
     @app.route('/api/net/arp-check', methods=['GET'])
     def net_arp_check():

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -1630,8 +1630,10 @@
                         <h3 class="text-lg font-semibold">ARP Scan</h3>
                         <p class="text-sm text-gray-400">Discover live hosts on the local segment via ARP.</p>
                     </div>
-                    <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-2">
-                        <input id="arp-iface" type="text" autocomplete="off" placeholder="interface (e.g. eth0)" class="w-full sm:w-auto sm:flex-1 sm:min-w-[12rem] bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm" onkeydown="if(event.key==='Enter')runArpScan()">
+                    <div class="flex flex-wrap items-center gap-2">
+                        <select id="arp-iface" title="Interface for the ARP scan — pick your WiFi or LAN NIC to scan that segment" class="w-full sm:w-auto bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-gray-300">
+                            <option value="">Auto (wired first)</option>
+                        </select>
                         <button onclick="runArpScan()" class="w-full sm:w-auto bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Scan</button>
                         <button onclick="exportArpCsv()" class="w-full sm:w-auto bg-slate-700 hover:bg-slate-600 text-gray-200 px-3 py-2 rounded text-sm whitespace-nowrap">Export CSV</button>
                     </div>
@@ -6672,7 +6674,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260719-wifi-gen-filter"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260719-arp-iface-dropdown"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -1218,6 +1218,7 @@ function showNetworkSubtab(name) {
         loadNetworkData();
     } else if (name === 'switch') {
         loadLldp();
+        _arpScanFillIfaces();
         _dhcpFillIfaces();
         _igmpFillIfaces();
         _ipv6FillIfaces();
@@ -3836,17 +3837,31 @@ async function loadLldp() {
     }
 }
 
+function _arpScanFillIfaces() {
+    const sel = document.getElementById('arp-iface');
+    if (!sel || sel.dataset.filled === '1') return Promise.resolve();
+    return fetchAPI('/api/net/interfaces').then(x => {
+        (x.interfaces || []).forEach(i => {
+            const o = document.createElement('option');
+            o.value = i.name;
+            const tag = i.type === 'wifi' ? ' (WiFi)' : i.type === 'ethernet' ? ' (LAN)' : (i.type ? ' (' + i.type + ')' : '');
+            o.textContent = i.name + tag;
+            sel.appendChild(o);
+        });
+        sel.dataset.filled = '1';
+    }).catch(() => {});
+}
 async function runArpScan() {
     const ifaceEl = document.getElementById('arp-iface');
     const out = document.getElementById('arp-scan-results');
-    const iface = (ifaceEl.value || '').trim();
-    if (!iface) { ifaceEl.focus(); return; }
+    const iface = ifaceEl && ifaceEl.value ? ifaceEl.value : '';
     const btn = event && event.target ? event.target : null;
     _ndBusy(btn, true, 'Scanning…');
     out.classList.remove('hidden');
-    out.innerHTML = '<p class="text-sm text-gray-400">Scanning ' + escapeHtml(iface) + '…</p>';
+    out.innerHTML = '<p class="text-sm text-gray-400">Scanning ' + (iface ? escapeHtml(iface) : 'the default segment') + '…</p>';
     try {
-        const data = await fetchAPI('/api/net/arp-scan?interface=' + encodeURIComponent(iface));
+        _arpScanFillIfaces();
+        const data = await fetchAPI('/api/net/arp-scan' + (iface ? '?interface=' + encodeURIComponent(iface) : ''));
         if (!data.success) {
             out.innerHTML = data.missing_tool
                 ? _ndMissingTool(data, 'runArpScan')
@@ -3854,8 +3869,9 @@ async function runArpScan() {
             return;
         }
         _ndLastArp = data;
+        const usedIface = data.interface || iface;
         if (!data.hosts.length) {
-            out.innerHTML = '<p class="text-sm text-gray-400">No hosts responded on ' + escapeHtml(iface) + '.</p>';
+            out.innerHTML = '<p class="text-sm text-gray-400">No hosts responded on ' + escapeHtml(usedIface || 'the segment') + '.</p>';
             return;
         }
         const rows = data.hosts.map(h => `
@@ -3864,7 +3880,7 @@ async function runArpScan() {
                 <td class="px-3 py-1.5 font-mono">${escapeHtml(h.mac)}</td>
                 <td class="px-3 py-1.5">${escapeHtml(String(h.vendor || '—'))}</td>
             </tr>`).join('');
-        out.innerHTML = `<p class="text-xs text-gray-500 mb-2">${data.count} host(s) on ${escapeHtml(iface)}</p>
+        out.innerHTML = `<p class="text-xs text-gray-500 mb-2">${data.count} host(s) on ${escapeHtml(usedIface || 'the segment')}</p>
             <table class="min-w-full text-sm text-gray-300 whitespace-nowrap">
             <thead><tr class="text-left text-xs uppercase text-gray-500">
                 <th class="px-3 py-1.5">IP</th><th class="px-3 py-1.5">MAC</th><th class="px-3 py-1.5">Vendor</th>


### PR DESCRIPTION
This pull request enhances the ARP Scan feature by making the network interface selection more user-friendly and robust. It replaces the manual text input for interface selection with a dropdown that auto-populates available interfaces, improves backend handling for automatic interface selection, and updates documentation and UI to match these changes.

**User Interface Improvements:**
- Replaced the manual text input for ARP scan interface selection with a dropdown selector (`<select>`), including an "Auto (wired first)" option, and auto-populates it with available interfaces on page load. [[1]](diffhunk://#diff-7a539845f7a3dbcb375c4f1fd20d0e033f28fd246928b5167f61ffef837e62f8L1633-R1636) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R1221) [[3]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R3840-R3874)
- Updated scan initiation and result messages to reflect the selected or automatically chosen interface, improving clarity for users. [[1]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R3840-R3874) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L3867-R3883)

**Backend and API Enhancements:**
- Modified the ARP scan API (`/api/net/arp-scan`) to accept an optional interface parameter, defaulting to automatic interface selection if none is provided. Improved error handling for missing or invalid interfaces. [[1]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL635-R643) [[2]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL14207-R14214)
- Adjusted the API endpoint documentation to reflect the new optional interface parameter and auto-selection behavior.

**Other:**
- Updated the JavaScript version reference to ensure the new UI logic is loaded.