### PR TITLE
wardriving diagnostics: detect stalled feeds, fix USB attribution and…

### DIFF
--- a/docs/wardriving.md
+++ b/docs/wardriving.md
@@ -370,7 +370,23 @@ not ride the 3-second status poll.
 | **GPS constellations** | per-constellation satellites in view and peak SNR (GPS / GLONASS / Galileo / BeiDou / QZSS / NavIC) |
 | **Radios** | every wireless interface present, whether it is scanning, its driver / mode / link state, the USB adapter behind it — and **when it is not scanning, the reason** |
 | **Power** | per-USB-device declared draw and which interface it backs, summed USB budget, `usb_max_current_enable`, supply throttle/under-voltage flags (now and since boot), core voltage, temperature, and Pi 5 PMIC board power |
-| **Errors** | everything currently complaining — engine, GPS, radios, companions and supply — gathered into one list |
+| **Errors** | everything currently complaining — engine, GPS, radios, companions, supply and **stalled feeds** — gathered into one list |
+
+> **Declared, not measured.** The per-device milliamps come from the USB
+> descriptor's `bMaxPower`. No Pi meters per-port current, and the figure is
+> frequently understated — a tri-band adapter that really pulls several hundred
+> milliamps may declare 100 mA. Treat the total as the budget the host *thinks*
+> it has handed out, not as consumption. `usb_max_current_enable` is a Pi 5
+> setting and is only shown on a Pi 5.
+
+> **Stalled feeds.** A feed that has *stopped* looks identical to a weak one in
+> the summary numbers — the last-known satellite count and SNR simply sit at
+> their final value. So **Last NMEA** and **Last scan** turn red once they go
+> stale (30 s and 60 s), and the Errors group says so in words. When GPS and
+> scanning go quiet within a minute of each other, it adds a note that both hang
+> off USB, so a bus/hub glitch or a dip on the USB rail fits better than an RF
+> or per-device fault — check `dmesg` for USB resets. That correlation is
+> invisible if you only read the satellite counts.
 | **Session** | id, duration, network totals, open/WEP/WPA, per-band, Bluetooth, cell towers, cameras, trackpoints, strongest AP, DB path |
 | **Scanning** | running, band mode, scans completed, networks last scan, last scan age, interfaces, plus per-adapter driver / bands / USB / manufacturer / network count |
 | **Coverage** | BSSIDs seen by 2+ adapters, and per adapter its unique count, *only-here* count and median best RSSI — the antenna-comparison view (dashboard only) |

--- a/wardrive_diagnostics.py
+++ b/wardrive_diagnostics.py
@@ -34,6 +34,12 @@ logger = logging.getLogger(__name__)
 _CACHE = {'ts': 0.0, 'data': None}
 _CACHE_TTL = 5.0
 
+# A live receiver emits NMEA every second or so, and the scan loop turns over
+# every few seconds. These thresholds are deliberately generous — they should
+# only fire on a genuine stall, never on a slow cycle.
+GPS_STALE_S = 30
+SCAN_STALE_S = 60
+
 # vcgencmd get_throttled bit meanings. Low nibble = happening now, bits 16-19 =
 # has happened since boot. The "occurred" bits are the ones that catch a
 # brownout that already passed — exactly the case where a GPS cold start dies
@@ -111,10 +117,18 @@ def _usb_devices():
         }
         # Which kernel interfaces does this USB device provide? That is what
         # turns "500mA device" into "wlan1 draws 500mA".
-        for net in glob.glob(f'{path}/*/net/*'):
-            dev['interfaces'].append(os.path.basename(net))
-        for tty in glob.glob(f'{path}/*/tty/*') + glob.glob(f'{path}/*/*/tty/*'):
-            dev['interfaces'].append(os.path.basename(tty))
+        #
+        # Scope this to the device's OWN interface directories ("<dev>:<cfg>.<n>").
+        # In sysfs a hub's downstream devices are nested underneath it, so a
+        # loose "{path}/*/*/tty/*" walks into them and credits the hub with its
+        # children's ports — a bus-powered hub showed up owning the GPS's
+        # ttyACM0. Child devices are enumerated separately in their own right.
+        for iface_dir in glob.glob(f'{path}/{base}:*'):
+            for node in (glob.glob(f'{iface_dir}/net/*')
+                         + glob.glob(f'{iface_dir}/tty/*')
+                         # usb-serial bridges nest one deeper: :1.0/ttyUSB0/tty/ttyUSB0
+                         + glob.glob(f'{iface_dir}/*/tty/*')):
+                dev['interfaces'].append(os.path.basename(node))
         dev['interfaces'] = sorted(set(dev['interfaces']))
         out.append(dev)
     return out
@@ -199,19 +213,21 @@ def power():
             info['temp_c'] = float(m.group(1))
 
     # Pi 5 caps *total* USB peripheral current at 600mA unless it detects a 5A
-    # PD supply or this flag is set. Worth surfacing next to the declared draw,
-    # because that is the ceiling the sum above is measured against.
-    for cfg in ('/boot/firmware/config.txt', '/boot/config.txt'):
-        txt = _read(cfg)
-        if txt is None:
-            continue
-        for line in txt.splitlines():
-            line = line.strip()
-            if line.startswith('usb_max_current_enable'):
-                info['usb_max_current_enabled'] = line.split('=')[-1].strip() in ('1', 'true')
-        if info['usb_max_current_enabled'] is None:
-            info['usb_max_current_enabled'] = False
-        break
+    # PD supply or this flag is set. Only meaningful on Pi 5 — reporting "not
+    # set" on a Zero 2 W or Pi 4 reads as a problem when the setting does not
+    # apply to that board at all, so leave it None (the UI then omits the row).
+    if (info['model'] or '').startswith('Raspberry Pi 5'):
+        for cfg in ('/boot/firmware/config.txt', '/boot/config.txt'):
+            txt = _read(cfg)
+            if txt is None:
+                continue
+            enabled = False
+            for line in txt.splitlines():
+                line = line.strip()
+                if line.startswith('usb_max_current_enable'):
+                    enabled = line.split('=')[-1].strip() in ('1', 'true')
+            info['usb_max_current_enabled'] = enabled
+            break
     return info
 
 
@@ -390,6 +406,37 @@ def errors(engine, shared_data=None):
     if not (getattr(engine, 'interfaces', None) or []):
         add('radios', 'No WiFi interface is scanning — see the Radios group '
                       'for why each radio was excluded.')
+
+    # --- Staleness -------------------------------------------------------
+    # A feed that has simply STOPPED looks identical to a weak one in the
+    # summary numbers: the last-known satellite count and SNR just sit there.
+    # Call it out explicitly, and when both feeds die together, say so — that
+    # pattern points at the shared USB bus (a hub dropping, a bus reset) rather
+    # than at reception or at either device individually.
+    now = time.time()
+    gps_stale = scan_stale = None
+
+    if gps is not None and getattr(gps, 'connected', False):
+        last = getattr(gps, 'last_sentence', 0) or 0
+        if last and now - last > GPS_STALE_S:
+            gps_stale = now - last
+            add('gps', f'No NMEA sentence for {int(gps_stale)}s although the '
+                       f'receiver still reports connected — the port is open '
+                       f'but nothing is arriving.')
+
+    if getattr(engine, '_running', False):
+        last = getattr(engine, 'last_scan_time', 0) or 0
+        if last and now - last > SCAN_STALE_S:
+            scan_stale = now - last
+            add('engine', f'No scan completed for {int(scan_stale)}s although '
+                          f'the engine reports running — the scan loop is '
+                          f'stalled or its radios stopped responding.')
+
+    if gps_stale and scan_stale and abs(gps_stale - scan_stale) < 60:
+        add('usb', 'GPS and WiFi scanning went quiet within a minute of each '
+                   'other. Both hang off USB, so a bus/hub glitch or a power '
+                   'dip on the USB rail fits better than an RF or per-device '
+                   'fault. Check dmesg for USB resets/disconnects.')
     for c in (getattr(engine, '_companions', None) or {}).values():
         try:
             if not c.connected:

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -6711,7 +6711,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260720-wardriving-diag-power"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260720-wardriving-diag-stale"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -22787,6 +22787,12 @@ function _wdAge(ts) {
     return `${Math.floor(s / 3600)}h${Math.floor(s / 60) % 60}m ago`;
 }
 
+// True when an epoch-seconds timestamp is older than `maxAge` seconds.
+function _wdStale(ts, maxAge) {
+    if (typeof ts !== 'number' || !isFinite(ts) || ts <= 0) return false;
+    return (Date.now() / 1000 - ts) > maxAge;
+}
+
 function _wdDur(sec) {
     if (typeof sec !== 'number' || !isFinite(sec) || sec < 0) return null;
     const t = Math.round(sec), h = Math.floor(t / 3600), m = Math.floor(t / 60) % 60;
@@ -22863,8 +22869,11 @@ function renderWardrivingDiagnostics(status) {
         ['Port', gps.port],
         ['Last update', _wdAge(gps.last_update)],
         // last_sentence is a TIMESTAMP of the last NMEA sentence, not its text
-        // — rendering it raw printed a bare epoch float on the device.
-        ['Last NMEA', _wdAge(gps.last_sentence)],
+        // — rendering it raw printed a bare epoch float on the device. Flag it
+        // red once it goes stale: a feed that stopped looks exactly like a weak
+        // one in the numbers above, which just sit at their last value.
+        ['Last NMEA', _wdAge(gps.last_sentence),
+            _wdStale(gps.last_sentence, 30) ? 'warn' : null],
         ['Time to first fix', _wdHas(gps.ttff_seconds) ? `${gps.ttff_seconds}s` : null],
         ['Searching for', _wdHas(gps.searching_seconds)
             ? `${_wdDur(gps.searching_seconds)} (no fix yet)` : null,
@@ -22907,7 +22916,8 @@ function renderWardrivingDiagnostics(status) {
         ['Band mode', st.band_mode],
         ['Scans completed', st.scans_completed],
         ['Networks last scan', st.networks_this_scan],
-        ['Last scan', _wdAge(st.last_scan_time)],
+        ['Last scan', _wdAge(st.last_scan_time),
+            (st.running && _wdStale(st.last_scan_time, 60)) ? 'warn' : null],
         ['Interfaces', (st.interfaces || []).join(', ')],
         ['Engine error', st.error, 'warn']
     ];

--- a/web/wardrive_mobile.html
+++ b/web/wardrive_mobile.html
@@ -286,6 +286,11 @@
     return h ? (h + 'h ' + m + 'm') : (m + 'm ' + (t % 60) + 's');
   }
   function has(v) { return v !== undefined && v !== null && v !== ''; }
+  // True when an epoch-seconds timestamp is older than maxAge seconds.
+  function stale(ts, maxAge) {
+    if (typeof ts !== 'number' || !isFinite(ts) || ts <= 0) return false;
+    return (Date.now() / 1000 - ts) > maxAge;
+  }
 
   function section(title, rows) {
     var any = rows.some(function (r) { return has(r[1]); });
@@ -337,7 +342,8 @@
       ['Last update', fmtAge(gps.last_update)],
       // last_sentence is a TIMESTAMP of the last NMEA sentence, not its text —
       // rendering it raw printed a bare epoch float on the device.
-      ['Last NMEA', fmtAge(gps.last_sentence)],
+      ['Last NMEA', fmtAge(gps.last_sentence),
+        stale(gps.last_sentence, 30) ? 'warn' : null],
       ['Time to first fix', has(gps.ttff_seconds) ? gps.ttff_seconds + 's' : null],
       ['Searching for', has(gps.searching_seconds)
         ? fmtDur(gps.searching_seconds) + ' (no fix)' : null,
@@ -379,7 +385,8 @@
       ['Band mode', st.band_mode],
       ['Scans completed', st.scans_completed],
       ['Networks last scan', st.networks_this_scan],
-      ['Last scan', fmtAge(st.last_scan_time)],
+      ['Last scan', fmtAge(st.last_scan_time),
+        (st.running && stale(st.last_scan_time, 60)) ? 'warn' : null],
       ['Interfaces', (st.interfaces || []).join(', ')],
       ['Engine error', st.error, 'warn']
     ];


### PR DESCRIPTION
This pull request improves the diagnostics and user interface for wardriving by detecting and surfacing stalled GPS and WiFi scanning feeds. It introduces logic to explicitly call out when these feeds have stopped updating, both in backend diagnostics and in the web/mobile UI, making it easier to identify USB-related issues and distinguish true stalls from weak signals. It also refines how USB device interfaces are attributed and clarifies reporting for Pi 5-specific power settings.

**Diagnostics and Error Reporting Improvements:**

* Added backend detection for stalled GPS (no NMEA sentence for 30s) and WiFi scanning (no scan for 60s), with explicit error messages and correlation logic to suggest USB bus issues when both stall together (`wardrive_diagnostics.py`).
* Updated the documentation in `docs/wardriving.md` to explain how stalled feeds are detected and reported, and clarified how USB power draw is interpreted.

**User Interface Enhancements:**

* Updated the web and mobile UI (`web/scripts/ragnar_modern.js`, `web/wardrive_mobile.html`) to highlight "Last NMEA" and "Last scan" fields in red when data is stale, using new helper functions to determine staleness. [[1]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L22866-R22876) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L22910-R22920) [[3]](diffhunk://#diff-ba5a8daccff50a38a98df12043d7934dba0a3736acf2f0d92bfb3d072ac04f9eL340-R346) [[4]](diffhunk://#diff-ba5a8daccff50a38a98df12043d7934dba0a3736acf2f0d92bfb3d072ac04f9eL382-R389) [[5]](diffhunk://#diff-ba5a8daccff50a38a98df12043d7934dba0a3736acf2f0d92bfb3d072ac04f9eR289-R293)
* Bumped the JavaScript version in `web/index_modern.html` to reflect these UI changes.

**USB Device Attribution and Power Reporting:**

* Improved attribution of kernel interfaces to the correct USB devices by scoping sysfs directory searches, preventing parent hubs from being incorrectly credited with child device interfaces (`wardrive_diagnostics.py`).
* Refined logic for reporting the `usb_max_current_enabled` setting to only apply to Raspberry Pi 5, avoiding misleading information on other models (`wardrive_diagnostics.py`).