### PR TITLE
Wardriving diag power

### DIFF
--- a/docs/wardriving.md
+++ b/docs/wardriving.md
@@ -356,9 +356,21 @@ with `· error` appended when the engine or GPS reports one), so a glance is
 often enough without expanding. Expanded, it lists everything the
 [Status Object](#status-object) exposes, grouped:
 
+The **GPS**, **Session**, **Scanning**, **Coverage**, **Companions** and
+**Device** groups come from the status object the panel already polls. The
+**GPS constellations**, **Radios**, **Power** and **Errors** groups come from a
+second endpoint, `GET /api/wardriving/diagnostics`, which the panel fetches
+**only while it is expanded** (and at most every 8 s; the backend caches 5 s).
+That walk touches sysfs and shells out to `vcgencmd`, so it deliberately does
+not ride the 3-second status poll.
+
 | Group | Contents |
 |-------|----------|
-| **GPS** | fix + quality, satellites used/in-view, SNR max, HDOP, lat/lon/altitude, speed, course, source, port, last update, last raw NMEA sentence, error |
+| **GPS** | fix + quality, satellites used/in-view, SNR max, HDOP, lat/lon/altitude, speed, course, source, port, age of last update and last NMEA sentence, time-to-first-fix (or how long it has been searching), error |
+| **GPS constellations** | per-constellation satellites in view and peak SNR (GPS / GLONASS / Galileo / BeiDou / QZSS / NavIC) |
+| **Radios** | every wireless interface present, whether it is scanning, its driver / mode / link state, the USB adapter behind it — and **when it is not scanning, the reason** |
+| **Power** | per-USB-device declared draw and which interface it backs, summed USB budget, `usb_max_current_enable`, supply throttle/under-voltage flags (now and since boot), core voltage, temperature, and Pi 5 PMIC board power |
+| **Errors** | everything currently complaining — engine, GPS, radios, companions and supply — gathered into one list |
 | **Session** | id, duration, network totals, open/WEP/WPA, per-band, Bluetooth, cell towers, cameras, trackpoints, strongest AP, DB path |
 | **Scanning** | running, band mode, scans completed, networks last scan, last scan age, interfaces, plus per-adapter driver / bands / USB / manufacturer / network count |
 | **Coverage** | BSSIDs seen by 2+ adapters, and per adapter its unique count, *only-here* count and median best RSSI — the antenna-comparison view (dashboard only) |
@@ -370,12 +382,25 @@ its DOM work entirely while collapsed (re-rendering from the last status when
 expanded), so the polling loop costs nothing extra when it is closed.
 
 > **Diagnosing "sees satellites but never gets a fix":** open **GPS** and read
-> **SNR max** together with **Satellites** (`used / in view`). A cold start must
-> demodulate the ephemeris — roughly 30 s of continuous reception at ≥30 dB-Hz —
-> while an already-established fix tracks down to ~20 dB-Hz. So a receiver
-> showing satellites in view with `0 used` and a low SNR is signal-limited
-> (antenna placement or RF interference from a nearby adapter), whereas
-> comparable SNR with the fix repeatedly resetting points at power instead.
+> **SNR max** together with **Satellites** (`used / in view`) and **Searching
+> for**. A cold start must demodulate the ephemeris — roughly 30 s of continuous
+> reception at ≥30 dB-Hz — while an already-established fix tracks down to
+> ~20 dB-Hz. So a receiver showing satellites in view with `0 used` and a low
+> SNR is signal-limited (antenna placement, or RF desense from an adapter sat
+> next to the puck), whereas comparable SNR with the fix repeatedly resetting
+> points at power instead. **Power** settles that second half: compare the
+> summed USB draw against what the board allows, and check whether
+> `under-voltage` appears under *Right now* or *Since boot* — the "since boot"
+> flags are what catch a brownout that has already passed.
+
+> **Diagnosing "only wlan0 is scanning":** open **Radios**. Every wireless
+> interface the kernel knows about is listed, and any radio that is not in the
+> scan set carries a *why not* line — `rfkill-blocked` (with the unblock
+> command), `held as the uplink / management radio` (wardriving never claims the
+> interface carrying Ragnar's own connectivity — see `_management_ifaces`), `in
+> AP mode (lent to the phone-access AP)`, a monitor child, or simply *present
+> but not claimed*. A radio that does not appear at all was never enumerated by
+> the kernel, which points at the adapter, cable or power rather than at Ragnar.
 
 ### Network Position Preservation
 
@@ -417,6 +442,7 @@ Falls back to linear when either endpoint speed is NULL or both are zero. The ch
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/api/wardriving/status` | Full status incl. GPS, serial, counters |
+| GET | `/api/wardriving/diagnostics` | Deep diagnostics: radios + exclusion reasons, USB power budget, supply health, GPS constellations, errors ([panel](#diagnostics-panel-ui)) |
 | POST | `/api/wardriving/start` | Start wardriving session |
 | POST | `/api/wardriving/stop` | Stop session |
 | GET | `/api/wardriving/networks` | List captured WiFi networks |

--- a/gps_manager.py
+++ b/gps_manager.py
@@ -289,6 +289,13 @@ class GPSManager:
         self.last_update = 0
         self.last_sentence = 0
         self._gsv_by_talker = {}
+        # Time-to-first-fix bookkeeping. A cold start has to demodulate the
+        # ephemeris (~30 s of uninterrupted reception), so a receiver that keeps
+        # browning out or is being desensed shows satellites in view while TTFF
+        # never completes. Recording when the reader started and when the first
+        # fix landed makes that visible instead of inferred.
+        self.start_time = 0
+        self.first_fix_time = 0
         self.connected = False
         self.error = None
         # Tracks whether the current position came from an external source
@@ -301,6 +308,12 @@ class GPSManager:
         """Start GPS reading thread."""
         if self._running:
             return
+
+        # Clock TTFF from the moment the reader is asked to run, not from the
+        # first sentence — the gap before data arrives is part of the problem
+        # when a receiver is struggling.
+        self.start_time = time.time()
+        self.first_fix_time = 0
 
         if not self.port:
             self.port = detect_gps_device(exclude_ports=self._exclude_ports)
@@ -410,7 +423,19 @@ class GPSManager:
         # Consider fix stale after 10 seconds without update
         if self.last_update and (time.time() - self.last_update) > 10:
             return False
+        # Stamp TTFF here rather than in each of the GGA / RMC / gpsd paths:
+        # this method is the one definition of "we actually have a fix", so
+        # every producer would otherwise need the same guard duplicated.
+        if not self.first_fix_time:
+            self.first_fix_time = time.time()
         return True
+
+    @property
+    def ttff_seconds(self):
+        """Seconds from reader start to first fix, or None if still searching."""
+        if not self.start_time or not self.first_fix_time:
+            return None
+        return round(self.first_fix_time - self.start_time, 1)
 
     def get_position(self):
         """Return current position dict (or None if no fix)."""
@@ -448,6 +473,11 @@ class GPSManager:
                 'satellites_in_view': self.satellites_in_view,
                 'snr_max': self.snr_max,
                 'hdop': self.hdop,
+                # TTFF once fixed; until then, how long we have been searching.
+                'ttff_seconds': self.ttff_seconds,
+                'searching_seconds': (round(time.time() - self.start_time, 1)
+                                      if (self.start_time and not self.first_fix_time)
+                                      else None),
                 'latitude': self.latitude,
                 'longitude': self.longitude,
                 'altitude': self.altitude,

--- a/wardrive_diagnostics.py
+++ b/wardrive_diagnostics.py
@@ -1,0 +1,449 @@
+# wardrive_diagnostics.py — deep diagnostics for the wardriving panel.
+#
+# Backs GET /api/wardriving/diagnostics, which the Diagnostics panel fetches
+# only while it is expanded (the 3 s status poll stays cheap). Everything here
+# is best-effort and read-only: a missing tool or sysfs node degrades one field,
+# never the payload.
+#
+# It answers three field questions the plain status object could not:
+#
+#   "why is only wlan0 scanning?"  -> radios(): every wireless netdev, whether
+#       it is in the live scan set, and when it is not, WHY (rfkill-blocked,
+#       held as the uplink/management radio, lent to the phone AP, a monitor
+#       child, or simply never detected).
+#   "what is each device drawing?" -> power(): per-USB-device bMaxPower, which
+#       netdev each adapter backs, and the summed budget.
+#   "is the Pi browning out?"      -> power(): throttled/undervoltage flags,
+#       core voltage, temperature, and Pi 5 PMIC rails when present.
+#
+# bMaxPower is the *declared* draw from the USB descriptor, not a measurement —
+# no Pi can meter per-port current. It is still the number that matters, because
+# it is what the host budgets against.
+
+import glob
+import logging
+import os
+import re
+import subprocess
+import time
+
+logger = logging.getLogger(__name__)
+
+# Whole-payload cache. The panel polls while open; sysfs walks and vcgencmd
+# shell-outs are cheap but not free.
+_CACHE = {'ts': 0.0, 'data': None}
+_CACHE_TTL = 5.0
+
+# vcgencmd get_throttled bit meanings. Low nibble = happening now, bits 16-19 =
+# has happened since boot. The "occurred" bits are the ones that catch a
+# brownout that already passed — exactly the case where a GPS cold start dies
+# but everything looks healthy by the time you go looking.
+_THROTTLE_BITS = (
+    (0,  'now',      'under-voltage'),
+    (1,  'now',      'ARM frequency capped'),
+    (2,  'now',      'currently throttled'),
+    (3,  'now',      'soft temperature limit'),
+    (16, 'occurred', 'under-voltage'),
+    (17, 'occurred', 'ARM frequency capped'),
+    (18, 'occurred', 'throttling'),
+    (19, 'occurred', 'soft temperature limit'),
+)
+
+
+def _run(cmd, timeout=4):
+    """Run a command, returning stdout or None. Never raises."""
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return r.stdout if r.returncode == 0 else None
+    except Exception:
+        return None
+
+
+def _read(path):
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except OSError:
+        return None
+
+
+def _int(val):
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return None
+
+
+# --------------------------------------------------------------------------
+# USB / power
+# --------------------------------------------------------------------------
+
+def _usb_devices():
+    """Every USB device with its declared power draw, newest sysfs first.
+
+    Skips root hubs (they are the host controller, not a peripheral) but keeps
+    external hubs, since a bus-powered hub's own draw counts against the budget.
+    """
+    out = []
+    for path in sorted(glob.glob('/sys/bus/usb/devices/*')):
+        base = os.path.basename(path)
+        # usbN = root hub; 'N-M:X.Y' = an interface, not a device.
+        if base.startswith('usb') or ':' in base:
+            continue
+        max_power = _read(f'{path}/bMaxPower')          # e.g. "500mA"
+        ma = _int((max_power or '').replace('mA', '').strip())
+        vid = _read(f'{path}/idVendor')
+        pid = _read(f'{path}/idProduct')
+        dev = {
+            'id': base,
+            'vendor_id': vid,
+            'product_id': pid,
+            'usb_id': f'{vid}:{pid}' if vid and pid else None,
+            'manufacturer': _read(f'{path}/manufacturer'),
+            'product': _read(f'{path}/product'),
+            'serial': None,      # deliberately not reported (identifying)
+            'max_power_ma': ma,
+            'speed_mbps': _int(_read(f'{path}/speed')),
+            'bus': _int(_read(f'{path}/busnum')),
+            'device': _int(_read(f'{path}/devnum')),
+            'class': _read(f'{path}/bDeviceClass'),
+            'interfaces': [],    # netdev / tty names this device backs
+        }
+        # Which kernel interfaces does this USB device provide? That is what
+        # turns "500mA device" into "wlan1 draws 500mA".
+        for net in glob.glob(f'{path}/*/net/*'):
+            dev['interfaces'].append(os.path.basename(net))
+        for tty in glob.glob(f'{path}/*/tty/*') + glob.glob(f'{path}/*/*/tty/*'):
+            dev['interfaces'].append(os.path.basename(tty))
+        dev['interfaces'] = sorted(set(dev['interfaces']))
+        out.append(dev)
+    return out
+
+
+def _throttled():
+    """Decode vcgencmd get_throttled into readable now/occurred flag lists."""
+    raw = _run(['vcgencmd', 'get_throttled'])
+    if not raw:
+        return None
+    m = re.search(r'0x([0-9a-fA-F]+)', raw)
+    if not m:
+        return None
+    val = int(m.group(1), 16)
+    now, occurred = [], []
+    for bit, when, label in _THROTTLE_BITS:
+        if val & (1 << bit):
+            (now if when == 'now' else occurred).append(label)
+    return {
+        'raw': f'0x{val:X}',
+        'now': now,
+        'occurred': occurred,
+        'healthy': val == 0,
+    }
+
+
+def _pmic_rails():
+    """Pi 5 PMIC per-rail volts/amps. Absent on earlier Pis (incl. Zero 2 W)."""
+    raw = _run(['vcgencmd', 'pmic_read_adc'])
+    if not raw:
+        return None
+    # Lines look like "  VDD_CORE_A current(7)=2.85760000A" and
+    # "  VDD_CORE_V volt(15)=0.83875000V" — the same rail appears twice with an
+    # _A / _V suffix, so strip that to pair current with voltage.
+    volts, amps = {}, {}
+    for m in re.finditer(r'(\S+)\s+(current|volt)\(\d+\)=([\d.]+)([AV])', raw):
+        name, _kind, value, unit = m.groups()
+        rail = re.sub(r'_[AV]$', '', name)
+        try:
+            fval = float(value)
+        except ValueError:
+            continue
+        (amps if unit == 'A' else volts)[rail] = fval
+    rails = []
+    for rail in sorted(set(volts) | set(amps)):
+        v, a = volts.get(rail), amps.get(rail)
+        rails.append({
+            'rail': rail, 'volts': v, 'amps': a,
+            'watts': round(v * a, 3) if (v is not None and a is not None) else None,
+        })
+    total = sum(r['watts'] for r in rails if r['watts'] is not None)
+    return {'rails': rails, 'total_watts': round(total, 2) if rails else None}
+
+
+def power():
+    """USB power budget + Pi supply health."""
+    devices = _usb_devices()
+    known = [d['max_power_ma'] for d in devices if d['max_power_ma']]
+    info = {
+        'usb_devices': devices,
+        'usb_count': len(devices),
+        'usb_declared_ma': sum(known) if known else 0,
+        'throttled': _throttled(),
+        'pmic': _pmic_rails(),
+        'core_volts': None,
+        'temp_c': None,
+        'model': _read('/proc/device-tree/model'),
+        'usb_max_current_enabled': None,
+    }
+    if info['model']:
+        info['model'] = info['model'].replace('\x00', '').strip()
+
+    volts = _run(['vcgencmd', 'measure_volts'])
+    if volts:
+        m = re.search(r'([\d.]+)V', volts)
+        if m:
+            info['core_volts'] = float(m.group(1))
+    temp = _run(['vcgencmd', 'measure_temp'])
+    if temp:
+        m = re.search(r'([\d.]+)', temp)
+        if m:
+            info['temp_c'] = float(m.group(1))
+
+    # Pi 5 caps *total* USB peripheral current at 600mA unless it detects a 5A
+    # PD supply or this flag is set. Worth surfacing next to the declared draw,
+    # because that is the ceiling the sum above is measured against.
+    for cfg in ('/boot/firmware/config.txt', '/boot/config.txt'):
+        txt = _read(cfg)
+        if txt is None:
+            continue
+        for line in txt.splitlines():
+            line = line.strip()
+            if line.startswith('usb_max_current_enable'):
+                info['usb_max_current_enabled'] = line.split('=')[-1].strip() in ('1', 'true')
+        if info['usb_max_current_enabled'] is None:
+            info['usb_max_current_enabled'] = False
+        break
+    return info
+
+
+# --------------------------------------------------------------------------
+# Radios
+# --------------------------------------------------------------------------
+
+def _all_wireless_ifaces():
+    """Every wireless netdev present, from sysfs (the authority on existence)."""
+    found = set()
+    try:
+        for name in os.listdir('/sys/class/net'):
+            if os.path.isdir(f'/sys/class/net/{name}/wireless') \
+                    or os.path.isdir(f'/sys/class/net/{name}/phy80211'):
+                found.add(name)
+    except OSError:
+        pass
+    return sorted(found)
+
+
+def _iface_mode(iface):
+    """managed / monitor / AP, via iw."""
+    out = _run(['iw', 'dev', iface, 'info'])
+    if not out:
+        return None
+    m = re.search(r'^\s*type\s+(\S+)', out, re.M)
+    return m.group(1) if m else None
+
+
+def _usb_owner(iface, usb_devices):
+    """The USB device backing this interface, if it is a dongle."""
+    for d in usb_devices:
+        if iface in d['interfaces']:
+            return d
+    return None
+
+
+def radios(engine, usb_devices=None):
+    """Every wireless radio and whether wardriving is scanning it — with the
+    reason when it is not. This is the answer to "why is only wlan0 listed?".
+    """
+    usb_devices = usb_devices if usb_devices is not None else _usb_devices()
+    scanning = set(getattr(engine, 'interfaces', None) or [])
+
+    try:
+        protected = engine._management_ifaces()
+    except Exception as e:
+        logger.debug(f"management iface lookup failed: {e}")
+        protected = set()
+
+    lent = getattr(engine, '_ap_lent_iface', None)
+
+    out = []
+    for name in _all_wireless_ifaces():
+        blocked = False
+        try:
+            blocked = engine._iface_rfkill_blocked(name)
+        except Exception:
+            pass
+        mode = _iface_mode(name)
+        operstate = _read(f'/sys/class/net/{name}/operstate')
+        usb = _usb_owner(name, usb_devices)
+
+        in_scan = name in scanning
+        reason = None
+        if not in_scan:
+            # Ordered by how decisive each cause is.
+            if name.endswith('mon') or name.startswith('mon'):
+                reason = 'monitor child interface (skipped by design)'
+            elif blocked:
+                reason = 'rfkill-blocked — run: sudo rfkill unblock all'
+            elif name in protected:
+                reason = 'held as the uplink / management radio'
+            elif mode == 'AP':
+                reason = 'in AP mode (lent to the phone-access AP)'
+            elif lent == name:
+                reason = 'lent to the phone-access AP'
+            else:
+                reason = 'not claimed — present but not in the scan set'
+
+        out.append({
+            'name': name,
+            'scanning': in_scan,
+            'excluded_reason': reason,
+            'rfkill_blocked': blocked,
+            'mode': mode,
+            'operstate': operstate,
+            'is_management': name in protected,
+            'driver': _driver_of(name),
+            'usb': {
+                'product': usb['product'],
+                'manufacturer': usb['manufacturer'],
+                'usb_id': usb['usb_id'],
+                'max_power_ma': usb['max_power_ma'],
+            } if usb else None,
+        })
+    return out
+
+
+def _driver_of(iface):
+    try:
+        return os.path.basename(os.path.realpath(f'/sys/class/net/{iface}/device/driver'))
+    except OSError:
+        return None
+
+
+# --------------------------------------------------------------------------
+# GPS
+# --------------------------------------------------------------------------
+
+def gps_extra(engine):
+    """GPS detail the summary card has no room for.
+
+    Notably the per-constellation GSV breakdown: 7 satellites in view split
+    across GPS/GLONASS/Galileo tells a very different story from 7 on one
+    constellation, and the per-talker SNR is what shows an antenna being
+    desensed rather than simply blocked.
+    """
+    gps = getattr(engine, '_gps', None)
+    if gps is None:
+        return {'present': False}
+
+    info = {'present': True}
+    try:
+        info['status'] = gps.get_status()
+    except Exception as e:
+        info['status_error'] = str(e)
+
+    # Per-constellation view, straight off the GSV bookkeeping.
+    talkers = {
+        'GP': 'GPS', 'GL': 'GLONASS', 'GA': 'Galileo', 'GB': 'BeiDou',
+        'BD': 'BeiDou', 'GQ': 'QZSS', 'GI': 'NavIC', 'GN': 'combined',
+    }
+    try:
+        now = time.time()
+        rows = []
+        for talker, val in (getattr(gps, '_gsv_by_talker', None) or {}).items():
+            in_view, snr, ts = val
+            rows.append({
+                'talker': talker,
+                'constellation': talkers.get(talker, talker),
+                'in_view': in_view,
+                'snr_max': snr,
+                'age_s': round(now - ts, 1) if ts else None,
+            })
+        info['constellations'] = sorted(rows, key=lambda r: r['constellation'])
+    except Exception as e:
+        logger.debug(f"GSV breakdown failed: {e}")
+        info['constellations'] = []
+
+    # Serial/gpsd plumbing worth seeing when nothing is arriving at all.
+    info['port'] = getattr(gps, 'port', None)
+    info['use_gpsd'] = bool(getattr(gps, '_use_gpsd', False))
+    info['baudrate'] = getattr(gps, 'baudrate', None)
+    info['ttff_s'] = getattr(gps, 'ttff_seconds', None)
+    return info
+
+
+# --------------------------------------------------------------------------
+# Errors
+# --------------------------------------------------------------------------
+
+def errors(engine, shared_data=None):
+    """Anything currently complaining, gathered into one list."""
+    out = []
+
+    def add(source, message, severity='error'):
+        if message:
+            out.append({'source': source, 'message': str(message),
+                        'severity': severity})
+
+    add('engine', getattr(engine, 'error', None))
+    gps = getattr(engine, '_gps', None)
+    if gps is not None:
+        add('gps', getattr(gps, 'error', None))
+    if not (getattr(engine, 'interfaces', None) or []):
+        add('radios', 'No WiFi interface is scanning — see the Radios group '
+                      'for why each radio was excluded.')
+    for c in (getattr(engine, '_companions', None) or {}).values():
+        try:
+            if not c.connected:
+                add('companion', f'{c.name or c.port}: disconnected', 'warn')
+            for alert in (c.esp_alerts or [])[-5:]:
+                add('companion', alert, 'warn')
+        except Exception:
+            pass
+
+    thr = _throttled()
+    if thr and not thr['healthy']:
+        if thr['now']:
+            add('power', 'Right now: ' + ', '.join(thr['now']))
+        if thr['occurred']:
+            add('power', 'Since boot: ' + ', '.join(thr['occurred']), 'warn')
+    return out
+
+
+# --------------------------------------------------------------------------
+
+def collect(engine, shared_data=None, force=False):
+    """Full diagnostics payload (cached ~5 s)."""
+    now = time.time()
+    if not force and _CACHE['data'] is not None and now - _CACHE['ts'] < _CACHE_TTL:
+        return _CACHE['data']
+
+    usb_devices = _usb_devices()
+    data = {
+        'generated_at': now,
+        'power': None,
+        'radios': [],
+        'gps': {'present': False},
+        'errors': [],
+    }
+    try:
+        data['power'] = power()
+    except Exception as e:
+        logger.error(f"power diagnostics failed: {e}")
+        data['power_error'] = str(e)
+    try:
+        data['radios'] = radios(engine, usb_devices)
+    except Exception as e:
+        logger.error(f"radio diagnostics failed: {e}")
+        data['radios_error'] = str(e)
+    try:
+        data['gps'] = gps_extra(engine)
+    except Exception as e:
+        logger.error(f"gps diagnostics failed: {e}")
+        data['gps_error'] = str(e)
+    try:
+        data['errors'] = errors(engine, shared_data)
+    except Exception as e:
+        logger.error(f"error collection failed: {e}")
+
+    _CACHE['ts'] = now
+    _CACHE['data'] = data
+    return data

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -6711,7 +6711,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260720-wardriving-diagnostics"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260720-wardriving-diag-power"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -22751,6 +22751,31 @@ function updateWardrivingUI(status) {
 // satellites but never fixes.
 let _wdDiagLastStatus = null;
 let _wdDiagBound = false;
+// Deep payload from /api/wardriving/diagnostics (radios, power, GPS detail,
+// errors). Fetched only while the panel is open — it walks sysfs and shells out
+// to vcgencmd, so it must not ride the 3 s status poll.
+let _wdDiagExtra = null;
+let _wdDiagExtraAt = 0;
+let _wdDiagExtraBusy = false;
+const _WD_DIAG_EXTRA_TTL = 8000;
+
+function _wdFetchDiagExtra(force) {
+    const panel = document.getElementById('wd-diag');
+    if (!panel || !panel.open || _wdDiagExtraBusy) return;
+    if (!force && Date.now() - _wdDiagExtraAt < _WD_DIAG_EXTRA_TTL) return;
+    _wdDiagExtraBusy = true;
+    fetch('/api/wardriving/diagnostics', { cache: 'no-store' })
+        .then(r => r.ok ? r.json() : null)
+        .then(d => {
+            if (d && !d.error) {
+                _wdDiagExtra = d;
+                _wdDiagExtraAt = Date.now();
+                if (_wdDiagLastStatus) renderWardrivingDiagnostics(_wdDiagLastStatus);
+            }
+        })
+        .catch(() => { /* panel degrades to the status-only groups */ })
+        .finally(() => { _wdDiagExtraBusy = false; });
+}
 
 function _wdHas(v) { return v !== undefined && v !== null && v !== ''; }
 
@@ -22809,10 +22834,13 @@ function renderWardrivingDiagnostics(status) {
     if (!_wdDiagBound) {
         _wdDiagBound = true;
         panel.addEventListener('toggle', () => {
-            if (panel.open && _wdDiagLastStatus) renderWardrivingDiagnostics(_wdDiagLastStatus);
+            if (!panel.open) return;
+            _wdFetchDiagExtra(true);
+            if (_wdDiagLastStatus) renderWardrivingDiagnostics(_wdDiagLastStatus);
         });
     }
     if (!panel.open) return;
+    _wdFetchDiagExtra(false);   // refresh the deep payload while open
 
     const sats = (_wdHas(gps.satellites) || _wdHas(gps.satellites_in_view))
         ? `${gps.satellites || 0} used / ${gps.satellites_in_view || 0} in view` : null;
@@ -22834,9 +22862,27 @@ function renderWardrivingDiagnostics(status) {
         ['Source', gps.source],
         ['Port', gps.port],
         ['Last update', _wdAge(gps.last_update)],
-        ['Last sentence', gps.last_sentence],
+        // last_sentence is a TIMESTAMP of the last NMEA sentence, not its text
+        // — rendering it raw printed a bare epoch float on the device.
+        ['Last NMEA', _wdAge(gps.last_sentence)],
+        ['Time to first fix', _wdHas(gps.ttff_seconds) ? `${gps.ttff_seconds}s` : null],
+        ['Searching for', _wdHas(gps.searching_seconds)
+            ? `${_wdDur(gps.searching_seconds)} (no fix yet)` : null,
+            gps.searching_seconds > 120 ? 'warn' : null],
         ['GPS error', gps.error, 'warn']
     ]));
+
+    // Per-constellation GSV breakdown + serial plumbing, from the deeper
+    // /api/wardriving/diagnostics payload.
+    const ex = _wdDiagExtra || {};
+    const exGps = ex.gps || {};
+    if ((exGps.constellations || []).length) {
+        groups.push(_wdDiagGroup('GPS constellations',
+            exGps.constellations.map(c => [
+                c.constellation,
+                `${c.in_view} in view` + (_wdHas(c.snr_max) ? ` · SNR ${c.snr_max} dB` : '')
+            ])));
+    }
 
     const strongest = stats.strongest || null;
     groups.push(_wdDiagGroup('Session', [
@@ -22910,6 +22956,77 @@ function renderWardrivingDiagnostics(status) {
         });
     });
     groups.push(_wdDiagGroup('Companions', compRows));
+
+    // Radios — every wireless interface present, and when one is NOT scanning,
+    // the reason. This is what turns "only wlan0 is listed" from a mystery into
+    // a statement (rfkill-blocked / held as uplink / lent to the AP / unclaimed).
+    const radios = ex.radios || [];
+    if (radios.length) {
+        const rows = [];
+        radios.forEach(r => {
+            const bits = [];
+            if (r.driver) bits.push(r.driver);
+            if (r.mode) bits.push(r.mode);
+            if (r.operstate) bits.push(r.operstate);
+            if (r.usb && r.usb.max_power_ma) bits.push(`${r.usb.max_power_ma} mA`);
+            if (r.usb && (r.usb.product || r.usb.manufacturer)) {
+                bits.push(r.usb.product || r.usb.manufacturer);
+            }
+            rows.push([r.name, (r.scanning ? 'scanning' : 'idle') +
+                (bits.length ? ' · ' + bits.join(' · ') : ''),
+                r.scanning ? 'good' : 'warn']);
+            if (r.excluded_reason) rows.push([`  why not`, r.excluded_reason, 'warn']);
+        });
+        groups.push(_wdDiagGroup('Radios', rows));
+    }
+
+    // Power — declared USB draw per device plus Pi supply health. bMaxPower is
+    // the descriptor's declared draw, not a measurement; no Pi meters per-port
+    // current. It is still the figure the host budgets against.
+    const pw = ex.power || {};
+    if (Object.keys(pw).length) {
+        const rows = [];
+        if (pw.model) rows.push(['Board', pw.model]);
+        (pw.usb_devices || []).forEach(d => {
+            const label = d.product || d.manufacturer || d.usb_id || d.id;
+            const bits = [];
+            if (_wdHas(d.max_power_ma)) bits.push(`${d.max_power_ma} mA`);
+            if (d.interfaces && d.interfaces.length) bits.push(d.interfaces.join(', '));
+            if (d.speed_mbps) bits.push(`${d.speed_mbps} Mb/s`);
+            rows.push([`  ${label}`, bits.join(' · ')]);
+        });
+        if (_wdHas(pw.usb_declared_ma)) {
+            rows.push(['USB declared total', `${pw.usb_declared_ma} mA` +
+                (pw.usb_count ? ` (${pw.usb_count} devices)` : ''),
+                pw.usb_declared_ma > 600 ? 'warn' : null]);
+        }
+        if (pw.usb_max_current_enabled === false) {
+            rows.push(['usb_max_current_enable', 'not set', 'warn']);
+        } else if (pw.usb_max_current_enabled === true) {
+            rows.push(['usb_max_current_enable', 'set', 'good']);
+        }
+        const thr = pw.throttled;
+        if (thr) {
+            rows.push(['Supply', thr.healthy ? 'healthy' : 'see flags below',
+                thr.healthy ? 'good' : 'warn']);
+            if ((thr.now || []).length) rows.push(['  Right now', thr.now.join(', '), 'warn']);
+            if ((thr.occurred || []).length) rows.push(['  Since boot', thr.occurred.join(', '), 'warn']);
+            rows.push(['  throttled flags', thr.raw]);
+        }
+        if (_wdHas(pw.core_volts)) rows.push(['Core voltage', `${pw.core_volts} V`]);
+        if (_wdHas(pw.temp_c)) rows.push(['Temperature', `${pw.temp_c} °C`]);
+        if (pw.pmic && _wdHas(pw.pmic.total_watts)) {
+            rows.push(['Board power (PMIC)', `${pw.pmic.total_watts} W`]);
+        }
+        groups.push(_wdDiagGroup('Power', rows));
+    }
+
+    // Errors — everything currently complaining, in one place.
+    const errs = ex.errors || [];
+    if (errs.length) {
+        groups.push(_wdDiagGroup('Errors',
+            errs.map(e => [e.source, e.message, 'warn'])));
+    }
 
     groups.push(_wdDiagGroup('Device', [
         ['Device name', st.device_name],

--- a/web/wardrive_mobile.html
+++ b/web/wardrive_mobile.html
@@ -251,6 +251,27 @@
   var diagEl = document.getElementById('diag');
   var diagBody = document.getElementById('diag-body');
   var lastStatus = null;
+  // Deep payload (radios, power, GPS constellations, errors) from
+  // /api/wardriving/diagnostics. Fetched only while the panel is open — it
+  // walks sysfs and shells out to vcgencmd, so it must not ride the 3s poll.
+  var diagExtra = null;
+  var diagExtraAt = 0;
+  var diagExtraBusy = false;
+
+  function fetchDiagExtra(force) {
+    if (!diagEl.open || diagExtraBusy) return;
+    if (!force && Date.now() - diagExtraAt < 8000) return;
+    diagExtraBusy = true;
+    getJSON('/api/wardriving/diagnostics').then(function (d) {
+      if (d && !d.error) {
+        diagExtra = d;
+        diagExtraAt = Date.now();
+        if (lastStatus) renderDiag(lastStatus);
+      }
+    }).catch(function () {
+      // panel degrades to the status-only groups
+    }).then(function () { diagExtraBusy = false; });
+  }
 
   function fmtAge(ts) {
     if (typeof ts !== 'number' || !isFinite(ts) || ts <= 0) return null;
@@ -291,6 +312,7 @@
     if (st.error || gps.error) note += ' · error';
     txt('diag-note', note);
     if (!diagEl.open) return;   // don't rebuild the DOM while collapsed
+    fetchDiagExtra(false);      // refresh the deep payload while open
 
     diagBody.textContent = '';
 
@@ -313,9 +335,24 @@
       ['Source', gps.source],
       ['Port', gps.port],
       ['Last update', fmtAge(gps.last_update)],
-      ['Last sentence', gps.last_sentence],
+      // last_sentence is a TIMESTAMP of the last NMEA sentence, not its text —
+      // rendering it raw printed a bare epoch float on the device.
+      ['Last NMEA', fmtAge(gps.last_sentence)],
+      ['Time to first fix', has(gps.ttff_seconds) ? gps.ttff_seconds + 's' : null],
+      ['Searching for', has(gps.searching_seconds)
+        ? fmtDur(gps.searching_seconds) + ' (no fix)' : null,
+        gps.searching_seconds > 120 ? 'warn' : null],
       ['GPS error', gps.error, 'warn']
     ]);
+
+    var ex = diagExtra || {};
+    var exGps = ex.gps || {};
+    if ((exGps.constellations || []).length) {
+      section('GPS constellations', exGps.constellations.map(function (c) {
+        return [c.constellation, c.in_view + ' in view' +
+                (has(c.snr_max) ? ' · SNR ' + c.snr_max + ' dB' : '')];
+      }));
+    }
 
     var strongest = stats.strongest || null;
     section('Session', [
@@ -378,6 +415,69 @@
     });
     section('Companions', compRows);
 
+    // Radios — and, when one is not scanning, why. Answers "only wlan0 is
+    // listed" without needing a shell on the device.
+    var radios = ex.radios || [];
+    if (radios.length) {
+      var rrows = [];
+      radios.forEach(function (r) {
+        var bits = [];
+        if (r.driver) bits.push(r.driver);
+        if (r.mode) bits.push(r.mode);
+        if (r.usb && r.usb.max_power_ma) bits.push(r.usb.max_power_ma + ' mA');
+        if (r.usb && (r.usb.product || r.usb.manufacturer)) {
+          bits.push(r.usb.product || r.usb.manufacturer);
+        }
+        rrows.push([r.name, (r.scanning ? 'scanning' : 'idle') +
+                    (bits.length ? ' · ' + bits.join(' · ') : ''),
+                    r.scanning ? 'good' : 'warn']);
+        if (r.excluded_reason) rrows.push(['  why not', r.excluded_reason, 'warn']);
+      });
+      section('Radios', rrows);
+    }
+
+    // Power — declared USB draw per device (bMaxPower from the descriptor, not
+    // a measurement) plus supply health.
+    var pw = ex.power || {};
+    if (Object.keys(pw).length) {
+      var prows = [];
+      if (pw.model) prows.push(['Board', pw.model]);
+      (pw.usb_devices || []).forEach(function (d) {
+        var bits = [];
+        if (has(d.max_power_ma)) bits.push(d.max_power_ma + ' mA');
+        if (d.interfaces && d.interfaces.length) bits.push(d.interfaces.join(', '));
+        prows.push(['  ' + (d.product || d.manufacturer || d.usb_id || d.id),
+                    bits.join(' · ')]);
+      });
+      if (has(pw.usb_declared_ma)) {
+        prows.push(['USB total', pw.usb_declared_ma + ' mA',
+                    pw.usb_declared_ma > 600 ? 'warn' : null]);
+      }
+      if (pw.usb_max_current_enabled === false) {
+        prows.push(['usb_max_current', 'not set', 'warn']);
+      }
+      var thr = pw.throttled;
+      if (thr) {
+        prows.push(['Supply', thr.healthy ? 'healthy' : 'see below',
+                    thr.healthy ? 'good' : 'warn']);
+        if ((thr.now || []).length) prows.push(['  Right now', thr.now.join(', '), 'warn']);
+        if ((thr.occurred || []).length) prows.push(['  Since boot', thr.occurred.join(', '), 'warn']);
+      }
+      if (has(pw.core_volts)) prows.push(['Core voltage', pw.core_volts + ' V']);
+      if (has(pw.temp_c)) prows.push(['Temperature', pw.temp_c + ' °C']);
+      if (pw.pmic && has(pw.pmic.total_watts)) {
+        prows.push(['Board power', pw.pmic.total_watts + ' W']);
+      }
+      section('Power', prows);
+    }
+
+    var errs = ex.errors || [];
+    if (errs.length) {
+      section('Errors', errs.map(function (e) {
+        return [e.source, e.message, 'warn'];
+      }));
+    }
+
     section('Device', [
       ['Device name', st.device_name],
       ['Bluetooth seen', st.bluetooth_count],
@@ -392,7 +492,9 @@
 
   // Expanding while collapsed skips DOM work, so render on open too.
   diagEl.addEventListener('toggle', function () {
-    if (diagEl.open && lastStatus) renderDiag(lastStatus);
+    if (!diagEl.open) return;
+    fetchDiagExtra(true);
+    if (lastStatus) renderDiag(lastStatus);
   });
 
   // Exit Wardriving: stop the session and drop the field AP, then head back to

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -134,6 +134,7 @@ def check_authentication():
             '/api/wardriving/status', '/api/wardriving/track',
             '/api/wardriving/networks', '/api/wardriving/gps',
             '/api/wardriving/bluetooth', '/api/wardriving/cells',
+            '/api/wardriving/diagnostics',
         )
         write_api = ('/api/wardriving/stop', '/api/system/restart-service')
         if path in ('/', '/wardrive') or (request.method == 'GET' and path in readonly_api):
@@ -8827,6 +8828,23 @@ def wardriving_start():
     except Exception as e:
         logger.error(f"Wardriving start error: {e}")
         return jsonify({'error': str(e)}), 500
+
+@app.route('/api/wardriving/diagnostics')
+def wardriving_diagnostics():
+    """Deep diagnostics for the Diagnostics panel.
+
+    Separate from /api/wardriving/status because the panel only fetches this
+    while it is expanded — the 3 s status poll stays cheap, and the sysfs walk
+    plus vcgencmd shell-outs here only run when somebody is actually looking.
+    """
+    try:
+        import wardrive_diagnostics
+        engine = _get_wardriving_engine()
+        return jsonify(wardrive_diagnostics.collect(engine, shared_data))
+    except Exception as e:
+        logger.error(f"Wardriving diagnostics error: {e}")
+        return jsonify({'error': str(e)}), 500
+
 
 @app.route('/api/wardriving/stop', methods=['POST'])
 def wardriving_stop():


### PR DESCRIPTION
This pull request significantly enhances the wardriving diagnostics panel, both in backend data reporting and frontend UI, to provide much deeper visibility into GPS status, wireless radios, power supply health, and error reporting. The diagnostics panel now fetches and displays detailed information from a new `/api/wardriving/diagnostics` endpoint, but only while the panel is expanded, minimizing backend load. Notably, it adds time-to-first-fix (TTFF) tracking for GPS, per-constellation satellite info, radio exclusion reasons, detailed power and supply status, and a unified error list, making troubleshooting much more straightforward.

**Diagnostics Data Collection and API:**
- Added a new backend endpoint (`/api/wardriving/diagnostics`) that provides deep diagnostics: per-radio status and exclusion reasons, USB power budget, supply health, GPS constellations, and current errors. The frontend only fetches this data while the diagnostics panel is open, with caching and throttling to avoid backend load. [[1]](diffhunk://#diff-3fa5d861f0651d3d6918a7f1af94b2df0a263a47b1156bfd0c8ebcf5db60269dR359-R373) [[2]](diffhunk://#diff-3fa5d861f0651d3d6918a7f1af94b2df0a263a47b1156bfd0c8ebcf5db60269dR445)

**GPS Enhancements:**
- Implemented time-to-first-fix (TTFF) tracking in `gps_manager.py`, recording when the GPS reader started and when the first fix was acquired, and exposing both TTFF and "searching for" duration in the status. [[1]](diffhunk://#diff-ecf8269cfc17cda0874b9bc1637ff64b656570a2fe6e75fb7c807609da158996R292-R298) [[2]](diffhunk://#diff-ecf8269cfc17cda0874b9bc1637ff64b656570a2fe6e75fb7c807609da158996R312-R317) [[3]](diffhunk://#diff-ecf8269cfc17cda0874b9bc1637ff64b656570a2fe6e75fb7c807609da158996R426-R439) [[4]](diffhunk://#diff-ecf8269cfc17cda0874b9bc1637ff64b656570a2fe6e75fb7c807609da158996R476-R480)
- Updated the diagnostics UI to show TTFF, searching duration, and per-constellation breakdown (e.g., GPS, GLONASS, Galileo) from the diagnostics payload. [[1]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L22837-R22886) [[2]](diffhunk://#diff-ba5a8daccff50a38a98df12043d7934dba0a3736acf2f0d92bfb3d072ac04f9eL316-R356)

**Frontend Diagnostics Panel Improvements:**
- The diagnostics panel now fetches and displays additional groups: GPS constellations, Radios (with exclusion reasons), Power (USB device draw, supply health, voltage, temperature), and Errors, in addition to the existing status groups. [[1]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R22960-R23030) [[2]](diffhunk://#diff-ba5a8daccff50a38a98df12043d7934dba0a3736acf2f0d92bfb3d072ac04f9eR418-R480)
- The UI for both desktop (`ragnar_modern.js`) and mobile (`wardrive_mobile.html`) was updated to support these new groups, display new fields, and clarify the meaning of certain values (e.g., rendering the last NMEA timestamp as an age, not a raw float). [[1]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L22812-R22843) [[2]](diffhunk://#diff-ba5a8daccff50a38a98df12043d7934dba0a3736acf2f0d92bfb3d072ac04f9eR315) [[3]](diffhunk://#diff-ba5a8daccff50a38a98df12043d7934dba0a3736acf2f0d92bfb3d072ac04f9eL316-R356)

**Troubleshooting Guidance and Documentation:**
- Expanded the documentation (`docs/wardriving.md`) with detailed explanations on how to use the new diagnostics to troubleshoot common issues, such as "sees satellites but never gets a fix" and "only wlan0 is scanning", and described the new panel groups and their data sources. [[1]](diffhunk://#diff-3fa5d861f0651d3d6918a7f1af94b2df0a263a47b1156bfd0c8ebcf5db60269dR359-R373) [[2]](diffhunk://#diff-3fa5d861f0651d3d6918a7f1af94b2df0a263a47b1156bfd0c8ebcf5db60269dL373-R403)

**Other:**
- Updated cache-busting version string for the main JS bundle to reflect the diagnostics changes.

These changes make the diagnostics panel much more powerful for field troubleshooting, with richer data and actionable explanations for common hardware and configuration problems.