### PR TITLE
Wardriving: count and store Zigbee/802.15.4 devices from Huginn

### DIFF
--- a/display.py
+++ b/display.py
@@ -2478,6 +2478,7 @@ class Display:
             ("WEP", st.get('wep_networks', 0)),
             ("BT", st.get('bluetooth_devices', 0)),
             ("Cell", st.get('cell_towers', 0)),
+            ("Zig", st.get('zigbee_devices', 0)),
             ("Track", st.get('gps_trackpoints', 0)),
         ]
         self._wd_compact_rows(draw, rows, int(15 * sy), footer_y)
@@ -2719,6 +2720,8 @@ class Display:
         ]
         if st.get('cell_towers', 0) > 0:
             stats_bottom.append(("Cell", str(st.get('cell_towers', 0))))
+        if st.get('zigbee_devices', 0) > 0:
+            stats_bottom.append(("Zigbee", str(st.get('zigbee_devices', 0))))
         if st.get('cameras', 0) > 0:
             stats_bottom.append(("Cameras", str(st.get('cameras', 0))))
         stats_bottom.append(("GPS", gps_str))
@@ -2750,6 +2753,9 @@ class Display:
                 ble = c.get('esp_ble_count', 0)
                 if ble > 0:
                     stats_bottom.append(("  BLE", str(ble)))
+                zig = c.get('esp_zigbee_count', 0)
+                if zig > 0:
+                    stats_bottom.append(("  Zigbee", str(zig)))
         else:
             stats_bottom.append(("Companion", "None"))
 
@@ -3200,7 +3206,11 @@ class Display:
             bt_n = st.get('bluetooth_devices', 0)
             cell_n = st.get('cell_towers', 0)
             cam_n = st.get('cameras', 0)
-            draw.text((30, y), f"BT:{bt_n} Cell:{cell_n} Cam:{cam_n}", font=font_side, fill=C_AMBER)
+            zig_n = st.get('zigbee_devices', 0)
+            bt_line = f"BT:{bt_n} Cell:{cell_n} Cam:{cam_n}"
+            if zig_n:
+                bt_line += f" Zig:{zig_n}"
+            draw.text((30, y), bt_line, font=font_side, fill=C_AMBER)
             y += line_h
             scans = wd.get('scans_completed', 0) if wd else 0
             draw.text((30, y), f"Scans: {scans}", font=font_side, fill=C_GRAY)
@@ -3685,6 +3695,7 @@ class Display:
             wpa_n = st.get('wpa_networks', 0)
             bt_n = st.get('bluetooth_devices', 0)
             cell_n = st.get('cell_towers', 0)
+            zig_n = st.get('zigbee_devices', 0)
             scans = wd.get('scans_completed', 0) if wd else 0
 
             if gps.get('has_fix'):
@@ -3715,7 +3726,8 @@ class Display:
 
             # Body
             draw.text((0, 15), f"Net:{total} Open:{open_n} WPA:{wpa_n}", font=font_body, fill=255)
-            draw.text((0, 26), f"BT:{bt_n} Cell:{cell_n} Scans:{scans}", font=font_body, fill=255)
+            _zig = f" Zig:{zig_n}" if zig_n else ""
+            draw.text((0, 26), f"BT:{bt_n} Cell:{cell_n}{_zig} Scans:{scans}", font=font_body, fill=255)
             draw.text((0, 37), gps_str[:22], font=font_body, fill=255)
 
             return img

--- a/docs/wardriving.md
+++ b/docs/wardriving.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-Ragnar's wardriving engine collects WiFi networks, BLE devices, cell towers, and GPS positions while driving. Data is stored in SQLite per session and can be exported to WiGLE CSV or KML.
+Ragnar's wardriving engine collects WiFi networks, BLE devices, Zigbee / 802.15.4 devices, cell towers, and GPS positions while driving. Data is stored in SQLite per session and can be exported to WiGLE CSV or KML.
 
 Ragnar supports **five operating modes**, in any combination — all five can run at the same time and merge into one session DB:
 
 | # | Mode | Hardware | What it adds |
 |---|------|----------|--------------|
 | 1 | **Standalone wardriver** | Raspberry Pi (or PC) with its built-in Wi-Fi and/or one or more USB Wi-Fi adapters | WiFi scanning via `iw`, multi-adapter antenna coverage |
-| 2 | **+ HuginnESP (USB)** | ESP32-S3-Touch-LCD-4B running [HuginnESP](https://github.com/PierreGode/HuginnESP) | Real-time WiFi + BLE + AirTag/Flipper/skimmer/pineapple detection |
+| 2 | **+ HuginnESP (USB)** | ESP32-S3-Touch-LCD-4B or ESP32-C5 running [HuginnESP](https://github.com/PierreGode/HuginnESP) | Real-time WiFi + BLE + AirTag/Flipper/skimmer/pineapple detection (+ Zigbee/802.15.4 on ESP32-C5) |
 | 3 | **+ Piglet (USB)** | Any [Piglet](https://github.com/Hamspiced/piglet) board (XIAO ESP32-S3/C5/C6, LilyGo T-Dongle C5) Works only with my fork till tested and aprooved by [Hamspiced](https://github.com/Hamspiced/), flash [here](https://pierregode.github.io/piglet/) | Live WiGLE-CSV stream over serial |
 | 4 | **+ Piglet Coordinator (USB)** | Dedicated [Coordinator](https://pierregode.github.io/Ragnar/) firmware on a Waveshare ESP32-C5 *or* ESP32-S3-Touch-LCD-4B | Receives records from a fleet of Piglet mesh nodes over ESP-Now and forwards them to Ragnar live |
 | 5 | **+ Piglet Core (USB)** | A regular Piglet board running mesh `core` mode, tethered to Ragnar | Same idea as #4 but on a standard Piglet — the Core scans locally *and* aggregates its mesh nodes, streaming the combined feed to Ragnar |
@@ -203,6 +203,24 @@ over-report. The companion status bar shows `2.4G` / `5G` alongside the total
 ```json
 {"type":"BLE","mac":"AA:BB:CC:DD:EE:FF","name":"DeviceName","rssi":-60}
 ```
+
+#### Zigbee / 802.15.4 Devices (JSON, one line per sighting)
+
+Emitted by HuginnESP builds with an IEEE 802.15.4 radio (ESP32-C5). Ragnar
+stores these in a dedicated `zigbee_devices` table and counts them separately
+from BLE — the live status bar and displays show a `Zigbee` total alongside
+`BT` and `Cell`, and `/api/wardriving/zigbee` returns the full list.
+
+```json
+{"type":"ZIGBEE","panid":"0x1A2B","addr":"AABBCCDDEEFF0011","short":"0x1234","channel":15,"rssi":-70,"lqi":180,"ftype":"beacon"}
+```
+
+Each device is identified by its 64-bit extended address (`addr` / EUI-64) when
+the frame carries one; otherwise Ragnar falls back to `"<panid>:<short>"` as the
+identity so a device is still counted once. `lqi` (link quality) and the
+802.15.4 `channel` (11–26) are retained; `ftype` (e.g. `beacon` / `data` /
+`cmd`) is stored as the device type. GPS is stamped from Ragnar's fix when the
+frame has none, exactly like WiFi/BLE rows.
 
 #### AirTag (multi-line, FILTERED + ALL mode)
 ```

--- a/wardriving.py
+++ b/wardriving.py
@@ -136,6 +136,7 @@ class _CompanionState:
         # Per-connection scan state
         self.current_esp_mode: str = 'wifi'
         self.esp_ble_count: int = 0
+        self.esp_zigbee_count: int = 0
         self.esp_alerts: list = []
         self.esp_alert_buffer: dict = {}
         self.esp_airtag_buffer = None
@@ -194,6 +195,7 @@ class _CompanionState:
             'coordinator_nodes': self.active_coordinator_nodes(),
             'esp_mode':          self.current_esp_mode,
             'esp_ble_count':     self.esp_ble_count,
+            'esp_zigbee_count':  self.esp_zigbee_count,
             'esp_alerts':        self.esp_alerts[-5:],
         }
 
@@ -364,6 +366,35 @@ class WardrivingSession:
             """)
             conn.execute("""
                 CREATE UNIQUE INDEX IF NOT EXISTS idx_cell ON cell_towers(cell_id)
+            """)
+            # Zigbee / IEEE 802.15.4 devices seen by a companion with a
+            # 2.4 GHz 802.15.4 radio (e.g. HuginnESP on an ESP32-C5). Keyed by
+            # the device identity: its 64-bit extended address (EUI-64) when the
+            # frame carries one, otherwise "<panid>:<short>" as a fallback.
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS zigbee_devices (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    addr TEXT NOT NULL,
+                    panid TEXT DEFAULT '',
+                    short_addr TEXT DEFAULT '',
+                    device_type TEXT DEFAULT '',
+                    rssi INTEGER DEFAULT -100,
+                    best_rssi INTEGER DEFAULT -100,
+                    lqi INTEGER DEFAULT 0,
+                    channel INTEGER DEFAULT 0,
+                    latitude REAL,
+                    longitude REAL,
+                    altitude REAL,
+                    best_lat REAL,
+                    best_lon REAL,
+                    first_seen TEXT NOT NULL,
+                    last_seen TEXT NOT NULL,
+                    scan_count INTEGER DEFAULT 1,
+                    gps_backfilled INTEGER DEFAULT 0
+                )
+            """)
+            conn.execute("""
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_zigbee_addr ON zigbee_devices(addr)
             """)
             # Migrate older networks / cell_towers tables that predate the
             # GPS-backfill flag. Table names here are hardcoded literals, so
@@ -688,6 +719,61 @@ class WardrivingSession:
             except Exception as e:
                 logger.debug(f"Cell upsert error: {e}")
 
+    def upsert_zigbee(self, addr, panid, short_addr, device_type,
+                      rssi, lqi, channel, lat, lon, alt):
+        """Insert or update a discovered Zigbee / 802.15.4 device.
+
+        `addr` is the stable identity (EUI-64 or "<panid>:<short>"). Best
+        position is tracked at the strongest RSSI sighting, mirroring how
+        Bluetooth devices are recorded so map exports stay consistent.
+        """
+        if not addr:
+            return
+        now = datetime.now(timezone.utc).isoformat()
+        with self._lock:
+            try:
+                with sqlite3.connect(self.db_path) as conn:
+                    existing = conn.execute(
+                        "SELECT scan_count, best_rssi FROM zigbee_devices WHERE addr = ?",
+                        (addr,)
+                    ).fetchone()
+                    if existing:
+                        count = (existing[0] or 0) + 1
+                        old_best = existing[1] if existing[1] is not None else -100
+                        new_best = rssi if rssi > old_best else old_best
+                        best_lat_val = lat if (rssi > old_best and lat) else None
+                        best_lon_val = lon if (rssi > old_best and lon) else None
+                        conn.execute("""
+                            UPDATE zigbee_devices SET
+                                panid = COALESCE(NULLIF(?, ''), panid),
+                                short_addr = COALESCE(NULLIF(?, ''), short_addr),
+                                device_type = COALESCE(NULLIF(?, ''), device_type),
+                                rssi = ?, lqi = ?,
+                                channel = CASE WHEN ? > 0 THEN ? ELSE channel END,
+                                best_rssi = ?,
+                                best_lat = COALESCE(?, best_lat),
+                                best_lon = COALESCE(?, best_lon),
+                                latitude = COALESCE(?, latitude),
+                                longitude = COALESCE(?, longitude),
+                                altitude = COALESCE(?, altitude),
+                                last_seen = ?, scan_count = ?
+                            WHERE addr = ?
+                        """, (panid, short_addr, device_type,
+                              rssi, lqi, channel, channel,
+                              new_best, best_lat_val, best_lon_val,
+                              lat, lon, alt, now, count, addr))
+                    else:
+                        conn.execute("""
+                            INSERT INTO zigbee_devices
+                                (addr, panid, short_addr, device_type, rssi, best_rssi,
+                                 lqi, channel, latitude, longitude, altitude,
+                                 best_lat, best_lon, first_seen, last_seen, scan_count)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+                        """, (addr, panid, short_addr, device_type, rssi, rssi,
+                              lqi, channel, lat, lon, alt, lat, lon, now, now))
+            except Exception as e:
+                logger.debug(f"Zigbee upsert error: {e}")
+
     def get_stats(self):
         """Return session statistics (cached for 5 s to reduce SQLite load)."""
         now = time.time()
@@ -721,15 +807,20 @@ class WardrivingSession:
                     strongest = conn.execute("SELECT bssid, ssid, best_rssi FROM networks ORDER BY best_rssi DESC LIMIT 1").fetchone()
                     trackpoints = conn.execute("SELECT COUNT(*) FROM gps_track").fetchone()[0]
 
-                    # Bluetooth and cell counts (tables may not exist in old DBs)
+                    # Bluetooth, cell and Zigbee counts (tables may not exist in old DBs)
                     bt_count = 0
                     cell_count = 0
+                    zigbee_count = 0
                     try:
                         bt_count = conn.execute("SELECT COUNT(*) FROM bluetooth_devices").fetchone()[0]
                     except Exception:
                         pass
                     try:
                         cell_count = conn.execute("SELECT COUNT(*) FROM cell_towers").fetchone()[0]
+                    except Exception:
+                        pass
+                    try:
+                        zigbee_count = conn.execute("SELECT COUNT(*) FROM zigbee_devices").fetchone()[0]
                     except Exception:
                         pass
 
@@ -745,6 +836,7 @@ class WardrivingSession:
                         'band_6ghz': band_6,
                         'bluetooth_devices': bt_count,
                         'cell_towers': cell_count,
+                        'zigbee_devices': zigbee_count,
                         'cameras': camera_count,
                         'gps_trackpoints': trackpoints,
                         'strongest': dict(strongest) if strongest else None,
@@ -862,6 +954,19 @@ class WardrivingSession:
                     conn.row_factory = sqlite3.Row
                     rows = conn.execute(
                         "SELECT * FROM cell_towers ORDER BY signal_dbm DESC"
+                    ).fetchall()
+                    return [dict(r) for r in rows]
+            except Exception:
+                return []
+
+    def get_zigbee_devices(self):
+        """Get all discovered Zigbee / 802.15.4 devices."""
+        with self._lock:
+            try:
+                with sqlite3.connect(self.db_path) as conn:
+                    conn.row_factory = sqlite3.Row
+                    rows = conn.execute(
+                        "SELECT * FROM zigbee_devices ORDER BY rssi DESC"
                     ).fetchall()
                     return [dict(r) for r in rows]
             except Exception:
@@ -1411,6 +1516,7 @@ class WardrivingEngine:
         self._last_gps_track = 0
         self.bt_count = 0
         self.cell_count = 0
+        self.zigbee_count = 0
         self.device_name = ''
         # Multi-companion support: one _CompanionState per USB-serial port.
         # Keyed by port path (e.g. '/dev/ttyACM0').
@@ -1480,6 +1586,10 @@ class WardrivingEngine:
     @property
     def _esp_ble_count(self) -> int:
         return sum(c.esp_ble_count for c in self._companions.values())
+
+    @property
+    def _esp_zigbee_count(self) -> int:
+        return sum(c.esp_zigbee_count for c in self._companions.values())
 
     @property
     def _esp_alerts(self) -> list:
@@ -1630,6 +1740,7 @@ class WardrivingEngine:
         self.scans_completed = 0
         self.bt_count = 0
         self.cell_count = 0
+        self.zigbee_count = 0
 
         # Save device name and session info
         if self.device_name:
@@ -2408,6 +2519,7 @@ class WardrivingEngine:
             'gps': gps_status,
             'bluetooth_count': self.bt_count,
             'cell_count': self.cell_count,
+            'zigbee_count': self.zigbee_count,
             'device_name': self.device_name,
             # Backward-compat single-companion fields (aggregated)
             'serial_connected': self.serial_connected,
@@ -2421,6 +2533,7 @@ class WardrivingEngine:
             'coordinator_nodes': self._active_coordinator_nodes(),
             'esp_mode':      self._current_esp_mode,
             'esp_ble_count': self._esp_ble_count,
+            'esp_zigbee_count': self._esp_zigbee_count,
             'esp_alerts':    self._esp_alerts[-5:],
             'band_mode': self.band_mode,
             # Multi-companion list: full per-device status for the UI
@@ -2485,6 +2598,17 @@ class WardrivingEngine:
                             "WHERE device_type IN ('BLE','Flipper','AirTag','Skimmer')"
                         ).fetchone()
                         result['esp_ble_count'] = row[0] if row else 0
+                    except Exception:
+                        pass
+                    # Unique Zigbee / 802.15.4 devices seen via a companion radio.
+                    # DB-backed so the status bar reflects unique devices, not
+                    # the running stream line count.
+                    try:
+                        row = conn.execute(
+                            "SELECT COUNT(*) FROM zigbee_devices"
+                        ).fetchone()
+                        result['esp_zigbee_count'] = row[0] if row else 0
+                        result['zigbee_count'] = result['esp_zigbee_count']
                     except Exception:
                         pass
             except Exception:
@@ -4108,6 +4232,58 @@ class WardrivingEngine:
                             'last_update': time.time(),
                         }
                         companion.mesh_node_count = len(companion.coordinator_nodes)
+                    return
+
+                # Zigbee / IEEE 802.15.4 rows from a companion with an
+                # 802.15.4 radio (HuginnESP on ESP32-C5). Handled before the
+                # 48-bit-MAC guard below because a Zigbee device is identified
+                # by its EUI-64 / PAN-ID + short address, not a Wi-Fi BSSID.
+                if data.get('type', '').upper() in ('ZIGBEE', 'ZB', '802.15.4', 'IEEE802154'):
+                    companion.current_esp_mode = 'zigbee'
+                    addr = str(data.get('addr') or data.get('eui')
+                               or data.get('ext') or data.get('mac') or ''
+                               ).upper().replace(':', '')
+                    panid = str(data.get('panid') or data.get('pan') or '').upper()
+                    short = str(data.get('short') or data.get('nwk') or '').upper()
+                    if not addr:
+                        # No extended address in the frame — fall back to the
+                        # PAN + short address (or just the PAN) as identity.
+                        if panid and short:
+                            addr = f"{panid}:{short}"
+                        elif panid:
+                            addr = panid
+                    if not addr:
+                        return
+                    try:
+                        z_rssi = int(data.get('rssi', data.get('signal', -80)))
+                    except (ValueError, TypeError):
+                        z_rssi = -80
+                    try:
+                        z_lqi = int(data.get('lqi', 0) or 0)
+                    except (ValueError, TypeError):
+                        z_lqi = 0
+                    try:
+                        z_channel = int(data.get('channel', data.get('ch', 0)) or 0)
+                    except (ValueError, TypeError):
+                        z_channel = 0
+                    z_dtype = str(data.get('ftype') or data.get('dev')
+                                  or data.get('name') or '')
+                    z_lat, z_lon, z_alt, z_from = self._resolve_coords(
+                        data.get('lat', data.get('latitude')),
+                        data.get('lon', data.get('longitude')),
+                        data.get('alt', data.get('altitude')),
+                        gps_lat, gps_lon, gps_alt,
+                    )
+                    self.session.upsert_zigbee(
+                        addr, panid, short, z_dtype,
+                        z_rssi, z_lqi, z_channel, z_lat, z_lon, z_alt
+                    )
+                    companion.esp_zigbee_count += 1
+                    if z_from and self._gps is not None:
+                        self._gps.update_external_fix(
+                            z_lat, z_lon, z_alt,
+                            source=companion.name or 'companion'
+                        )
                     return
 
                 mac = data.get('mac', data.get('bssid', '')).upper()

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -9156,6 +9156,25 @@ def wardriving_cells():
         return jsonify({'error': str(e)}), 500
 
 
+@app.route('/api/wardriving/zigbee')
+def wardriving_zigbee():
+    """Get discovered Zigbee / 802.15.4 devices."""
+    try:
+        engine = _get_wardriving_engine()
+        session_id = request.args.get('session_id')
+        if session_id and (not engine.session or engine.session.session_id != session_id):
+            from wardriving import WardrivingSession
+            session = WardrivingSession(engine.data_dir, session_id=session_id)
+        elif engine.session:
+            session = engine.session
+        else:
+            return jsonify({'devices': [], 'total': 0})
+        devices = session.get_zigbee_devices()
+        return jsonify({'devices': devices, 'total': len(devices)})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
 @app.route('/api/wardriving/backfill_gps', methods=['POST'])
 def wardriving_backfill_gps():
     """Backfill missing GPS positions on networks / BT / cell rows from the


### PR DESCRIPTION
## Summary

Ragnar's wardriving engine now counts and stores Zigbee / IEEE 802.15.4 devices streamed by a HuginnESP companion running on an ESP32-C5 (see PierreGode/HuginnESP#18). They're tracked separately from BLE and surfaced everywhere BT/Cell already are.

Companion emits:
```json
{"type":"ZIGBEE","panid":"0x1A2B","addr":"AABBCCDDEEFF0011","short":"0x1234","channel":15,"rssi":-70,"lqi":180,"ftype":"beacon"}
```

## Changes

- **Storage:** new `zigbee_devices` SQLite table + `upsert_zigbee()` / `get_zigbee_devices()`. Each device is deduped by its EUI-64 (or `"<panid>:<short>"` when the frame carries only a short address), tracking best position at strongest RSSI plus LQI and the 802.15.4 channel.
- **Parsing:** `ZIGBEE` JSON lines are handled in `_parse_serial_line` **before** the 48-bit-MAC guard that would otherwise discard them, and GPS is stamped from Ragnar's fix when the frame has none — exactly like WiFi/BLE rows.
- **Counting:** per-companion `esp_zigbee_count`, aggregated across companions, exposed in `get_stats()` and the status dict (DB-backed unique count, so the status bar reflects unique devices rather than stream volume).
- **Surfacing:** new `/api/wardriving/zigbee` endpoint; the e-paper / LCD displays now show a `Zigbee` total alongside `BT` and `Cell` (compact, side, and per-companion views).
- **Docs:** `docs/wardriving.md` updated (overview, companion capability table, and a new Zigbee serial-output section).

## Testing

- DB layer verified with a functional test (dedup, best-RSSI update, `panid:short` fallback).
- Full `_parse_serial_line` path verified end-to-end (Zigbee counted, BLE unaffected, unique-device dedup, `as_dict` exposure).
- `wardriving.py`, `webapp_modern.py`, and `display.py` all byte-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Axa2CEazybfsS8NtLW3So