### PR TITLE
wardriving: Exit Wardriving button on the phone AP page

### DIFF
--- a/docs/DISPLAY_CONTROLS.md
+++ b/docs/DISPLAY_CONTROLS.md
@@ -52,6 +52,15 @@ In Default and Wardriving layers the keys act **on press**.
 > overlapping the neighbouring band. All three share one size so the row stays
 > visually even.
 
+> **Exit Wardriving from the phone page:** the minimal wardriving page (join the
+> KEY1 AP, open `http://192.168.4.1:8000/`) has an **Exit Wardriving** button at
+> the bottom. It stops the current session and then tears down the phone-access
+> AP so the device returns to normal Ragnar operation. Because dropping the AP
+> disconnects the phone, the button confirms first and, once the stop is issued,
+> tells you to reconnect to your normal Wi-Fi to reach Ragnar web. (It is the
+> only write action an un-authenticated AP client is allowed — everything else
+> on that page is read-only.)
+
 ### Network Diagnostic mode
 
 Each key gains a **short** and a **long** (hold ~0.6 s) press — see the full

--- a/web/wardrive_mobile.html
+++ b/web/wardrive_mobile.html
@@ -31,6 +31,18 @@
   .legend i { display:inline-block; width:10px; height:10px; border-radius:50%; margin-right:5px; vertical-align:-1px; }
   .foot { text-align:center; color:var(--mut); font-size:11px; margin-top:14px; }
   .stale { opacity:.5; }
+  .exit-wrap { margin-top:18px; }
+  .exit-btn { width:100%; padding:14px 16px; border-radius:12px; border:1px solid #7f1d1d;
+              background:#3b1414; color:#fca5a5; font-size:15px; font-weight:600;
+              letter-spacing:.3px; cursor:pointer; -webkit-appearance:none; appearance:none; }
+  .exit-btn:active { background:#4c1a1a; }
+  .exit-btn:disabled { opacity:.6; cursor:default; }
+  .overlay { position:fixed; inset:0; background:rgba(6,9,20,.92); display:none;
+             align-items:center; justify-content:center; padding:24px; z-index:50; }
+  .overlay.show { display:flex; }
+  .overlay .msg { max-width:360px; text-align:center; }
+  .overlay .msg h2 { font-size:18px; margin:0 0 10px; }
+  .overlay .msg p { color:var(--mut); font-size:13px; line-height:1.5; margin:0; }
 </style>
 </head>
 <body>
@@ -58,8 +70,19 @@
     </div>
   </div>
 
+  <div class="exit-wrap">
+    <button type="button" id="exit-btn" class="exit-btn">Exit Wardriving</button>
+  </div>
+
   <div class="foot" id="foot">Connecting…</div>
 </main>
+
+<div class="overlay" id="exit-overlay">
+  <div class="msg">
+    <h2 id="exit-title">Stopping wardriving…</h2>
+    <p id="exit-note">Ending the session and shutting down the Ragnar access point.</p>
+  </div>
+</div>
 
 <script>
 (function () {
@@ -182,6 +205,46 @@
       txt('foot', 'Reconnecting…');
     });
   }
+
+  // Exit Wardriving: stop the session and drop the field AP, then head back to
+  // Ragnar web. The AP teardown is deferred server-side (~1.5s) so this request
+  // completes first; after that the AP radio goes down and this phone loses the
+  // Ragnar network, so we give clear on-screen guidance rather than assume the
+  // redirect will load.
+  var stopping = false;
+  function showOverlay(title, note) {
+    txt('exit-title', title);
+    txt('exit-note', note);
+    document.getElementById('exit-overlay').classList.add('show');
+  }
+  function exitWardriving() {
+    if (stopping) return;
+    if (!window.confirm('Stop wardriving and shut down the Ragnar access point?')) return;
+    stopping = true;
+    var btn = document.getElementById('exit-btn');
+    btn.disabled = true;
+    btn.textContent = 'Stopping…';
+    showOverlay('Stopping wardriving…', 'Ending the session and shutting down the Ragnar access point.');
+    fetch('/api/wardriving/stop', { method: 'POST', cache: 'no-store' })
+      .then(function (r) { return r.json().catch(function () { return {}; }); })
+      .then(function (res) {
+        if (res && res.ap_teardown) {
+          showOverlay('Wardriving stopped',
+            'The Ragnar access point is shutting down. Reconnect your phone to its normal Wi-Fi to reach Ragnar web.');
+        } else {
+          showOverlay('Wardriving stopped', 'Returning to Ragnar web…');
+        }
+        setTimeout(function () { window.location.href = '/'; }, 2500);
+      })
+      .catch(function () {
+        // The AP may have dropped before the response arrived — that still means
+        // the stop was issued. Guide the user rather than showing a raw error.
+        showOverlay('Wardriving stopping',
+          'If this page does not return, reconnect your phone to its normal Wi-Fi to reach Ragnar web.');
+        setTimeout(function () { window.location.href = '/'; }, 3000);
+      });
+  }
+  document.getElementById('exit-btn').addEventListener('click', exitWardriving);
 
   refresh();
   setInterval(refresh, 3000);

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -125,7 +125,9 @@ def check_authentication():
     # Wardriving phone-access AP (KEY1): let AP clients view the minimal live
     # page and its READ-ONLY data without login — same spirit as the captive
     # portal. Scoped to GET on the status/track/networks endpoints so a phone
-    # on the AP can watch but cannot stop wardriving, wipe data, etc.
+    # on the AP can watch but cannot wipe data, change settings, etc.
+    # The one write allowed is POST /api/wardriving/stop — the "Exit Wardriving"
+    # button on the mobile page, which ends the session and drops this AP.
     if getattr(shared_data, 'wardrive_ap_active', False) and is_ap_client_request():
         readonly_api = (
             '/api/wardriving/status', '/api/wardriving/track',
@@ -133,6 +135,8 @@ def check_authentication():
             '/api/wardriving/bluetooth', '/api/wardriving/cells',
         )
         if path in ('/', '/wardrive') or (request.method == 'GET' and path in readonly_api):
+            return
+        if request.method == 'POST' and path == '/api/wardriving/stop':
             return
 
     # Kiosk loopback bypass: any request originating from the Pi itself
@@ -8824,10 +8828,37 @@ def wardriving_start():
 
 @app.route('/api/wardriving/stop', methods=['POST'])
 def wardriving_stop():
-    """Stop the current wardriving session."""
+    """Stop the current wardriving session.
+
+    If the phone-access AP is up (the field 'Exit Wardriving' button on the
+    minimal mobile page hits this), also tear the AP down so the device returns
+    to normal Ragnar operation. The teardown is deferred to a background thread
+    so this HTTP response reaches the AP client *before* the AP radio drops —
+    otherwise the client's connection dies mid-response and it never learns the
+    stop succeeded.
+    """
     try:
         engine = _get_wardriving_engine()
         result = engine.stop()
+
+        ap_teardown = False
+        if getattr(shared_data, 'wardrive_ap_active', False):
+            ragnar_instance = getattr(shared_data, 'ragnar_instance', None)
+            wifi_mgr = getattr(ragnar_instance, 'wifi_manager', None) if ragnar_instance else None
+            if wifi_mgr is not None:
+                ap_teardown = True
+
+                def _deferred_ap_teardown():
+                    try:
+                        time.sleep(1.5)
+                        wifi_mgr.stop_wardrive_ap()
+                    except Exception as exc:
+                        logger.error(f"Wardrive AP teardown after stop failed: {exc}")
+
+                threading.Thread(target=_deferred_ap_teardown, daemon=True).start()
+
+        if isinstance(result, dict):
+            result['ap_teardown'] = ap_teardown
         return jsonify(result)
     except Exception as e:
         logger.error(f"Wardriving stop error: {e}")


### PR DESCRIPTION
Add an Exit Wardriving button to the minimal wardriving mobile page served by the KEY1 phone-access AP. It stops the current session and then tears down the phone-access AP (deferred ~1.5s so the HTTP response reaches the phone before the AP radio drops), returning the device to normal Ragnar operation.

- /api/wardriving/stop now also drops the wardrive AP when one is active and reports ap_teardown in its JSON so the page can guide the user.
- AP clients (192.168.4.x, unauthenticated) are allowed POST on that one endpoint only; everything else on the page stays read-only.
- Page confirms first, shows a stopping overlay, and tells the user to reconnect to their normal Wi-Fi to reach Ragnar web once the AP is gone.
- Docs: DISPLAY_CONTROLS.md notes the Exit Wardriving button.