### PR TITLE
wardriving: diagnostics panel on the main dashboard tab too

### DIFF
--- a/docs/DISPLAY_CONTROLS.md
+++ b/docs/DISPLAY_CONTROLS.md
@@ -79,7 +79,10 @@ In Default and Wardriving layers the keys act **on press**.
 > **SNR max** and **satellites used / in view** — the two numbers that separate
 > a weak-signal problem from a receiver that keeps restarting when it sees
 > satellites but never fixes. Fields with no value are omitted rather than shown
-> blank, and the panel skips its DOM work entirely while collapsed.
+> blank, and the panel skips its DOM work entirely while collapsed. The same
+> panel is on the main dashboard's **Wardriving** tab (which adds an antenna
+> **Coverage** group) — see
+> [Diagnostics Panel (UI)](wardriving.md#diagnostics-panel-ui).
 >
 > **The AP does not carry your phone's internet.** Ragnar never routes for AP
 > clients (no NAT, no `ip_forward`, and while wardriving the radio is usually

--- a/docs/wardriving.md
+++ b/docs/wardriving.md
@@ -344,6 +344,39 @@ Shows the most actionable signals at a glance:
 - **Sats line** — `Sats: used/in-view · SNR N dB · HDOP H`. HDOP is hidden while it's still the pre-fix 99.99 placeholder.
 - **Speed line** — velocity in the configured unit. Set **Config → Wardriving → Speed Unit** (`wardriving_speed_unit`, `kmh` or `mph`) to choose km/h or mph. This is display-only and applies everywhere speed is shown — GPS card, live map marker, kiosk readout, and the hardware display. Recorded data (`speed_kmh`) is always stored in km/h regardless of the setting.
 
+### Diagnostics Panel (UI)
+
+At the bottom of the **Wardriving** tab (and of the phone-access AP page,
+`web/wardrive_mobile.html`) sits a **Diagnostics** panel, collapsed by default.
+It is a native `<details>` element, so the toggle keeps working even if a script
+errors — which is precisely when the panel gets opened.
+
+Its summary always shows a live hint (`GPS fix` / `GPS searching` / `no GPS`,
+with `· error` appended when the engine or GPS reports one), so a glance is
+often enough without expanding. Expanded, it lists everything the
+[Status Object](#status-object) exposes, grouped:
+
+| Group | Contents |
+|-------|----------|
+| **GPS** | fix + quality, satellites used/in-view, SNR max, HDOP, lat/lon/altitude, speed, course, source, port, last update, last raw NMEA sentence, error |
+| **Session** | id, duration, network totals, open/WEP/WPA, per-band, Bluetooth, cell towers, cameras, trackpoints, strongest AP, DB path |
+| **Scanning** | running, band mode, scans completed, networks last scan, last scan age, interfaces, plus per-adapter driver / bands / USB / manufacturer / network count |
+| **Coverage** | BSSIDs seen by 2+ adapters, and per adapter its unique count, *only-here* count and median best RSSI — the antenna-comparison view (dashboard only) |
+| **Companions** | per-device up/down, network counts, 2.4/5 split, ESP mode, BLE count, mesh nodes, coordinator board/firmware, recent alerts |
+| **Device** | device name, Bluetooth/cell totals, GPS-backfill setting |
+
+Fields with no value are omitted rather than rendered blank, and the panel skips
+its DOM work entirely while collapsed (re-rendering from the last status when
+expanded), so the polling loop costs nothing extra when it is closed.
+
+> **Diagnosing "sees satellites but never gets a fix":** open **GPS** and read
+> **SNR max** together with **Satellites** (`used / in view`). A cold start must
+> demodulate the ephemeris — roughly 30 s of continuous reception at ≥30 dB-Hz —
+> while an already-established fix tracks down to ~20 dB-Hz. So a receiver
+> showing satellites in view with `0 used` and a low SNR is signal-limited
+> (antenna placement or RF interference from a nearby adapter), whereas
+> comparable SNR with the fix repeatedly resetting points at power instead.
+
 ### Network Position Preservation
 
 `upsert_network` uses `COALESCE(?, col)` for `latitude`, `longitude`, `altitude`, `best_lat`, `best_lon`, `speed_kmh`, and `hdop` on both the stronger-RSSI and weaker-RSSI update paths. Concretely: an existing row's GPS columns are **never** overwritten with NULL. A re-scan with a stronger signal but no current GPS fix keeps the previously-recorded position instead of erasing it.

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -5467,9 +5467,23 @@
                         <p class="text-gray-500 text-sm">No previous sessions.</p>
                     </div>
                 </div>
+
+                <!-- Diagnostics — collapsed by default. Mirrors the panel on the
+                     phone-access AP page (web/wardrive_mobile.html); a native
+                     <details> so the toggle survives a script error, which is
+                     exactly when this panel gets opened. -->
+                <details id="wd-diag" class="mt-8 bg-slate-800/40 border border-slate-700 rounded-lg overflow-hidden">
+                    <summary class="px-4 py-3 cursor-pointer select-none flex items-center gap-3 hover:bg-slate-700/30 transition-colors">
+                        <h3 class="text-md font-semibold text-gray-300">Diagnostics</h3>
+                        <span id="wd-diag-note" class="text-xs text-gray-500 ml-auto"></span>
+                    </summary>
+                    <div id="wd-diag-body" class="px-4 pb-4">
+                        <p class="text-gray-500 text-sm">Waiting for status…</p>
+                    </div>
+                </details>
             </div>
         </div>
-        
+
         <!-- Config Tab -->
         <div id="config-tab" class="tab-content hidden">
             <div class="glass rounded-xl p-6">
@@ -6697,7 +6711,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260720-wardriving-speed-unit-card"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260720-wardriving-diagnostics"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -22737,6 +22737,194 @@ function updateWardrivingUI(status) {
 
     // Serial ESP32 config card
     updateSerialStatus(status);
+
+    // Collapsed diagnostics panel at the bottom of the tab
+    renderWardrivingDiagnostics(status);
+}
+
+// --- Wardriving diagnostics panel -----------------------------------------
+// Everything /api/wardriving/status exposes, grouped, collapsed by default.
+// Mirrors the panel on the phone-access AP page (web/wardrive_mobile.html) and
+// adds the antenna Coverage group, which only the full dashboard has room for.
+// GPS leads: SNR max and satellites used-vs-in-view are what separate a
+// weak-signal problem from a receiver that keeps restarting when it can see
+// satellites but never fixes.
+let _wdDiagLastStatus = null;
+let _wdDiagBound = false;
+
+function _wdHas(v) { return v !== undefined && v !== null && v !== ''; }
+
+function _wdAge(ts) {
+    if (typeof ts !== 'number' || !isFinite(ts) || ts <= 0) return null;
+    const s = Math.max(0, Math.round(Date.now() / 1000 - ts));
+    if (s < 60) return `${s}s ago`;
+    if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+    return `${Math.floor(s / 3600)}h${Math.floor(s / 60) % 60}m ago`;
+}
+
+function _wdDur(sec) {
+    if (typeof sec !== 'number' || !isFinite(sec) || sec < 0) return null;
+    const t = Math.round(sec), h = Math.floor(t / 3600), m = Math.floor(t / 60) % 60;
+    return h ? `${h}h ${m}m` : `${m}m ${t % 60}s`;
+}
+
+// One titled group of key/value rows. Rows with no value are dropped, and a
+// group with nothing left to show is skipped entirely.
+function _wdDiagGroup(title, rows) {
+    const kept = rows.filter(r => _wdHas(r[1]));
+    if (!kept.length) return '';
+    const body = kept.map(([k, v, tone]) => {
+        const cls = tone === 'warn' ? 'text-red-400'
+                  : tone === 'good' ? 'text-emerald-400' : 'text-gray-200';
+        return `<div class="flex items-baseline gap-3 py-0.5">
+            <span class="text-gray-500 whitespace-nowrap">${escapeHtml(String(k))}</span>
+            <span class="${cls} ml-auto text-right font-mono break-all">${escapeHtml(String(v))}</span>
+        </div>`;
+    }).join('');
+    return `<div class="min-w-0">
+        <h4 class="text-xs uppercase tracking-wide text-gray-500 font-semibold mb-2 pb-1 border-b border-slate-700">${escapeHtml(title)}</h4>
+        <div class="text-xs">${body}</div>
+    </div>`;
+}
+
+function renderWardrivingDiagnostics(status) {
+    const panel = document.getElementById('wd-diag');
+    const body = document.getElementById('wd-diag-body');
+    if (!panel || !body) return;
+
+    _wdDiagLastStatus = status || {};
+    const st = _wdDiagLastStatus;
+    const gps = st.gps || {};
+    const stats = st.stats || {};
+
+    // Headline stays readable while collapsed so a glance often suffices.
+    const note = document.getElementById('wd-diag-note');
+    if (note) {
+        let hint = gps.has_fix ? 'GPS fix' : (gps.connected ? 'GPS searching' : 'no GPS');
+        if (st.error || gps.error) hint += ' · error';
+        note.textContent = hint;
+    }
+
+    // Re-render on expand instead of keeping the DOM warm while hidden.
+    if (!_wdDiagBound) {
+        _wdDiagBound = true;
+        panel.addEventListener('toggle', () => {
+            if (panel.open && _wdDiagLastStatus) renderWardrivingDiagnostics(_wdDiagLastStatus);
+        });
+    }
+    if (!panel.open) return;
+
+    const sats = (_wdHas(gps.satellites) || _wdHas(gps.satellites_in_view))
+        ? `${gps.satellites || 0} used / ${gps.satellites_in_view || 0} in view` : null;
+
+    const groups = [];
+
+    groups.push(_wdDiagGroup('GPS', [
+        ['Fix', gps.has_fix ? 'yes' : 'no', gps.has_fix ? 'good' : 'warn'],
+        ['Fix quality', gps.fix_quality],
+        ['Satellites', sats],
+        ['SNR max', _wdHas(gps.snr_max) ? `${gps.snr_max} dB` : null],
+        ['HDOP', gps.hdop],
+        ['Latitude', _wdHas(gps.latitude) ? Number(gps.latitude).toFixed(6) : null],
+        ['Longitude', _wdHas(gps.longitude) ? Number(gps.longitude).toFixed(6) : null],
+        ['Altitude', _wdHas(gps.altitude) ? `${Number(gps.altitude).toFixed(1)} m` : null],
+        ['Speed', _wdHas(gps.speed_kmh) ? formatWardrivingSpeed(gps.speed_kmh) : null],
+        ['Course', _wdHas(gps.course) ? `${Number(gps.course).toFixed(0)}°` : null],
+        ['Connected', gps.connected ? 'yes' : 'no'],
+        ['Source', gps.source],
+        ['Port', gps.port],
+        ['Last update', _wdAge(gps.last_update)],
+        ['Last sentence', gps.last_sentence],
+        ['GPS error', gps.error, 'warn']
+    ]));
+
+    const strongest = stats.strongest || null;
+    groups.push(_wdDiagGroup('Session', [
+        ['Session', st.session_id],
+        ['Duration', _wdDur(stats.duration_seconds)],
+        ['Networks', stats.total_networks],
+        ['Open / WEP / WPA', _wdHas(stats.total_networks)
+            ? `${stats.open_networks || 0} / ${stats.wep_networks || 0} / ${stats.wpa_networks || 0}` : null],
+        ['2.4 / 5 / 6 GHz', _wdHas(stats.total_networks)
+            ? `${stats.band_2_4ghz || 0} / ${stats.band_5ghz || 0} / ${stats.band_6ghz || 0}` : null],
+        ['Bluetooth', stats.bluetooth_devices],
+        ['Cell towers', stats.cell_towers],
+        ['Cameras', stats.cameras],
+        ['GPS trackpoints', stats.gps_trackpoints],
+        ['Strongest', strongest ? `${strongest.ssid || strongest.bssid || '?'}` +
+            (_wdHas(strongest.best_rssi) ? ` (${strongest.best_rssi} dBm)` : '') : null],
+        ['Database', stats.db_path]
+    ]));
+
+    const scanRows = [
+        ['Running', st.running ? 'yes' : 'no', st.running ? 'good' : 'warn'],
+        ['Band mode', st.band_mode],
+        ['Scans completed', st.scans_completed],
+        ['Networks last scan', st.networks_this_scan],
+        ['Last scan', _wdAge(st.last_scan_time)],
+        ['Interfaces', (st.interfaces || []).join(', ')],
+        ['Engine error', st.error, 'warn']
+    ];
+    (st.interface_details || []).forEach(d => {
+        const bits = [];
+        if (_wdHas(d.networks)) bits.push(`${d.networks} nets`);
+        if (d.driver) bits.push(d.driver);
+        if (d.bands) bits.push([].concat(d.bands).join('/'));
+        if (d.is_usb) bits.push('USB');
+        if (d.manufacturer) bits.push(d.manufacturer);
+        scanRows.push([`  ${d.name}`, bits.join(' · ')]);
+    });
+    groups.push(_wdDiagGroup('Scanning', scanRows));
+
+    // Antenna coverage — which adapter is actually pulling its weight.
+    const cov = st.coverage || {};
+    const perIface = cov.per_interface || {};
+    const covRows = [['Seen by 2+ adapters', cov.overlap]];
+    Object.keys(perIface).forEach(name => {
+        const c = perIface[name] || {};
+        const bits = [];
+        if (_wdHas(c.unique)) bits.push(`${c.unique} uniq`);
+        if (_wdHas(c.only_here)) bits.push(`${c.only_here} only here`);
+        if (_wdHas(c.best_rssi_median)) bits.push(`med ${Number(c.best_rssi_median).toFixed(0)} dBm`);
+        covRows.push([`  ${name}`, bits.join(' · ')]);
+    });
+    groups.push(_wdDiagGroup('Coverage', covRows));
+
+    const comps = st.companions || [];
+    const compRows = [['Companions', comps.length || null]];
+    comps.forEach(c => {
+        const bits = [c.connected ? 'up' : 'down'];
+        if (_wdHas(c.networks)) bits.push(`${c.networks} nets`);
+        if (_wdHas(c.networks_24) || _wdHas(c.networks_5)) {
+            bits.push(`${c.networks_24 || 0}/${c.networks_5 || 0} 2.4/5`);
+        }
+        if (c.esp_mode) bits.push(c.esp_mode);
+        if (_wdHas(c.esp_ble_count)) bits.push(`${c.esp_ble_count} BLE`);
+        if (c.mesh_node_count) bits.push(`${c.mesh_node_count} nodes`);
+        if (c.coordinator_board) bits.push(c.coordinator_board);
+        if (c.coordinator_fw) bits.push(`fw ${c.coordinator_fw}`);
+        compRows.push([`  ${c.name || c.port || 'companion'}`, bits.join(' · ')]);
+        (c.esp_alerts || []).slice(-3).forEach((a, i) => {
+            compRows.push([`    alert ${i + 1}`,
+                typeof a === 'string' ? a : JSON.stringify(a), 'warn']);
+        });
+    });
+    groups.push(_wdDiagGroup('Companions', compRows));
+
+    groups.push(_wdDiagGroup('Device', [
+        ['Device name', st.device_name],
+        ['Bluetooth seen', st.bluetooth_count],
+        ['Cells seen', st.cell_count],
+        ['GPS backfill', _wdHas(st.allow_backfill) ? (st.allow_backfill ? 'allowed' : 'off') : null]
+    ]));
+
+    const html = groups.filter(Boolean).join('');
+    body.innerHTML = html
+        // gap-6 (not gap-x-8/gap-y-5): web/css/tailwind.css is a prebuilt,
+        // purged bundle and there is no local Tailwind CLI to rebuild it, so
+        // every class here must already exist in that file.
+        ? `<div class="grid grid-cols-1 md:grid-cols-2 gap-6 pt-2">${html}</div>`
+        : '<p class="text-gray-500 text-sm">No diagnostics available yet.</p>';
 }
 
 // Render one status bar per connected USB companion. The backend exposes a


### PR DESCRIPTION
The collapsible Diagnostics panel was only on the phone-access AP page. Mirror it onto the main web UI's Wardriving tab, below Session History, so the same detail is available without joining the field AP.

Same contract as the AP page: native <details> collapsed by default (the toggle survives a script error, which is when this gets opened), a live summary hint (GPS fix / searching / no GPS, plus an error marker), DOM work skipped entirely while collapsed and re-rendered on expand, and empty fields omitted rather than blank. Groups: GPS / Session / Scanning / Coverage / Companions / Device.

GPS leads, since SNR max plus satellites used-vs-in-view is what separates a signal-limited receiver from one that keeps resetting. The dashboard also gets a Coverage group the narrow AP page has no room for — per-adapter unique and only-here BSSID counts and median best RSSI, i.e. the antenna comparison.

Two things caught while verifying the render in headless Chromium:

- web/css/tailwind.css is a prebuilt, purged bundle and there is no local Tailwind CLI to rebuild it, so gap-x-8/gap-y-5 and mb-1.5 simply did not exist and the two columns collided. Switched to gap-6/mb-2 after auditing every class in this change against the shipped CSS.
- Bumped the ragnar_modern.js ?v= cache-buster, without which browsers would keep serving the old script and the panel would never appear.

Verified by extracting the real renderer into a harness and screenshotting the collapsed, expanded and no-fix states against stubbed status.

Docs: wardriving.md gains a Diagnostics Panel section (incl. how to read SNR vs satellites for the sees-sats-but-never-fixes case); DISPLAY_CONTROLS.md cross-links to it.