### PR TITLE
gps: make the UBX auto-recovery survive real u-blox 7 clones

### DIFF
--- a/docs/wardriving.md
+++ b/docs/wardriving.md
@@ -76,6 +76,25 @@ required).
 
 Optional USB GPS receiver (NMEA via pyserial). Auto-detected at startup.
 
+**u-blox receivers stuck in UBX binary mode.** Some u-blox 7 USB pucks
+(VID 1546) come up emitting only UBX binary frames instead of NMEA, which
+looks like a healthy receiver that never finds a position ("Searching..."
+forever). Ragnar detects this and reconfigures the receiver in place over
+the same serial port — no action needed; the journal logs
+`sent the NMEA-enable config (attempt N/3)` when it happens. The cheap
+pucks have no battery-backed RAM or flash, so the fix cannot be persisted
+on them and is reapplied automatically after every power cycle or replug.
+If the automatic recovery fails, the manual path is:
+
+```bash
+sudo systemctl stop ragnar
+sudo python3 scripts/gps_set_nmea.py /dev/ttyACM0 --verify
+sudo systemctl restart ragnar
+```
+
+`scripts/gps_diag.sh` answers "is it the receiver or is it us" — it reports
+whether the port is emitting NMEA, UBX binary, or nothing at all.
+
 ---
 
 ## Architecture

--- a/gps_manager.py
+++ b/gps_manager.py
@@ -43,6 +43,11 @@ _NMEA_GSV_HEADER = re.compile(
 
 UBX_SYNC = b'\xb5\x62'
 
+# Start of a plausible NMEA sentence: '$' + talker/sentence letters + ','
+# (e.g. $GPGGA, $GNRMC, $PUBX). Deliberately loose about the exact talker,
+# strict that binary noise decoding to a stray '$' does not qualify.
+_NMEA_SHAPE = re.compile(r'^\$[A-Z]{4,5}\d*,')
+
 
 def _ubx_frame(msg_class, msg_id, payload=b''):
     """Build a UBX frame with its 8-bit Fletcher checksum."""
@@ -54,8 +59,8 @@ def _ubx_frame(msg_class, msg_id, payload=b''):
     return UBX_SYNC + body + bytes((ck_a, ck_b))
 
 
-def ubx_enable_nmea_sequence(save=True):
-    """Bytes that switch a u-blox port from UBX-only to NMEA output.
+def ubx_enable_nmea_frames(save=True):
+    """UBX frames that switch a u-blox port from UBX-only to NMEA output.
 
     Some u-blox receivers (commonly the u-blox 7 USB pucks) ship or end up
     configured to emit only UBX binary. We parse NMEA, so in that state a
@@ -66,6 +71,11 @@ def ubx_enable_nmea_sequence(save=True):
                already speaking UBX (e.g. gpsd) keeps working
       CFG-MSG  explicitly enable GGA/GSA/GSV/RMC in case they were switched off
       CFG-CFG  persist, so the fix survives a replug
+
+    Returned as a list (CFG-PRT first) rather than one blob: the receiver may
+    reinitialize the port while applying CFG-PRT and drop bytes that are
+    already in flight, so the sender must pace the frames — see
+    _recover_from_ubx(), and scripts/gps_set_nmea.py which does the same.
     """
     frames = [
         # portID 3 = USB; mode/baud are ignored there but must be present.
@@ -78,7 +88,12 @@ def ubx_enable_nmea_sequence(save=True):
     if save:
         frames.append(_ubx_frame(0x06, 0x09,
                                  struct.pack('<IIIB', 0, 0x0000FFFF, 0, 0x17)))
-    return b''.join(frames)
+    return frames
+
+
+def ubx_enable_nmea_sequence(save=True):
+    """The same frames as one byte string (drift check against the script)."""
+    return b''.join(ubx_enable_nmea_frames(save))
 
 
 def _nmea_to_decimal(raw, direction):
@@ -624,7 +639,12 @@ class GPSManager:
                     continue
 
                 line = raw.decode('ascii', errors='ignore').strip()
-                if not line.startswith('$'):
+                # Require real sentence shape ($GPGGA, $GNRMC, $PUBX, ...),
+                # not just a leading '$': in a UBX-only stream a binary chunk
+                # can decode to a line starting with '$', and one such fluke
+                # counted as NMEA would permanently disarm the UBX recovery
+                # below while the receiver stays unusable.
+                if not _NMEA_SHAPE.match(line):
                     continue
 
                 self._nmea_seen = getattr(self, '_nmea_seen', 0) + 1
@@ -654,8 +674,17 @@ class GPSManager:
             return
         self._ubx_fix_attempts = attempts + 1
         try:
-            self._serial.write(ubx_enable_nmea_sequence())
-            self._serial.flush()
+            # Pace the frames like scripts/gps_set_nmea.py does (the path that
+            # is proven on real hardware). Applying CFG-PRT can reinitialize
+            # the port, and the cheap u-blox 7 clones drop bytes that arrive
+            # while that happens — blasting the whole sequence in one write
+            # loses the CFG-MSG/CFG-CFG tail on exactly the receivers this
+            # recovery exists for.
+            frames = ubx_enable_nmea_frames()
+            for i, frame in enumerate(frames):
+                self._serial.write(frame)
+                self._serial.flush()
+                time.sleep(0.3 if i == 0 else 0.05)
             logger.warning(
                 f"GPS on {self.port} is emitting UBX binary, not NMEA — sent the "
                 f"NMEA-enable config (attempt {self._ubx_fix_attempts}/{max_attempts})")
@@ -703,6 +732,13 @@ class GPSManager:
             if port:
                 self._serial = pyserial.Serial(port, self.baudrate, timeout=1)
                 self.port = port
+                # Fresh device state: the u-blox 7 pucks have no battery/flash,
+                # so a replugged receiver comes back in whatever mode it ships
+                # in (often UBX-only). Stale counters from before the replug
+                # would block the UBX recovery exactly when it's needed again.
+                self._ubx_seen = 0
+                self._nmea_seen = 0
+                self._ubx_fix_attempts = 0
                 with self._lock:
                     self.connected = True
                     self.error = None

--- a/tests/test_gps_ubx_recovery.py
+++ b/tests/test_gps_ubx_recovery.py
@@ -1,0 +1,159 @@
+"""Tests for the u-blox UBX-binary-mode auto-recovery in gps_manager.
+
+The cheap u-blox 7 USB pucks have no battery-backed RAM or flash, so the
+NMEA-enable config is lost on every power cycle and the receiver comes back
+emitting only UBX binary. _recover_from_ubx() must therefore work reliably,
+unattended, on exactly those receivers:
+
+* the frames it sends must stay byte-identical to scripts/gps_set_nmea.py
+  (the path proven on real hardware),
+* the frames must be written individually with the same pacing the script
+  uses — applying CFG-PRT can reinitialize the port and clones drop bytes
+  that arrive during it,
+* a replug must re-arm the recovery (fresh attempts, cleared counters),
+* binary noise that decodes to a leading '$' must not count as NMEA, since
+  one such fluke would permanently disarm the recovery.
+"""
+
+import importlib.util
+import os
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import gps_manager
+from gps_manager import GPSManager, _NMEA_SHAPE, ubx_enable_nmea_frames
+
+
+def _load_manual_script():
+    """Import scripts/gps_set_nmea.py (not a package) as a module."""
+    path = os.path.join(os.path.dirname(__file__), '..',
+                        'scripts', 'gps_set_nmea.py')
+    spec = importlib.util.spec_from_file_location('gps_set_nmea', path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def mgr():
+    m = GPSManager(port='/dev/ttyACM0')
+    m._serial = MagicMock()
+    return m
+
+
+def test_frames_match_manual_script():
+    """Auto-recovery must send the exact bytes the proven script sends."""
+    script = _load_manual_script()
+    frames = ubx_enable_nmea_frames()
+
+    assert frames[0] == script.cfg_prt_usb()
+    # GGA, GSA, GSV, RMC — the sentences Ragnar's parser consumes.
+    for frame, msg_id in zip(frames[1:-1], (0x00, 0x02, 0x03, 0x04)):
+        assert frame == script.cfg_msg(0xF0, msg_id, 1)
+    assert frames[-1] == script.cfg_save()
+
+
+def test_recovery_writes_frames_individually_with_pacing(mgr):
+    frames = ubx_enable_nmea_frames()
+    with patch('gps_manager.time.sleep') as sleep:
+        mgr._recover_from_ubx()
+
+    written = [c.args[0] for c in mgr._serial.write.call_args_list]
+    assert written == frames
+
+    delays = [c.args[0] for c in sleep.call_args_list]
+    assert len(delays) == len(frames)
+    assert delays[0] >= 0.3          # CFG-PRT may reinitialize the port
+    assert all(d >= 0.05 for d in delays[1:])
+
+    assert mgr._ubx_fix_attempts == 1
+    assert 'gps_set_nmea.py' in mgr.error
+
+
+def test_recovery_attempts_are_capped(mgr):
+    frames = ubx_enable_nmea_frames()
+    with patch('gps_manager.time.sleep'):
+        for _ in range(5):
+            mgr._recover_from_ubx(max_attempts=3)
+
+    assert mgr._ubx_fix_attempts == 3
+    assert mgr._serial.write.call_count == 3 * len(frames)
+
+
+def test_recovery_write_failure_names_manual_script(mgr):
+    mgr._serial.write.side_effect = OSError('device reports readiness errors')
+    with patch('gps_manager.time.sleep'):
+        mgr._recover_from_ubx()
+
+    assert 'automatic fix' in mgr.error
+    assert 'gps_set_nmea.py' in mgr.error
+
+
+def test_reconnect_rearms_recovery(mgr):
+    """A replugged no-NVM puck reverts to UBX-only; stale counters from
+    before the replug must not block the recovery from running again."""
+    mgr._running = True
+    mgr._ubx_seen = 120
+    mgr._nmea_seen = 500
+    mgr._ubx_fix_attempts = 3
+
+    fake_serial = MagicMock()
+    fake_serial.Serial.return_value = MagicMock()
+    with patch.dict('sys.modules', {'serial': fake_serial}), \
+         patch('gps_manager.time.sleep'):
+        mgr._reconnect()
+
+    assert mgr.connected is True
+    assert mgr._ubx_seen == 0
+    assert mgr._nmea_seen == 0
+    assert mgr._ubx_fix_attempts == 0
+
+
+def test_nmea_shape_accepts_real_sentences():
+    for line in (
+        '$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47',
+        '$GNRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A',
+        '$GPGSV,3,1,11,03,03,111,00,04,15,270,00,06,01,010,00,13,06,292,00*74',
+        '$PUBX,00,081350.00,4717.113210,N,00833.915187,E,546.589,G3,2.1,2.0*5B',
+    ):
+        assert _NMEA_SHAPE.match(line), line
+
+
+def test_nmea_shape_rejects_binary_noise():
+    """UBX payload bytes decoded with errors='ignore' can start with '$' —
+    that must not register as NMEA flowing."""
+    noise = [
+        '$',
+        '$\x12\x01 binary tail',
+        '$5b\x00\x07',
+        '$G',                      # too short to be a sentence header
+        '$gpgga,lowercase,fake',   # NMEA talkers are upper-case
+    ]
+    for line in noise:
+        assert not _NMEA_SHAPE.match(line), repr(line)
+
+
+def test_read_loop_noise_does_not_disarm_recovery(mgr):
+    """End-to-end through _read_loop: 19 UBX chunks, one '$'-leading binary
+    fluke, then the 20th UBX chunk must still trigger the recovery write."""
+    chunks = [b'\xb5\x62\x01\x06junk\n'] * 19 + [b'$\x12\x01fluke\n',
+                                                 b'\xb5\x62\x01\x06junk\n']
+    reads = iter(chunks)
+
+    def readline():
+        try:
+            return next(reads)
+        except StopIteration:
+            mgr._running = False
+            return b''
+
+    mgr._running = True
+    mgr._serial.is_open = True
+    mgr._serial.readline.side_effect = lambda: readline()
+    with patch('gps_manager.time.sleep'):
+        mgr._read_loop()
+
+    assert mgr._ubx_fix_attempts == 1
+    assert mgr._serial.write.call_count == len(ubx_enable_nmea_frames())


### PR DESCRIPTION
The auto-recovery shipped in 43d2c03 sent the right bytes but could still leave a receiver dead in three ways, all hit by the no-NVM u-blox 7 pucks (VK-172 class) that revert to UBX-only mode on every power cycle:

* All config frames went out in a single write. Applying CFG-PRT can reinitialize the port, and the clones drop bytes that arrive while that happens — losing the CFG-MSG/CFG-CFG tail on exactly the receivers the recovery exists for. The frames are now written one at a time with the same pacing as scripts/gps_set_nmea.py (0.3 s after CFG-PRT, 50 ms between the rest), the path proven on real hardware.

* A replug re-enumerated the device back in UBX-only mode, but the stale _nmea_seen counter from before the replug permanently disarmed the recovery. _reconnect() now resets the UBX/NMEA bookkeeping on every successful reopen, so each fresh device gets fresh attempts.

* In a UBX-only stream a binary chunk can decode to a line starting with '$', and one such fluke counted as NMEA — disarming the recovery while the receiver stayed unusable. NMEA bookkeeping is now gated on real sentence shape ($GPGGA/$GNRMC/$PUBX...), not just a leading '$'.

ubx_enable_nmea_frames() returns the frame list (CFG-PRT first) so the pacing lives with the sender; tests/test_gps_ubx_recovery.py locks the frames byte-identical to the manual script and covers the pacing, the attempt cap, the replug re-arm, and the noise gate end-to-end through _read_loop. docs/wardriving.md documents the self-heal and the manual fallback.