### PR TITLE
GPS sky view: make the fullscreen view actually live (1 Hz, uncached)

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -165,8 +165,10 @@ so you can see the sky the receiver is looking at.
   az/el and always render.)
 - **Tap/click** a satellite for its constellation / PRN / elevation / azimuth /
   SNR, or a star for its name, constellation, magnitude and elevation/azimuth.
-- It polls this same endpoint every ~2.5 s, so satellites move live and the
-  starfield drifts with sidereal time.
+- It polls the lightweight, uncached `GET /api/wardriving/gps` (which now carries
+  the `sky` list alongside the GPS status) at ~1 Hz — not the heavy, 5 s-cached
+  `/diagnostics` endpoint — so satellites update live and the starfield drifts
+  with sidereal time.
 
 No external libraries or CDN — pure SVG + vanilla JS; the RA/Dec→alt/az
 transform is self-tested against Polaris (altitude ≈ latitude, azimuth ≈ 0°).

--- a/gps_manager.py
+++ b/gps_manager.py
@@ -504,6 +504,36 @@ class GPSManager:
             except Exception as e:
                 logger.debug(f"last-known GPS persist failed: {e}")
 
+    # Talker code -> human constellation name, for the sky view. Shared by the
+    # gpsd (SKY) and serial (GSV) paths, both of which key by these codes.
+    _TALKER_NAMES = {
+        'GP': 'GPS', 'GL': 'GLONASS', 'GA': 'Galileo', 'GB': 'BeiDou',
+        'BD': 'BeiDou', 'GQ': 'QZSS', 'GI': 'NavIC', 'GN': 'combined',
+    }
+
+    def get_sky_view(self):
+        """Per-satellite sky list (constellation / prn / az / elev / snr) for the
+        sky-view plot, from the live GSV/SKY bookkeeping. Only satellites with
+        both azimuth and elevation (the plottable ones); stale talkers (>30 s)
+        are skipped. Cheap enough to poll at ~1 Hz for a live view."""
+        now = time.time()
+        with self._lock:
+            items = [(t, s, ts) for t, (s, ts) in self._sats_by_talker.items()]
+        out = []
+        for talker, sats, ts in items:
+            if ts and now - ts > 30:
+                continue
+            cons = self._TALKER_NAMES.get(talker, talker)
+            for s in sats:
+                if s.get('az') is None or s.get('elev') is None:
+                    continue
+                out.append({
+                    'constellation': cons, 'talker': talker,
+                    'prn': s.get('prn'), 'az': s.get('az'),
+                    'elev': s.get('elev'), 'snr': s.get('snr'),
+                })
+        return out
+
     def get_status(self):
         """Return full GPS status dict."""
         with self._lock:

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -6711,8 +6711,8 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="/web/scripts/skyview.js?v=20260721-skyview-lastknown"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260721-skyview-lastknown"></script>
+    <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260721-skyview-live"></script>
 
 </body>
 </html>

--- a/web/scripts/skyview.js
+++ b/web/scripts/skyview.js
@@ -22,7 +22,7 @@
 
   const D2R = Math.PI / 180, R2D = 180 / Math.PI;
   const CATALOG_URL = '/web/vendor/star_catalog.json';
-  const REFRESH_MS = 2500;
+  const REFRESH_MS = 1000;
 
   // Constellation colours mirror the small diagnostics plot.
   const SAT_COLORS = {
@@ -271,13 +271,16 @@
   }
 
   function refresh() {
-    fetch('/api/wardriving/diagnostics')
+    // The lightweight, uncached GPS endpoint (status + sky) — polled at 1 Hz so
+    // the view is actually live, unlike the heavy 5 s-cached /diagnostics one.
+    // Its body IS the status object (has_fix/lat/lon/last_known at top level),
+    // with a `sky` array alongside.
+    fetch('/api/wardriving/gps', { cache: 'no-store' })
       .then(r => r.ok ? r.json() : null)
       .then(d => {
         if (!d || !overlay) return;
-        const gps = d.gps || {};
-        const p = positionFromStatus(gps.status);
-        lastData = { sky: gps.sky || [], lat: p.lat, lon: p.lon, mode: p.mode, t: p.t };
+        const p = positionFromStatus(d);
+        lastData = { sky: d.sky || [], lat: p.lat, lon: p.lon, mode: p.mode, t: p.t };
         render();
       })
       .catch(() => {});

--- a/web/wardrive_mobile.html
+++ b/web/wardrive_mobile.html
@@ -118,7 +118,7 @@
   </div>
 </div>
 
-<script src="/web/scripts/skyview.js?v=20260721-skyview-lastknown"></script>
+<script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
 <script>
 (function () {
   "use strict";

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -8963,7 +8963,12 @@ def wardriving_gps():
     try:
         engine = _get_wardriving_engine()
         if engine._gps:
-            return jsonify(engine._gps.get_status())
+            status = engine._gps.get_status()
+            # Include the per-satellite sky list so the live fullscreen sky view
+            # can poll this cheap, uncached endpoint instead of the heavy,
+            # 5 s-cached /diagnostics one.
+            status['sky'] = engine._gps.get_sky_view()
+            return jsonify(status)
         return jsonify({'connected': False, 'error': 'GPS not initialized'})
     except Exception as e:
         return jsonify({'error': str(e)}), 500


### PR DESCRIPTION
The fullscreen sky view polled /api/wardriving/diagnostics, which is cached 5 s server-side and does heavy sysfs/vcgencmd/iw work — so satellites moved in chunky 5 s steps and felt frozen. Add get_sky_view() to GPSManager and expose the per-satellite sky list on the lightweight, uncached /api/wardriving/gps endpoint; skyview.js now polls that at 1 Hz. Same data, fresh every second, far cheaper per poll.