### PR TITLE
Wardriving GPS sky view: per-satellite azimuth/elevation polar plot

### DIFF
--- a/docs/wardriving.md
+++ b/docs/wardriving.md
@@ -313,7 +313,7 @@ Re-run `sudo scripts/setup_gpsd.sh` manually after swapping to a different GPS r
 
 - **Permissive talker IDs.** The GGA/RMC/GSV regexes accept any two-letter talker prefix (GP, GN, GL, GA, GB, GI, GQ, …) so multi-GNSS modules are covered.
 - **Optional time field.** Pre-fix receivers emit GGA/RMC with empty time and position. The parser accepts these so `last_update` and satellite counters move as soon as any NMEA is received — not only after first fix.
-- **GSV parsing.** Per-constellation `$xxGSV` sentences are aggregated; the API exposes `satellites_in_view` (sum across all reporting constellations) and `snr_max` (highest reported SNR in dB-Hz). Entries that haven't been heard from in 30 s are pruned so a constellation that stops reporting doesn't inflate the total.
+- **GSV parsing.** Per-constellation `$xxGSV` sentences are aggregated; the API exposes `satellites_in_view` (sum across all reporting constellations) and `snr_max` (highest reported SNR in dB-Hz). The multi-message GSV sweep is also stitched back into a **per-satellite list** (PRN, elevation, azimuth, SNR) per constellation, which the diagnostics endpoint surfaces as `gps.sky` for the sky-view plot; the NMEA 4.10+ trailing signal-ID field is ignored. Entries that haven't been heard from in 30 s are pruned so a constellation that stops reporting doesn't inflate the total.
 - **Liveness signal.** `last_sentence` updates on any recognized NMEA line (including GSV / GSA / VTG / GLL / TXT and pre-fix GGA/RMC). `last_update` continues to mean "last positional/fix update". Together they distinguish "GPS is alive but has no fix yet" from "GPS isn't transmitting at all".
 
 ### Status Fields (`/api/wardriving/gps`)
@@ -358,9 +358,10 @@ often enough without expanding. Expanded, it lists everything the
 
 The **GPS**, **Session**, **Scanning**, **Coverage**, **Companions** and
 **Device** groups come from the status object the panel already polls. The
-**GPS constellations**, **Radios**, **Power** and **Errors** groups come from a
-second endpoint, `GET /api/wardriving/diagnostics`, which the panel fetches
-**only while it is expanded** (and at most every 8 s; the backend caches 5 s).
+**GPS constellations**, **GPS sky view**, **Radios**, **Power** and **Errors**
+groups come from a second endpoint, `GET /api/wardriving/diagnostics`, which the
+panel fetches **only while it is expanded** (and at most every 8 s; the backend
+caches 5 s).
 That walk touches sysfs and shells out to `vcgencmd`, so it deliberately does
 not ride the 3-second status poll.
 
@@ -368,6 +369,7 @@ not ride the 3-second status poll.
 |-------|----------|
 | **GPS** | fix + quality, satellites used/in-view, SNR max, HDOP, lat/lon/altitude, speed, course, source, port, age of last update and last NMEA sentence, time-to-first-fix (or how long it has been searching), error |
 | **GPS constellations** | per-constellation satellites in view and peak SNR (GPS / GLONASS / Galileo / BeiDou / QZSS / NavIC) |
+| **GPS sky view** | polar plot of every satellite by azimuth/elevation, coloured per constellation — North up, zenith at centre, horizon at the rim. Fill opacity tracks SNR (untracked satellites render hollow); hover a dot for PRN / elevation / azimuth / SNR. This is the graphical half of the same GSV data u-center draws |
 | **Radios** | every wireless interface present, whether it is scanning, its driver / mode / link state, the USB adapter behind it — and **when it is not scanning, the reason** |
 | **Power** | per-USB-device declared draw and which interface it backs, summed USB budget, `usb_max_current_enable`, supply throttle/under-voltage flags (now and since boot), core voltage, temperature, and Pi 5 PMIC board power |
 | **Errors** | everything currently complaining — engine, GPS, radios, companions, supply and **stalled feeds** — gathered into one list |

--- a/gps_manager.py
+++ b/gps_manager.py
@@ -289,6 +289,11 @@ class GPSManager:
         self.last_update = 0
         self.last_sentence = 0
         self._gsv_by_talker = {}
+        # Per-satellite sky view (prn/elev/az/snr) keyed by talker, plus the
+        # in-flight accumulator that stitches the multi-message GSV sequence
+        # (each sentence carries ≤4 satellites) back into one sweep.
+        self._sats_by_talker = {}
+        self._gsv_accum = {}
         # Time-to-first-fix bookkeeping. A cold start has to demodulate the
         # ephemeris (~30 s of uninterrupted reception), so a receiver that keeps
         # browning out or is being desensed shows satellites in view while TTFF
@@ -859,19 +864,46 @@ class GPSManager:
             try:
                 talker = m.group('talker')
                 in_view = int(m.group('in_view'))
+                total_msgs = int(m.group('total_msgs'))
+                msg_num = int(m.group('msg_num'))
                 fields = m.group('body').split(',')
                 snr_max = None
-                for i in range(3, len(fields), 4):
-                    raw = fields[i].strip()
-                    if not raw:
+                # The body is repeating quads: prn, elev, az, snr. NMEA 4.10+
+                # appends a trailing signalID field, so iterate complete quads
+                # only (range stops before an odd tail).
+                msg_sats = []
+                for i in range(0, len(fields) - 3, 4):
+                    prn = fields[i].strip()
+                    elev = fields[i + 1].strip()
+                    az = fields[i + 2].strip()
+                    raw = fields[i + 3].strip()
+                    try:
+                        snr = int(raw) if raw else None
+                    except ValueError:
+                        snr = None
+                    if snr is not None and (snr_max is None or snr > snr_max):
+                        snr_max = snr
+                    if not prn:
                         continue
                     try:
-                        snr = int(raw)
+                        msg_sats.append({
+                            'prn': int(prn),
+                            'elev': int(elev) if elev else None,
+                            'az': int(az) if az else None,
+                            'snr': snr,
+                        })
                     except ValueError:
                         continue
-                    if snr_max is None or snr > snr_max:
-                        snr_max = snr
                 with self._lock:
+                    # Reset the accumulator on the first message of a sweep and
+                    # commit the whole list on the last, so the sky view never
+                    # shows a half-populated constellation mid-sequence.
+                    if msg_num <= 1:
+                        self._gsv_accum[talker] = []
+                    self._gsv_accum.setdefault(talker, []).extend(msg_sats)
+                    if msg_num >= total_msgs:
+                        self._sats_by_talker[talker] = (self._gsv_accum.pop(talker, []), now)
+
                     prev = self._gsv_by_talker.get(talker, (0, None, 0))
                     merged_snr = snr_max
                     if merged_snr is None:
@@ -882,6 +914,9 @@ class GPSManager:
                     stale = [t for t, v in self._gsv_by_talker.items() if now - v[2] > 30]
                     for t in stale:
                         del self._gsv_by_talker[t]
+                    for t in [t for t, v in self._sats_by_talker.items()
+                              if now - v[1] > 30]:
+                        del self._sats_by_talker[t]
                     self.satellites_in_view = sum(v[0] for v in self._gsv_by_talker.values())
                     snrs = [v[1] for v in self._gsv_by_talker.values() if v[1] is not None]
                     self.snr_max = max(snrs) if snrs else None

--- a/wardrive_diagnostics.py
+++ b/wardrive_diagnostics.py
@@ -378,6 +378,33 @@ def gps_extra(engine):
         logger.debug(f"GSV breakdown failed: {e}")
         info['constellations'] = []
 
+    # Per-satellite sky view (azimuth/elevation/SNR) for a polar plot — the
+    # graphical half of the same GSV data u-center draws. Only satellites with
+    # both azimuth and elevation are plottable.
+    try:
+        now = time.time()
+        sky = []
+        for talker, val in (getattr(gps, '_sats_by_talker', None) or {}).items():
+            sats, ts = val
+            if ts and now - ts > 30:
+                continue
+            cons = talkers.get(talker, talker)
+            for s in sats:
+                if s.get('az') is None or s.get('elev') is None:
+                    continue
+                sky.append({
+                    'constellation': cons,
+                    'talker': talker,
+                    'prn': s.get('prn'),
+                    'az': s.get('az'),
+                    'elev': s.get('elev'),
+                    'snr': s.get('snr'),
+                })
+        info['sky'] = sky
+    except Exception as e:
+        logger.debug(f"sky view failed: {e}")
+        info['sky'] = []
+
     # Serial/gpsd plumbing worth seeing when nothing is arriving at all.
     info['port'] = getattr(gps, 'port', None)
     info['use_gpsd'] = bool(getattr(gps, '_use_gpsd', False))

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -6711,7 +6711,7 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/ragnar_modern.js?v=20260720-wardriving-diag-stale"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260721-gps-sky-view"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -22801,6 +22801,63 @@ function _wdDur(sec) {
 
 // One titled group of key/value rows. Rows with no value are dropped, and a
 // group with nothing left to show is skipped entirely.
+// Polar sky plot of satellites by azimuth/elevation, coloured per
+// constellation — the graphical half of the GSV data u-center draws. North is
+// up, zenith at the centre, horizon at the outer ring. Fill opacity tracks SNR
+// so a weak-but-tracked satellite reads as faint; an untracked one (no SNR)
+// shows as a hollow ring. Colours are inline (SVG attrs / style), not Tailwind
+// classes, so the purged tailwind.css bundle needs no rebuild.
+const _WD_SKY_COLORS = {
+    GPS: '#34d399', GLONASS: '#f87171', Galileo: '#60a5fa',
+    BeiDou: '#fbbf24', QZSS: '#a78bfa', NavIC: '#f472b6', combined: '#94a3b8'
+};
+
+function _wdSkyPlot(sky) {
+    const pts = (sky || []).filter(s => _wdHas(s.az) && _wdHas(s.elev));
+    if (!pts.length) return '';
+    const S = 220, c = S / 2, R = c - 16;   // leave a margin for cardinal labels
+    // Elevation rings at 0°, 30°, 60° (radius = (90 - elev) / 90).
+    const rings = [1, 2 / 3, 1 / 3].map(f =>
+        `<circle cx="${c}" cy="${c}" r="${(R * f).toFixed(1)}" fill="none" stroke="#334155" stroke-width="1"/>`
+    ).join('');
+    const card = [['N', 0], ['E', 90], ['S', 180], ['W', 270]].map(([lab, az]) => {
+        const a = az * Math.PI / 180;
+        const lx = c + (R + 9) * Math.sin(a), ly = c - (R + 9) * Math.cos(a);
+        return `<text x="${lx.toFixed(1)}" y="${(ly + 3).toFixed(1)}" fill="#64748b" font-size="10" text-anchor="middle">${lab}</text>`;
+    }).join('');
+    const dots = pts.map(s => {
+        const elev = Math.max(0, Math.min(90, s.elev));
+        const r = R * (90 - elev) / 90;
+        const a = s.az * Math.PI / 180;
+        const x = c + r * Math.sin(a), y = c - r * Math.cos(a);
+        const col = _WD_SKY_COLORS[s.constellation] || '#94a3b8';
+        const hasSnr = _wdHas(s.snr) && s.snr > 0;
+        const op = hasSnr ? (0.3 + 0.7 * Math.min(1, s.snr / 50)) : 0.35;
+        const fill = hasSnr ? col : 'none';
+        const tip = `${s.constellation} PRN ${s.prn} · el ${s.elev}° az ${s.az}°`
+            + (hasSnr ? ` · SNR ${s.snr} dB` : ' · untracked');
+        return `<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="3.2" fill="${fill}" stroke="${col}" stroke-width="1" opacity="${op.toFixed(2)}"><title>${escapeHtml(tip)}</title></circle>`;
+    }).join('');
+    const svg = `<svg viewBox="0 0 ${S} ${S}" class="w-full" style="max-width:240px" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="${c}" cy="${c}" r="${R}" fill="#0f172a"/>
+        ${rings}
+        <line x1="${c}" y1="${c - R}" x2="${c}" y2="${c + R}" stroke="#334155" stroke-width="1"/>
+        <line x1="${c - R}" y1="${c}" x2="${c + R}" y2="${c}" stroke="#334155" stroke-width="1"/>
+        ${card}${dots}
+    </svg>`;
+    const present = [...new Set(pts.map(s => s.constellation))];
+    const legend = present.map(name => {
+        const col = _WD_SKY_COLORS[name] || '#94a3b8';
+        return `<span class="inline-flex items-center gap-1 mr-2"><span style="width:8px;height:8px;border-radius:9999px;background:${col};display:inline-block"></span>${escapeHtml(name)}</span>`;
+    }).join('');
+    return `<div class="min-w-0">
+        <h4 class="text-xs uppercase tracking-wide text-gray-500 font-semibold mb-2 pb-1 border-b border-slate-700">GPS sky view</h4>
+        <div class="flex flex-col items-center">${svg}
+            <div class="text-[10px] text-gray-400 mt-1 flex flex-wrap justify-center">${legend}</div>
+        </div>
+    </div>`;
+}
+
 function _wdDiagGroup(title, rows) {
     const kept = rows.filter(r => _wdHas(r[1]));
     if (!kept.length) return '';
@@ -22891,6 +22948,10 @@ function renderWardrivingDiagnostics(status) {
                 c.constellation,
                 `${c.in_view} in view` + (_wdHas(c.snr_max) ? ` · SNR ${c.snr_max} dB` : '')
             ])));
+    }
+    if ((exGps.sky || []).length) {
+        const skyHtml = _wdSkyPlot(exGps.sky);
+        if (skyHtml) groups.push(skyHtml);
     }
 
     const strongest = stats.strongest || null;

--- a/web/wardrive_mobile.html
+++ b/web/wardrive_mobile.html
@@ -309,6 +309,71 @@
     diagBody.appendChild(dl);
   }
 
+  // Polar sky plot: satellites by azimuth/elevation, coloured per
+  // constellation (North up, zenith centre, horizon at the rim). Fill opacity
+  // tracks SNR; untracked satellites (no SNR) render hollow. Styles are inline
+  // so this needs nothing from the page stylesheet.
+  var SKY_COLORS = { GPS: '#34d399', GLONASS: '#f87171', Galileo: '#60a5fa',
+    BeiDou: '#fbbf24', QZSS: '#a78bfa', NavIC: '#f472b6', combined: '#94a3b8' };
+
+  function skyEsc(v) {
+    return String(v).replace(/[<>&"]/g, function (ch) {
+      return { '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;' }[ch];
+    });
+  }
+
+  function skyPlot(sky) {
+    var pts = (sky || []).filter(function (s) { return has(s.az) && has(s.elev); });
+    if (!pts.length) return;
+    var S = 220, c = S / 2, R = c - 16;
+    var svg = '<circle cx="' + c + '" cy="' + c + '" r="' + R + '" fill="#0f172a"/>';
+    [1, 2 / 3, 1 / 3].forEach(function (f) {
+      svg += '<circle cx="' + c + '" cy="' + c + '" r="' + (R * f).toFixed(1) +
+             '" fill="none" stroke="#334155" stroke-width="1"/>';
+    });
+    svg += '<line x1="' + c + '" y1="' + (c - R) + '" x2="' + c + '" y2="' + (c + R) + '" stroke="#334155" stroke-width="1"/>';
+    svg += '<line x1="' + (c - R) + '" y1="' + c + '" x2="' + (c + R) + '" y2="' + c + '" stroke="#334155" stroke-width="1"/>';
+    [['N', 0], ['E', 90], ['S', 180], ['W', 270]].forEach(function (p) {
+      var a = p[1] * Math.PI / 180;
+      var lx = c + (R + 9) * Math.sin(a), ly = c - (R + 9) * Math.cos(a);
+      svg += '<text x="' + lx.toFixed(1) + '" y="' + (ly + 3).toFixed(1) +
+             '" fill="#64748b" font-size="10" text-anchor="middle">' + p[0] + '</text>';
+    });
+    pts.forEach(function (s) {
+      var elev = Math.max(0, Math.min(90, s.elev));
+      var r = R * (90 - elev) / 90, a = s.az * Math.PI / 180;
+      var x = c + r * Math.sin(a), y = c - r * Math.cos(a);
+      var col = SKY_COLORS[s.constellation] || '#94a3b8';
+      var hasSnr = has(s.snr) && s.snr > 0;
+      var op = hasSnr ? (0.3 + 0.7 * Math.min(1, s.snr / 50)) : 0.35;
+      var tip = s.constellation + ' PRN ' + s.prn + ' · el ' + s.elev + '° az ' +
+                s.az + '°' + (hasSnr ? ' · SNR ' + s.snr + ' dB' : ' · untracked');
+      svg += '<circle cx="' + x.toFixed(1) + '" cy="' + y.toFixed(1) +
+             '" r="3.2" fill="' + (hasSnr ? col : 'none') + '" stroke="' + col +
+             '" stroke-width="1" opacity="' + op.toFixed(2) + '"><title>' +
+             skyEsc(tip) + '</title></circle>';
+    });
+    var h = document.createElement('h3'); h.textContent = 'GPS sky view';
+    diagBody.appendChild(h);
+    var wrap = document.createElement('div');
+    wrap.innerHTML = '<svg viewBox="0 0 ' + S + ' ' + S +
+      '" style="width:100%;max-width:240px;display:block;margin:0 auto" ' +
+      'xmlns="http://www.w3.org/2000/svg">' + svg + '</svg>';
+    var present = [];
+    pts.forEach(function (s) {
+      if (present.indexOf(s.constellation) < 0) present.push(s.constellation);
+    });
+    var leg = document.createElement('div');
+    leg.style.cssText = 'font-size:10px;color:#9ca3af;display:flex;flex-wrap:wrap;justify-content:center;gap:8px;margin-top:4px';
+    leg.innerHTML = present.map(function (name) {
+      var col = SKY_COLORS[name] || '#94a3b8';
+      return '<span><i style="display:inline-block;width:8px;height:8px;border-radius:9999px;background:' +
+             col + ';margin-right:4px;vertical-align:middle"></i>' + skyEsc(name) + '</span>';
+    }).join('');
+    wrap.appendChild(leg);
+    diagBody.appendChild(wrap);
+  }
+
   function renderDiag(st) {
     var gps = st.gps || {}, stats = st.stats || {};
     // Headline stays visible while collapsed so a glance is often enough.
@@ -359,6 +424,7 @@
                 (has(c.snr_max) ? ' · SNR ' + c.snr_max + ' dB' : '')];
       }));
     }
+    skyPlot(exGps.sky);
 
     var strongest = stats.strongest || null;
     section('Session', [


### PR DESCRIPTION
Extend GSV parsing to stitch the multi-message sweep into a per-satellite list (PRN, elevation, azimuth, SNR) per constellation, ignoring the NMEA 4.10+ trailing signal-ID field. Surface it as gps.sky in the diagnostics endpoint and render an SVG polar sky plot in both the modern and mobile diagnostics panels — North up, zenith centre, horizon at the rim, coloured per constellation with fill opacity tracking SNR. The graphical half of the same GSV data u-center draws.