### PR TITLE
nettools: Locate Port and L2 Link Health get the interface dropdown

### DIFF
--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -927,9 +927,12 @@ what's wrong at Layer 2 — no configuration, just plug in and scan:
 - **Duplicate IP** — the same IP claimed by different MACs (conflicting ARP).
 
 Findings are ranked (warn / info / ok). This is the one-tap "why is this
-segment misbehaving" check that normally needs a laptop and Wireshark.
+segment misbehaving" check that normally needs a laptop and Wireshark. An
+**interface selector** (Auto / WiFi / LAN) targets the capture at a chosen
+segment — Auto prefers a link-up wired port, falling back to the default-route
+interface.
 
-- Endpoint: `POST /api/net/l2-health` `{interface, seconds}` · binary: `tcpdump`
+- Endpoint: `POST /api/net/l2-health` `{interface?, seconds}` · binary: `tcpdump`
 
 ### IGMP Watch
 A **passive** IGMP-snooping security scanner for the IPv4 multicast control
@@ -1840,9 +1843,11 @@ Notes and safety:
 - Physical Ethernet only (`eth*`/`en*`) — locating a switch port only works on a
   wired link. Both methods require the port's link to be up (a cable in the
   switch); a dead/unplugged port can't blink.
+- The **interface selector** defaults to **Auto (wired)**, which picks the
+  link-up Ethernet port; with no wired link it errors rather than guessing.
 - Runs in the background so it completes even if your session blips.
 
-- Endpoint: `POST /api/net/locate-port` `{interface, count, method, force}` ·
+- Endpoint: `POST /api/net/locate-port` `{interface?, count, method, force}` ·
   `flap` uses `ip link`, `burst` uses a raw `AF_PACKET` socket
 
 ### PCAP Analyzer

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -3263,8 +3263,12 @@ def do_locate_port(interface, count=6, on_ms=800, off_ms=800, force=False, metho
                 link stays up. Never drops connectivity, so no force is needed
                 — safe even on the default route."""
     interface = (interface or '').strip()
-    if not interface:
-        return {'success': False, 'error': 'interface required'}
+    auto = not interface
+    if auto:
+        # _capture_iface prefers a link-up wired port — exactly what locate
+        # needs; if it falls through to a wireless default route, the
+        # ethernet check below rejects it with the auto-specific message.
+        interface = _capture_iface(None) or ''
     method = (method or 'flap').strip().lower()
     if method not in ('flap', 'burst'):
         method = 'flap'
@@ -3272,8 +3276,14 @@ def do_locate_port(interface, count=6, on_ms=800, off_ms=800, force=False, metho
     match = next((i for i in do_interfaces(include_virtual=True).get('interfaces', [])
                   if i['name'] == interface), None)
     if match is None:
-        return {'success': False, 'error': f'unknown interface: {interface}'}
+        return {'success': False, 'error': f'unknown interface: {interface}'
+                if interface else 'no wired Ethernet port found — plug in a cable or pick an interface.'}
     if match.get('type') != 'ethernet' or not interface.startswith(('eth', 'en')):
+        if auto:
+            return {'success': False,
+                    'error': 'no wired Ethernet port with link found — locating a '
+                             'switch port needs a cable; pick an interface explicitly '
+                             'if one exists.'}
         return {'success': False,
                 'error': f'{interface} is not a physical Ethernet port; locating '
                          'a switch port only works on a wired link.'}
@@ -3317,9 +3327,9 @@ def do_l2_health(interface, seconds=12):
     bridge(s) and topology churn (loop smell), CDP/LLDP/DTP/VTP control frames,
     broadcast/multicast storm rate, rogue DHCP servers, rogue IPv6 RA sources,
     and duplicate IPs (conflicting ARP). One 'what's wrong at L2' snapshot."""
-    interface = (interface or '').strip()
+    interface = _capture_iface((interface or '').strip() or None)
     if not interface:
-        return {'success': False, 'error': 'interface required'}
+        return {'success': False, 'error': 'No suitable interface found — pick one explicitly.'}
     if not _have('tcpdump'):
         return {'success': False, 'missing_tool': 'tcpdump',
                 'error': 'tcpdump is not installed. Click Install to add it.'}

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -2007,8 +2007,10 @@
                             <li><strong class="text-gray-400">Traffic burst</strong> — floods traffic so the <strong>ACTIVITY</strong> LED blinks while the link <strong>stays up</strong>. Never drops connectivity — safe on any port.</li>
                         </ul>
                     </div>
-                    <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-2">
-                        <input id="locate-iface" type="text" autocomplete="off" placeholder="interface (e.g. eth0)" class="w-full sm:w-auto sm:flex-1 sm:min-w-[12rem] bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm" onkeydown="if(event.key==='Enter')locatePort()">
+                    <div class="flex flex-wrap items-center gap-2">
+                        <select id="locate-iface" title="Wired port to flash — Auto picks the link-up Ethernet port" class="w-full sm:w-auto bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-gray-300">
+                            <option value="">Auto (wired)</option>
+                        </select>
                         <select id="locate-method" title="Which LED to blink" class="w-full sm:w-auto bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm">
                             <option value="flap">Link flap (LINK LED)</option>
                             <option value="burst">Traffic burst (ACTIVITY LED)</option>
@@ -2023,8 +2025,10 @@
                         <h3 class="text-lg font-semibold">L2 Link Health</h3>
                         <p class="text-sm text-gray-400">Listens passively for a few seconds and reports Layer-2 problems: STP root bridge &amp; loop churn, CDP/LLDP/DTP/VTP control frames, broadcast-storm rate, rogue DHCP servers, rogue IPv6 RA, and duplicate IPs. One "what's wrong at L2" snapshot.</p>
                     </div>
-                    <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-2">
-                        <input id="l2-iface" type="text" autocomplete="off" placeholder="interface (e.g. eth0)" class="w-full sm:w-auto sm:flex-1 sm:min-w-[12rem] bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm" onkeydown="if(event.key==='Enter')runL2Health()">
+                    <div class="flex flex-wrap items-center gap-2">
+                        <select id="l2-iface" title="Interface for the L2 capture — pick the LAN/WiFi NIC for the segment to watch" class="w-full sm:w-auto bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-gray-300">
+                            <option value="">Auto (wired first)</option>
+                        </select>
                         <input id="l2-secs" type="number" min="3" max="30" value="12" title="capture seconds" class="w-full sm:w-24 bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm">
                         <button onclick="runL2Health()" class="w-full sm:w-auto bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Scan L2</button>
                     </div>
@@ -6674,7 +6678,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260719-arp-iface-dropdown"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260719-locate-l2-iface-dropdown"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -1219,6 +1219,8 @@ function showNetworkSubtab(name) {
     } else if (name === 'switch') {
         loadLldp();
         _arpScanFillIfaces();
+        _locateFillIfaces();
+        _l2FillIfaces();
         _dhcpFillIfaces();
         _igmpFillIfaces();
         _ipv6FillIfaces();
@@ -4092,18 +4094,32 @@ async function analyzePcap() {
     }
 }
 
+function _l2FillIfaces() {
+    const sel = document.getElementById('l2-iface');
+    if (!sel || sel.dataset.filled === '1') return Promise.resolve();
+    return fetchAPI('/api/net/interfaces').then(x => {
+        (x.interfaces || []).forEach(i => {
+            const o = document.createElement('option');
+            o.value = i.name;
+            const tag = i.type === 'wifi' ? ' (WiFi)' : i.type === 'ethernet' ? ' (LAN)' : (i.type ? ' (' + i.type + ')' : '');
+            o.textContent = i.name + tag;
+            sel.appendChild(o);
+        });
+        sel.dataset.filled = '1';
+    }).catch(() => {});
+}
 async function runL2Health() {
     const ifaceEl = document.getElementById('l2-iface');
     const out = document.getElementById('l2-results');
-    const iface = (ifaceEl.value || '').trim();
-    if (!iface) { ifaceEl.focus(); return; }
+    const iface = ifaceEl && ifaceEl.value ? ifaceEl.value : '';
     let secs = parseInt(document.getElementById('l2-secs').value, 10);
     if (!Number.isFinite(secs)) secs = 12;
     const btn = event && event.target ? event.target : null;
     _ndBusy(btn, true, 'Listening…');
     out.classList.remove('hidden');
-    out.innerHTML = '<p class="text-sm text-gray-400">Capturing on ' + escapeHtml(iface) + ' for ' + secs + 's…</p>';
+    out.innerHTML = '<p class="text-sm text-gray-400">Capturing on ' + (iface ? escapeHtml(iface) : 'the default segment') + ' for ' + secs + 's…</p>';
     try {
+        _l2FillIfaces();
         const d = await postAPI('/api/net/l2-health', { interface: iface, seconds: secs });
         if (!d.success) {
             out.innerHTML = d.missing_tool ? _ndMissingTool(d, 'runL2Health')
@@ -4124,7 +4140,7 @@ async function runL2Health() {
         if (d.ra_sources && d.ra_sources.length) detail.push('IPv6 RA source(s): ' + d.ra_sources.map(escapeHtml).join(', '));
         if (d.duplicate_ips && Object.keys(d.duplicate_ips).length) detail.push('Duplicate IPs: ' + Object.keys(d.duplicate_ips).map(escapeHtml).join(', '));
         out.innerHTML = `<ul class="space-y-1 mb-2">${findings}</ul>
-            <p class="text-xs text-gray-500 mb-1">${d.packets} pkts in ${d.seconds}s · ${d.broadcast} bcast / ${d.multicast} mcast (${d.bcast_mcast_per_s}/s)</p>
+            <p class="text-xs text-gray-500 mb-1">${d.packets} pkts in ${d.seconds}s on ${escapeHtml(d.interface || '—')} · ${d.broadcast} bcast / ${d.multicast} mcast (${d.bcast_mcast_per_s}/s)</p>
             <div class="mb-1">${protos}</div>
             ${detail.length ? '<p class="text-xs text-gray-400">' + detail.join(' &nbsp;·&nbsp; ') + '</p>' : ''}`;
     } catch (e) {
@@ -4137,11 +4153,24 @@ async function runL2Health() {
 // Blink a wired link in a pattern so its switch LED reveals the port. POSTs to
 // /api/net/locate-port; on the default-route guard it asks for confirmation and
 // re-sends with force.
+function _locateFillIfaces() {
+    const sel = document.getElementById('locate-iface');
+    if (!sel || sel.dataset.filled === '1') return Promise.resolve();
+    return fetchAPI('/api/net/interfaces').then(x => {
+        (x.interfaces || []).forEach(i => {
+            const o = document.createElement('option');
+            o.value = i.name;
+            const tag = i.type === 'wifi' ? ' (WiFi)' : i.type === 'ethernet' ? ' (LAN)' : (i.type ? ' (' + i.type + ')' : '');
+            o.textContent = i.name + tag;
+            sel.appendChild(o);
+        });
+        sel.dataset.filled = '1';
+    }).catch(() => {});
+}
 async function locatePort(force) {
     const ifaceEl = document.getElementById('locate-iface');
     const out = document.getElementById('locate-results');
-    const iface = (ifaceEl.value || '').trim();
-    if (!iface) { ifaceEl.focus(); return; }
+    const iface = ifaceEl && ifaceEl.value ? ifaceEl.value : '';
     let count = parseInt(document.getElementById('locate-count').value, 10);
     if (!Number.isFinite(count)) count = 6;
     const methEl = document.getElementById('locate-method');
@@ -4150,6 +4179,7 @@ async function locatePort(force) {
     _ndBusy(btn, true, method === 'burst' ? 'Bursting…' : 'Flashing…');
     out.classList.remove('hidden');
     try {
+        _locateFillIfaces();
         const data = await postAPI('/api/net/locate-port', { interface: iface, count: count, method: method, force: !!force });
         if (!data.success) {
             if (data.needs_force) {
@@ -4165,7 +4195,7 @@ async function locatePort(force) {
     } catch (e) {
         // A flap on the interface serving this page can abort the request — that's
         // expected. (Burst never drops the link, so this path is flap-only.)
-        out.innerHTML = '<p class="text-amber-300">Flash started on ' + escapeHtml(iface)
+        out.innerHTML = '<p class="text-amber-300">Flash started on ' + escapeHtml(iface || 'the wired port')
             + '. If the UI dropped, that\'s the link flapping — watch the switch LED; it auto-restores.</p>';
     } finally {
         _ndBusy(btn, false);


### PR DESCRIPTION
This pull request improves the user experience and reliability of the "Locate Port" and "L2 Link Health" network tools by replacing manual interface text entry with dropdown selectors, adding smarter default selection logic, and updating backend and documentation to match. Now, users can select network interfaces from a list, with "Auto" options that prefer wired ports, and clearer error messages guide users when no suitable interface is found.

**UI/UX Improvements:**
* Replaced manual interface text inputs with dropdown selectors for both "Locate Port" and "L2 Link Health" tools in `web/index_modern.html`, defaulting to "Auto" (wired first) for easier and less error-prone selection. (`[[1]](diffhunk://#diff-7a539845f7a3dbcb375c4f1fd20d0e033f28fd246928b5167f61ffef837e62f8L2010-R2013)`, `[[2]](diffhunk://#diff-7a539845f7a3dbcb375c4f1fd20d0e033f28fd246928b5167f61ffef837e62f8L2026-R2031)`)
* Added JavaScript functions `_locateFillIfaces` and `_l2FillIfaces` in `web/scripts/ragnar_modern.js` to populate these dropdowns with available interfaces, and updated tool invocation logic to use the selected value or default to auto. (`[[1]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R4097-R4122)`, `[[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R4156-R4173)`, `[[3]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R4182)`)

**Backend/Logic Enhancements:**
* Updated `do_locate_port` and `do_l2_health` in `network_diagnostics.py` to support optional interface arguments, automatically selecting the best wired port if none is specified, and providing clearer, context-sensitive error messages when no suitable interface is available. (`[[1]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL3266-R3286)`, `[[2]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL3320-R3332)`)
* Adjusted API documentation in `docs/nettools.md` to reflect that the `interface` parameter is now optional, and described the new auto-selection behavior. (`[[1]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaL930-R935)`, `[[2]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaR1846-R1850)`)

**Feedback and Messaging:**
* Improved user feedback in the UI to clarify which interface is being used (or that the default is being used), and included the interface name in result summaries. (`[[1]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L4127-R4143)`, `[[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L4168-R4198)`)

These changes make the tools more robust and user-friendly, especially for users unfamiliar with network interface names.

Same Auto/WiFi/LAN select as the other Switch L2/L3 cards. L2 Link Health auto-picks via _capture_iface (wired first); Locate Port's Auto picks the link-up Ethernet port and errors clearly when no wired link exists, since flashing only works on a cable.