### PR TITLE
Gps ubx recovery pacing

### DIFF
--- a/display.py
+++ b/display.py
@@ -30,6 +30,19 @@ from logger import Logger
 import subprocess  
 from shared import detect_wifi_interface
 
+def _fmt_wd_speed(speed_kmh, unit, decimals=1):
+    """Format a km/h speed for the wardriving display in the configured unit.
+
+    Recorded data is always stored in km/h; ``unit`` ('kmh' or 'mph') only
+    controls presentation. Returns e.g. '12.3km/h' or '7.6mph'.
+    """
+    if speed_kmh is None:
+        return None
+    if unit == 'mph':
+        return f"{speed_kmh * 0.621371:.{decimals}f}mph"
+    return f"{speed_kmh:.{decimals}f}km/h"
+
+
 # Map rotation angle → PIL transpose operation
 _ROTATION_TRANSPOSE = {
     90:  Image.Transpose.ROTATE_90,
@@ -2422,7 +2435,8 @@ class Display:
                 stats_bottom.append(("Sats", str(sats)))
             spd = gps.get('speed_kmh')
             if spd is not None and spd > 0:
-                stats_bottom.append(("Speed", f"{spd:.1f}km/h"))
+                unit = self.config.get('wardriving_speed_unit', 'kmh')
+                stats_bottom.append(("Speed", _fmt_wd_speed(spd, unit)))
 
         # Companions — show each connected device separately so the user can
         # see a Huginn + Piglet + Piglet Core at a glance.
@@ -3400,7 +3414,8 @@ class Display:
                 spd = gps.get('speed_kmh')
                 gps_str = f"{gps.get('latitude', 0):.4f},{gps.get('longitude', 0):.4f}"
                 if spd is not None:
-                    gps_str += f" {spd:.0f}km/h"
+                    unit = self.config.get('wardriving_speed_unit', 'kmh')
+                    gps_str += f" {_fmt_wd_speed(spd, unit, decimals=0)}"
             elif gps.get('connected'):
                 in_view = gps.get('satellites_in_view')
                 snr = gps.get('snr_max')

--- a/docs/wardriving.md
+++ b/docs/wardriving.md
@@ -342,6 +342,7 @@ Shows the most actionable signals at a glance:
 - **Status line** — `GPS-Fix OK` / `Searching (N visible)` / `Connected` / `No GPS`. The visible count appears when there's no fix but the antenna is seeing satellites — it tells you whether you're antenna-limited or signal-limited.
 - **Coords line** — `lat, lon` once a fix is established.
 - **Sats line** — `Sats: used/in-view · SNR N dB · HDOP H`. HDOP is hidden while it's still the pre-fix 99.99 placeholder.
+- **Speed line** — velocity in the configured unit. Set **Config → Wardriving → Speed Unit** (`wardriving_speed_unit`, `kmh` or `mph`) to choose km/h or mph. This is display-only and applies everywhere speed is shown — GPS card, live map marker, kiosk readout, and the hardware display. Recorded data (`speed_kmh`) is always stored in km/h regardless of the setting.
 
 ### Network Position Preservation
 

--- a/shared.py
+++ b/shared.py
@@ -860,6 +860,7 @@ class SharedData:
             "wardriving_interfaces": [],
             "wardriving_auto_export": True,
             "wardriving_device_name": "",
+            "wardriving_speed_unit": "kmh",
             "wardriving_on_boot": False,
             "piglet_core_mode": False,
             "piglet_core_max_nodes": 4,

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -6679,7 +6679,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260719-lldp-iface-dropdown"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260720-wardriving-speed-unit"></script>
 
 </body>
 </html>

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -5762,6 +5762,24 @@
                             </div>
                         </div>
 
+                        <!-- Speed Unit Card -->
+                        <div class="glass rounded-lg p-4">
+                            <div class="flex items-center justify-between mb-3">
+                                <h4 class="font-medium">Speed Unit</h4>
+                            </div>
+                            <div class="text-sm text-gray-400 mb-3">
+                                How GPS speed is shown across the wardriving dashboard, map, kiosk, and hardware display. Recorded data stays in km/h.
+                            </div>
+                            <div class="flex items-center justify-center gap-3">
+                                <span id="wd-speed-unit-kmh-label" class="text-sm font-semibold text-Ragnar-400">km/h</span>
+                                <label class="toggle-switch relative inline-flex items-center cursor-pointer">
+                                    <input type="checkbox" id="wardriving-speed-unit" class="sr-only peer" onchange="toggleWardrivingSpeedUnit()">
+                                    <div class="w-11 h-6 bg-gray-700 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all"></div>
+                                </label>
+                                <span id="wd-speed-unit-mph-label" class="text-sm font-semibold text-gray-500">mph</span>
+                            </div>
+                        </div>
+
                         <!-- GPS Backfill Card -->
                         <div class="glass rounded-lg p-4 border border-amber-900/40">
                             <div class="flex items-center justify-between mb-3">
@@ -6679,7 +6697,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260720-wardriving-speed-unit"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260720-wardriving-speed-unit-card"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -504,8 +504,25 @@ const configMetadata = {
     wardriving_auto_export: {
         label: "Auto Export on Stop",
         description: "Automatically export a WiGLE CSV file when a wardriving session is stopped."
+    },
+    wardriving_speed_unit: {
+        label: "Speed Unit",
+        description: "Unit used to display GPS speed across the wardriving views (dashboard, map, kiosk, and hardware display). Choose km/h or mph. Recorded data is always stored in km/h; this only changes how it is shown."
     }
 };
+
+// Speed unit preference (kmh | mph), kept in sync with config so the various
+// speed readouts can format without re-fetching /api/config each tick.
+let _wdSpeedUnit = 'kmh';
+
+// Format a km/h value using the user's selected wardriving speed unit.
+function formatWardrivingSpeed(kmh, decimals = 1) {
+    if (kmh == null || typeof kmh !== 'number' || isNaN(kmh)) return '—';
+    if (_wdSpeedUnit === 'mph') {
+        return `${(kmh * 0.621371).toFixed(decimals)} mph`;
+    }
+    return `${kmh.toFixed(decimals)} km/h`;
+}
 
 function getConfigLabel(key) {
     if (configMetadata[key] && configMetadata[key].label) {
@@ -18100,16 +18117,26 @@ function displayConfigForm(config) {
     const attacksEnabled = config.hasOwnProperty('enable_attacks') ? Boolean(config.enable_attacks) : true;
     updateAttackWarningBanner(attacksEnabled);
 
+    // Keep the speed-unit preference in sync so the live readouts format correctly.
+    _wdSpeedUnit = (config.wardriving_speed_unit === 'mph') ? 'mph' : 'kmh';
+
     // Render wardriving config settings into the dedicated Wardriving section slot
     const wdSlot = document.getElementById('wardriving-config-slot');
     if (wdSlot) {
-        const wdKeys = ['wardriving_scan_interval', 'wardriving_gps_port', 'wardriving_gps_baudrate', 'wardriving_auto_export'];
+        const wdKeys = ['wardriving_scan_interval', 'wardriving_gps_port', 'wardriving_gps_baudrate', 'wardriving_speed_unit', 'wardriving_auto_export'];
         let wdHtml = '<form id="wardriving-config-form" class="bg-slate-800 bg-opacity-50 rounded-lg p-4 mt-4"><h4 class="text-md font-bold mb-4 text-gray-300">Settings</h4><div class="grid grid-cols-1 md:grid-cols-2 gap-4">';
         wdKeys.forEach(key => {
             const hasKey = Object.prototype.hasOwnProperty.call(config, key);
             let value = config[key];
             if (!hasKey && knownBooleans.includes(key)) value = true;
             if (!hasKey && alwaysShowKeys.has(key)) value = fallbackValues[key];
+            if (key === 'wardriving_speed_unit') {
+                const label = getConfigLabel(key);
+                const description = escapeHtml(getConfigDescription(key));
+                const unit = (value === 'mph') ? 'mph' : 'kmh';
+                wdHtml += `<div class="space-y-2"><label class="flex items-center gap-2 text-sm text-gray-400">${label}<span class="info-icon" tabindex="0" role="button" aria-label="${description}" data-tooltip="${description}">ⓘ</span></label><select name="${key}" class="w-full px-4 py-2 rounded-lg bg-slate-700 border border-slate-600 focus:border-Ragnar-500 focus:ring-1 focus:ring-Ragnar-500"><option value="kmh" ${unit === 'kmh' ? 'selected' : ''}>km/h</option><option value="mph" ${unit === 'mph' ? 'selected' : ''}>mph</option></select></div>`;
+                return;
+            }
             if (hasKey || knownBooleans.includes(key) || alwaysShowKeys.has(key)) {
                 const label = getConfigLabel(key);
                 const description = escapeHtml(getConfigDescription(key));
@@ -22664,7 +22691,7 @@ function updateWardrivingUI(status) {
     const speedEl = document.getElementById('wd-speed-val');
     const headEl = document.getElementById('wd-heading-val');
     if (speedEl) {
-        speedEl.textContent = (gps.speed_kmh != null && gps.has_fix) ? `${gps.speed_kmh.toFixed(1)} km/h` : '—';
+        speedEl.textContent = (gps.speed_kmh != null && gps.has_fix) ? formatWardrivingSpeed(gps.speed_kmh) : '—';
     }
     if (headEl) {
         if (gps.course != null && gps.has_fix) {
@@ -23367,7 +23394,7 @@ async function _refreshKioskWardrivingView() {
         setText('kiosk-gps-lon', _fmtCoord(gps.longitude, ['E', 'W']));
         setText('kiosk-gps-sats', gps.satellites ?? '—');
         const speed = gps.speed_kmh;
-        setText('kiosk-gps-speed', (typeof speed === 'number') ? speed.toFixed(1) + ' km/h' : '—');
+        setText('kiosk-gps-speed', (typeof speed === 'number') ? formatWardrivingSpeed(speed) : '—');
         setText('kiosk-gps-port', gps.port || '—');
     } catch (e) {
         /* network blip — keep last values */
@@ -23957,7 +23984,7 @@ async function _updateVikingPosition() {
                 _wdLastFixLon = gps.longitude;
             }
             const stationaryNote = stationary ? '<br><span style="color:#94a3b8">Stationär (drift dämpad)</span>' : '';
-            const popup = `<b>Ragnar</b><br>${speed.toFixed(1)} km/h${stationaryNote}`;
+            const popup = `<b>Ragnar</b><br>${formatWardrivingSpeed(speed)}${stationaryNote}`;
             if (!_wdVikingMarker) {
                 const icon = L.divIcon({
                     html: _VIKING_ICON_HTML,

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -10802,6 +10802,9 @@ async function loadConfigData() {
         // Load GPS-backfill opt-in state (gates the map Backfill GPS button)
         loadWardrivingBackfillState();
 
+        // Load speed-unit (km/h vs mph) card state
+        loadWardrivingSpeedUnitState();
+
         // Load on-screen kiosk state + service badge
         loadKioskState();
 
@@ -18117,26 +18120,20 @@ function displayConfigForm(config) {
     const attacksEnabled = config.hasOwnProperty('enable_attacks') ? Boolean(config.enable_attacks) : true;
     updateAttackWarningBanner(attacksEnabled);
 
-    // Keep the speed-unit preference in sync so the live readouts format correctly.
-    _wdSpeedUnit = (config.wardriving_speed_unit === 'mph') ? 'mph' : 'kmh';
+    // Keep the speed-unit preference in sync so the live readouts format correctly,
+    // and reflect it on the Speed Unit card toggle.
+    applyWardrivingSpeedUnitState((config.wardriving_speed_unit === 'mph') ? 'mph' : 'kmh');
 
     // Render wardriving config settings into the dedicated Wardriving section slot
     const wdSlot = document.getElementById('wardriving-config-slot');
     if (wdSlot) {
-        const wdKeys = ['wardriving_scan_interval', 'wardriving_gps_port', 'wardriving_gps_baudrate', 'wardriving_speed_unit', 'wardriving_auto_export'];
+        const wdKeys = ['wardriving_scan_interval', 'wardriving_gps_port', 'wardriving_gps_baudrate', 'wardriving_auto_export'];
         let wdHtml = '<form id="wardriving-config-form" class="bg-slate-800 bg-opacity-50 rounded-lg p-4 mt-4"><h4 class="text-md font-bold mb-4 text-gray-300">Settings</h4><div class="grid grid-cols-1 md:grid-cols-2 gap-4">';
         wdKeys.forEach(key => {
             const hasKey = Object.prototype.hasOwnProperty.call(config, key);
             let value = config[key];
             if (!hasKey && knownBooleans.includes(key)) value = true;
             if (!hasKey && alwaysShowKeys.has(key)) value = fallbackValues[key];
-            if (key === 'wardriving_speed_unit') {
-                const label = getConfigLabel(key);
-                const description = escapeHtml(getConfigDescription(key));
-                const unit = (value === 'mph') ? 'mph' : 'kmh';
-                wdHtml += `<div class="space-y-2"><label class="flex items-center gap-2 text-sm text-gray-400">${label}<span class="info-icon" tabindex="0" role="button" aria-label="${description}" data-tooltip="${description}">ⓘ</span></label><select name="${key}" class="w-full px-4 py-2 rounded-lg bg-slate-700 border border-slate-600 focus:border-Ragnar-500 focus:ring-1 focus:ring-Ragnar-500"><option value="kmh" ${unit === 'kmh' ? 'selected' : ''}>km/h</option><option value="mph" ${unit === 'mph' ? 'selected' : ''}>mph</option></select></div>`;
-                return;
-            }
             if (hasKey || knownBooleans.includes(key) || alwaysShowKeys.has(key)) {
                 const label = getConfigLabel(key);
                 const description = escapeHtml(getConfigDescription(key));
@@ -23163,6 +23160,42 @@ async function loadWardrivingBackfillState() {
         const cb = document.getElementById('wardriving-allow-backfill');
         if (cb) cb.checked = allow;
         applyWardrivingBackfillVisibility(allow);
+    } catch (e) { /* silent */ }
+}
+
+// Speed unit ('kmh' | 'mph') is display-only — recorded data stays in km/h.
+// Applies the choice to the card toggle, the label emphasis, and the module-level
+// _wdSpeedUnit used by formatWardrivingSpeed() for all live readouts.
+function applyWardrivingSpeedUnitState(unit) {
+    _wdSpeedUnit = (unit === 'mph') ? 'mph' : 'kmh';
+    const cb = document.getElementById('wardriving-speed-unit');
+    if (cb) cb.checked = (_wdSpeedUnit === 'mph');
+    const kmhLabel = document.getElementById('wd-speed-unit-kmh-label');
+    const mphLabel = document.getElementById('wd-speed-unit-mph-label');
+    if (kmhLabel) kmhLabel.className = 'text-sm font-semibold ' + (_wdSpeedUnit === 'kmh' ? 'text-Ragnar-400' : 'text-gray-500');
+    if (mphLabel) mphLabel.className = 'text-sm font-semibold ' + (_wdSpeedUnit === 'mph' ? 'text-Ragnar-400' : 'text-gray-500');
+}
+
+async function toggleWardrivingSpeedUnit() {
+    const cb = document.getElementById('wardriving-speed-unit');
+    if (!cb) return;
+    const unit = cb.checked ? 'mph' : 'kmh';
+    applyWardrivingSpeedUnitState(unit);
+    try {
+        await postAPI('/api/config', { wardriving_speed_unit: unit });
+        addConsoleMessage('Wardriving speed unit set to ' + (unit === 'mph' ? 'mph' : 'km/h'), 'success');
+    } catch (e) {
+        console.error('[Wardriving] speed unit toggle error:', e);
+        addConsoleMessage('Failed to update speed unit setting', 'error');
+        applyWardrivingSpeedUnitState(unit === 'mph' ? 'kmh' : 'mph');
+    }
+}
+
+async function loadWardrivingSpeedUnitState() {
+    try {
+        const res = await fetch('/api/config');
+        const cfg = await res.json();
+        applyWardrivingSpeedUnitState(cfg.wardriving_speed_unit === 'mph' ? 'mph' : 'kmh');
     } catch (e) { /* silent */ }
 }
 


### PR DESCRIPTION
This pull request introduces a configurable speed unit (km/h or mph) for all wardriving-related speed displays across the application. Users can now select their preferred unit for GPS speed, which will be reflected consistently in the dashboard, live map, kiosk, and hardware display. The underlying data continues to be stored in km/h; the unit setting only affects how speed is presented.

**Key changes include:**

**Backend and Data Handling:**
- Added a new configuration option `wardriving_speed_unit` (default: `'kmh'`) to store the user's preferred display unit for speed.
- Implemented the `_fmt_wd_speed` helper in `display.py` to format speed values according to the selected unit for all relevant displays.

**Frontend/UI Updates:**
- Introduced a new "Speed Unit" card in the wardriving config section of the web UI, allowing users to toggle between km/h and mph.
- Updated all speed readouts in the dashboard, map marker popups, and kiosk view to use the selected unit via a new `formatWardrivingSpeed` function, ensuring consistent formatting throughout the UI. [[1]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L22667-R22691) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L23370-R23430) [[3]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L23960-R24020)

**Configuration Synchronization:**
- Added logic to keep the frontend's speed unit preference in sync with backend configuration, updating all live displays immediately when the setting is changed. [[1]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R10805-R10807) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R18123-R18126) [[3]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R23166-R23201)

**Documentation:**
- Updated `docs/wardriving.md` to describe the new speed unit option and clarify that it affects only presentation, not data storage.

**Backend Display Logic:**
- Modified backend display rendering in `display.py` to use the new formatting function and reflect the user's unit preference in all relevant views. [[1]](diffhunk://#diff-f6c06aabaaa561e18d40bbe59a0e91b4f589b497ab5cb4d59d5242e8704f3c3aL2425-R2439) [[2]](diffhunk://#diff-f6c06aabaaa561e18d40bbe59a0e91b4f589b497ab5cb4d59d5242e8704f3c3aL3403-R3418)

These changes provide a more user-friendly and customizable experience for users in different regions or with different preferences, while maintaining consistent data storage.