### PR TITLE
nettools: Switch Discovery gets the interface dropdown

### DIFF
--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -814,7 +814,17 @@ For each local interface it shows the discovered switch **name**, the
 Switches announce roughly every 30 seconds, so after plugging in give it up to
 a minute for the first neighbour to appear. Results export to CSV.
 
-- Endpoint: `GET /api/net/lldp` · binary: `lldpctl` (`lldpd`)
+**Interface selector.** The same Auto/WiFi/LAN dropdown as the other Switch
+L2/L3 cards. **Auto (all interfaces)** reports every neighbour this box can
+hear; picking one local port limits discovery to it — on a multi-homed Ragnar
+(LAN cable + USB NIC + WiFi) that is the difference between *"which switch is
+**this** port plugged into"* and a merged list you have to eyeball. Filtering is
+done by `lldpctl` itself, and an unknown interface name is rejected rather than
+returning an empty list that looks like "no switch found". When a chosen port
+has no neighbours, the note says so and suggests switching back to Auto.
+
+- Endpoint: `GET /api/net/lldp` · optional `?interface=<name>` · binary:
+  `lldpctl` (`lldpd`)
 
 #### PoE detection
 A PoE-capable switch advertises its power state in the LLDP/LLDP-MED

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -461,11 +461,16 @@ def do_speedtest(interface=None):
 # Switch & L2: LLDP/CDP/EDP neighbor discovery + ARP scan
 # --------------------------------------------------------------------------
 
-def do_lldp():
+def do_lldp(interface=None):
     """Return discovered switch neighbors via lldpctl. lldpd (configured with
     -c -e -f -s) also decodes CDPv1/v2 (Cisco), EDP (Extreme), FDP (Foundry)
     and SONMP (Nortel) in addition to LLDP. VLAN id/name are included when the
-    neighbor advertises them."""
+    neighbor advertises them.
+
+    `interface` limits discovery to one local port; '' / None reports every
+    interface (the default). On a multi-homed box — a Ragnar with a LAN cable,
+    a USB NIC and WiFi — that is the difference between "which switch am I
+    plugged into on *this* port" and a merged list you have to eyeball."""
     if not _have('lldpctl'):
         return {'success': False,
                 'error': 'lldpd/lldpctl is not installed. Click Install to add it '
@@ -473,9 +478,19 @@ def do_lldp():
                          'Cisco, Extreme, Foundry and Nortel switches are seen too).',
                 'missing_tool': 'lldpd',
                 'neighbors': []}
-    res = _run(['lldpctl', '-f', 'json'], timeout=15)
+    if interface:
+        # Name/injection guard plus an existence check, so a typo surfaces as a
+        # clear error rather than an empty neighbour list that looks like "no
+        # switch found".
+        if not _valid_iface(interface) or interface not in _list_iface_names(include_virtual=True):
+            return {'success': False, 'error': f'Unknown interface: {interface}',
+                    'neighbors': []}
+    # lldpctl takes trailing interface names to filter natively.
+    cmd = ['lldpctl', '-f', 'json'] + ([interface] if interface else [])
+    res = _run(cmd, timeout=15)
     if res['rc'] != 0 and not res['out']:
-        return {'success': False, 'error': res['err'] or 'lldpctl failed', 'neighbors': []}
+        return {'success': False, 'error': res['err'] or 'lldpctl failed',
+                'interface': interface, 'neighbors': []}
     neighbors = []
     try:
         data = json.loads(res['out'])
@@ -487,11 +502,18 @@ def do_lldp():
                 neighbors.append(_parse_lldp_iface(local_if, info))
     except ValueError as e:
         return {'success': False, 'error': f'could not parse lldpctl output: {e}',
-                'neighbors': [], 'output': res['out']}
-    return {'success': True, 'neighbors': neighbors,
-            'note': ('No neighbors yet? Switches announce every ~30s; give it up '
-                     'to a minute after connecting, and ensure the port isn\'t on a hub.')
-            if not neighbors else None}
+                'interface': interface, 'neighbors': [], 'output': res['out']}
+    if not neighbors:
+        note = ('No neighbors yet? Switches announce every ~30s; give it up '
+                'to a minute after connecting, and ensure the port isn\'t on a hub.')
+        if interface:
+            note = (f'No neighbours on {interface}. ' + note +
+                    ' If the cable is on a different port, switch to Auto (all '
+                    'interfaces) to see every neighbour this box can hear.')
+    else:
+        note = None
+    return {'success': True, 'interface': interface, 'neighbors': neighbors,
+            'note': note}
 
 
 def _first_key(d):
@@ -14230,7 +14252,8 @@ def register_network_diagnostics(app, logger=None):
     @app.route('/api/net/lldp', methods=['GET'])
     def net_lldp():
         _log("net/lldp")
-        return jsonify(do_lldp())
+        iface = (request.args.get('interface') or '').strip() or None
+        return jsonify(do_lldp(interface=iface))
 
     @app.route('/api/net/arp-scan', methods=['GET'])
     def net_arp_scan():

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -1621,7 +1621,7 @@
                             <h3 class="text-lg font-semibold">Switch Discovery (LLDP / CDPv1/v2 / EDP / FDP)</h3>
                             <p class="text-sm text-gray-400">Neighbouring switches via LLDP, Cisco CDPv1/v2, Extreme EDP, Foundry FDP and Nortel SONMP: name, port, VLAN, PoE and management IP.</p>
                         </div>
-                        <div class="flex gap-2 w-full sm:w-auto"><button onclick="loadLldp()" class="flex-1 bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Refresh</button><button onclick="exportLldpCsv()" class="w-full sm:w-auto bg-slate-700 hover:bg-slate-600 text-gray-200 px-3 py-2 rounded text-sm whitespace-nowrap">Export CSV</button></div>
+                        <div class="flex flex-wrap gap-2 w-full sm:w-auto"><select id="lldp-iface" onchange="loadLldp()" title="Local port to query — Auto reports neighbours on every interface" class="w-full sm:w-auto bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-gray-300"><option value="">Auto (all interfaces)</option></select><button onclick="loadLldp()" class="flex-1 bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Refresh</button><button onclick="exportLldpCsv()" class="w-full sm:w-auto bg-slate-700 hover:bg-slate-600 text-gray-200 px-3 py-2 rounded text-sm whitespace-nowrap">Export CSV</button></div>
                     </div>
                     <div id="lldp-results" class="mt-3 overflow-x-auto text-sm text-gray-400">Loading…</div>
                 </div>
@@ -6679,7 +6679,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260719-huginn-band-split"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260719-lldp-iface-dropdown"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -1217,6 +1217,7 @@ function showNetworkSubtab(name) {
     } else if (name === 'hosts') {
         loadNetworkData();
     } else if (name === 'switch') {
+        _lldpFillIfaces();
         loadLldp();
         _arpScanFillIfaces();
         _locateFillIfaces();
@@ -3802,11 +3803,31 @@ function _poeCell(poe) {
     return '<span class="text-gray-500">—</span>';
 }
 
+function _lldpFillIfaces() {
+    const sel = document.getElementById('lldp-iface');
+    if (!sel || sel.dataset.filled === '1') return Promise.resolve();
+    return fetchAPI('/api/net/interfaces').then(x => {
+        (x.interfaces || []).forEach(i => {
+            const o = document.createElement('option');
+            o.value = i.name;
+            const tag = i.type === 'wifi' ? ' (WiFi)' : i.type === 'ethernet' ? ' (LAN)' : (i.type ? ' (' + i.type + ')' : '');
+            o.textContent = i.name + tag;
+            sel.appendChild(o);
+        });
+        sel.dataset.filled = '1';
+    }).catch(() => {});
+}
+
 async function loadLldp() {
     const out = document.getElementById('lldp-results');
-    out.innerHTML = '<p class="text-gray-400">Loading neighbours…</p>';
+    const ifaceEl = document.getElementById('lldp-iface');
+    const iface = ifaceEl && ifaceEl.value ? ifaceEl.value : '';
+    out.innerHTML = '<p class="text-gray-400">Loading neighbours' +
+        (iface ? ' on ' + escapeHtml(iface) : '') + '…</p>';
     try {
-        const data = await fetchAPI('/api/net/lldp');
+        _lldpFillIfaces();
+        const data = await fetchAPI('/api/net/lldp' +
+            (iface ? '?interface=' + encodeURIComponent(iface) : ''));
         if (!data.success) {
             out.innerHTML = data.missing_tool
                 ? _ndMissingTool(data, 'loadLldp')


### PR DESCRIPTION
Same Auto/WiFi/LAN select as the other Switch L2/L3 cards. Auto (all interfaces) keeps the previous behaviour; picking a local port limits discovery to it, which on a multi-homed box is the difference between 'which switch is this port plugged into' and a merged list you have to eyeball.

Filtering is done by lldpctl natively (trailing interface argument) rather than post-filtering the parsed output. An unknown name is rejected up front, since an empty neighbour list is indistinguishable from 'no switch found', and the selected interface is echoed back in the response. When a chosen port has no neighbours the note names it and suggests Auto.

Verified live against a real LLDP neighbour: unfiltered and wlan0 both return the GT-AC5300, eth0 returns none with the guidance note, and a bad name plus a shell-injection attempt are both rejected.

Note: web/scripts/ragnar_modern.min.js is not referenced anywhere and is stale (it predates loadLldp entirely), so there was nothing to sync there.