### PR TITLE
wardriving: show GPS speed on the 1.44" ST7735S compact page

### DIFF
--- a/display.py
+++ b/display.py
@@ -2288,9 +2288,18 @@ class Display:
         else:
             comp_str = "None"
 
+        # Speed row: only while we have a fix and are actually moving, so a
+        # stationary stop doesn't waste one of the few rows this panel affords.
+        rows = [("GPS", gps_str)]
+        spd = gps.get('speed_kmh')
+        if gps.get('has_fix') and spd is not None and spd > 0:
+            unit = self.config.get('wardriving_speed_unit', 'kmh')
+            rows.append(("Spd", _fmt_wd_speed(spd, unit)))
+        rows.append(("Comp", comp_str))
+
         pad_x = int(6 * sx)
         line_h = int(18 * sy)
-        for label, value in [("GPS", gps_str), ("Comp", comp_str)]:
+        for label, value in rows:
             val_str = str(value)
             vw = font_row.getlength(val_str)
             # Trim the value if it would collide with the label.

--- a/docs/DISPLAY_CONTROLS.md
+++ b/docs/DISPLAY_CONTROLS.md
@@ -43,8 +43,9 @@ In Default and Wardriving layers the keys act **on press**.
 > **Compact wardriving page on the 1.44" ST7735S:** the 128×128 panel is too
 > small for the full stat page, so it drops the "WARDRIVING" header and shows
 > only the essentials — the **2.4 / 5 / 6 GHz** network counts as large numbers,
-> the **GPS** fix, and the **companion** status — with the key hints in the
-> footer. Larger panels still get the full stat page.
+> the **GPS** fix, **speed** (only while moving), and the **companion** status —
+> with the key hints in the footer. Larger panels still get the full stat page.
+> The speed uses the **Speed Unit** setting (km/h or mph) from Config → Wardriving.
 >
 > The count font **auto-shrinks** as the numbers grow, so a long drive that
 > pushes a band into the thousands (or higher) still fits its column instead of


### PR DESCRIPTION
The compact ST7735S wardriving layout showed band counts, GPS fix, and companion status but not speed. Add a Spd row between GPS and Comp, shown only while we have a fix and are actually moving so a stationary stop doesn't waste a row on the cramped 128x128 panel. Formats via the existing Speed Unit setting (km/h or mph).