### PR TITLE
Wardrive web zigbee counts

### DIFF
--- a/docs/wardriving.md
+++ b/docs/wardriving.md
@@ -211,6 +211,12 @@ stores these in a dedicated `zigbee_devices` table and counts them separately
 from BLE — the live status bar and displays show a `Zigbee` total alongside
 `BT` and `Cell`, and `/api/wardriving/zigbee` returns the full list.
 
+> **WiGLE export is opt-in.** WiGLE has no standard 802.15.4 record type, so
+> Zigbee devices are **excluded from WiGLE CSV export by default**. Enable
+> **Config → Wardriving → Include Zigbee in WiGLE CSV** (`wardriving_wigle_include_zigbee`)
+> to append them with a `ZIGBEE` type token — intended for your own tooling,
+> not for submitting to WiGLE. Applies to both manual export and Auto Export on Stop.
+
 ```json
 {"type":"ZIGBEE","panid":"0x1A2B","addr":"AABBCCDDEEFF0011","short":"0x1234","channel":15,"rssi":-70,"lqi":180,"ftype":"beacon"}
 ```

--- a/shared.py
+++ b/shared.py
@@ -859,6 +859,7 @@ class SharedData:
             "wardriving_gps_baudrate": 9600,
             "wardriving_interfaces": [],
             "wardriving_auto_export": True,
+            "wardriving_wigle_include_zigbee": False,
             "wardriving_device_name": "",
             "wardriving_speed_unit": "kmh",
             "wardriving_on_boot": False,

--- a/wardriving.py
+++ b/wardriving.py
@@ -1118,12 +1118,17 @@ class WardrivingSession:
                 logger.error(f"GPS backfill error: {e}")
         return result
 
-    def export_wigle_csv(self, device_name='Ragnar'):
+    def export_wigle_csv(self, device_name='Ragnar', include_zigbee=False):
         """Export session to WiGLE CSV format string including WiFi, BT, and cell.
 
         Rows whose position was estimated via backfill_gps_from_track
         (gps_backfilled = 1) are excluded — they are interpolated coordinates,
-        not real observations, and must not be submitted to WiGLE."""
+        not real observations, and must not be submitted to WiGLE.
+
+        Zigbee / 802.15.4 devices are excluded by default: WiGLE has no
+        standard 802.15.4 record type, so those rows are only useful for the
+        user's own tooling. Set `include_zigbee=True` (opt-in from the config
+        tab) to append them with a `ZIGBEE` type token."""
         lines = []
         dn = device_name or 'Ragnar'
         lines.append(f'WigleWifi-1.4,appRelease=Ragnar,model=RaspberryPi,release=1.0,device={dn},display=EPD,board=RPi,brand=Ragnar')
@@ -1199,6 +1204,32 @@ class WardrivingSession:
                             ]))
                     except Exception:
                         pass
+                    # Zigbee / 802.15.4 devices — opt-in only (see docstring).
+                    if include_zigbee:
+                        try:
+                            zb_rows = conn.execute(
+                                "SELECT * FROM zigbee_devices WHERE COALESCE(gps_backfilled, 0) = 0 "
+                                "ORDER BY first_seen"
+                            ).fetchall()
+                            for row in zb_rows:
+                                r = dict(row)
+                                zlat = r.get('best_lat') if r.get('best_lat') is not None else r.get('latitude')
+                                zlon = r.get('best_lon') if r.get('best_lon') is not None else r.get('longitude')
+                                lines.append(','.join([
+                                    r.get('addr', ''),
+                                    (r.get('panid', '') or '').replace(',', '\\,'),
+                                    '[ZIGBEE]',
+                                    r.get('first_seen', ''),
+                                    str(r.get('channel', 0)),
+                                    str(r.get('best_rssi', -100)),
+                                    str(zlat if zlat is not None else ''),
+                                    str(zlon if zlon is not None else ''),
+                                    str(r.get('altitude', '') or ''),
+                                    '',
+                                    'ZIGBEE'
+                                ]))
+                        except Exception:
+                            pass
             except Exception as e:
                 logger.error(f"WiGLE export error: {e}")
 

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -505,6 +505,10 @@ const configMetadata = {
         label: "Auto Export on Stop",
         description: "Automatically export a WiGLE CSV file when a wardriving session is stopped."
     },
+    wardriving_wigle_include_zigbee: {
+        label: "Include Zigbee in WiGLE CSV",
+        description: "Append discovered Zigbee / 802.15.4 devices to WiGLE CSV exports with a ZIGBEE type token. Off by default: WiGLE has no standard 802.15.4 record type, so enable this only for your own tooling, not for submitting to WiGLE."
+    },
     wardriving_speed_unit: {
         label: "Speed Unit",
         description: "Unit used to display GPS speed across the wardriving views (dashboard, map, kiosk, and hardware display). Choose km/h or mph. Recorded data is always stored in km/h; this only changes how it is shown."
@@ -17868,7 +17872,7 @@ function displayConfigForm(config) {
         'Display': ['epd_type', 'screen_reversed', 'spi_clock_mhz', 'gc9a01_mascot_color', 'ssd1306_i2c_address', 'lcd1602_i2c_address', 'max7219_spi_port', 'max7219_spi_device', 'max7219_block_orientation', 'display_brightness']
     };
     
-    const knownBooleans = ['manual_mode', 'debug_mode', 'scan_vuln_running', 'scan_vuln_no_ports', 'enable_attacks', 'blacklistcheck', 'wardriving_enabled', 'wardriving_display', 'wardriving_auto_export'];
+    const knownBooleans = ['manual_mode', 'debug_mode', 'scan_vuln_running', 'scan_vuln_no_ports', 'enable_attacks', 'blacklistcheck', 'wardriving_enabled', 'wardriving_display', 'wardriving_auto_export', 'wardriving_wigle_include_zigbee'];
     const alwaysShowKeys = new Set(['network_max_failed_pings', 'gc9a01_mascot_color', 'ssd1306_i2c_address', 'lcd1602_i2c_address', 'spi_clock_mhz', 'max7219_spi_port', 'max7219_spi_device', 'max7219_block_orientation', 'display_brightness', 'wardriving_scan_interval', 'wardriving_gps_port', 'wardriving_gps_baudrate']);
     const fallbackValues = {
         network_max_failed_pings: 15,
@@ -18127,7 +18131,7 @@ function displayConfigForm(config) {
     // Render wardriving config settings into the dedicated Wardriving section slot
     const wdSlot = document.getElementById('wardriving-config-slot');
     if (wdSlot) {
-        const wdKeys = ['wardriving_scan_interval', 'wardriving_gps_port', 'wardriving_gps_baudrate', 'wardriving_auto_export'];
+        const wdKeys = ['wardriving_scan_interval', 'wardriving_gps_port', 'wardriving_gps_baudrate', 'wardriving_auto_export', 'wardriving_wigle_include_zigbee'];
         let wdHtml = '<form id="wardriving-config-form" class="bg-slate-800 bg-opacity-50 rounded-lg p-4 mt-4"><h4 class="text-md font-bold mb-4 text-gray-300">Settings</h4><div class="grid grid-cols-1 md:grid-cols-2 gap-4">';
         wdKeys.forEach(key => {
             const hasKey = Object.prototype.hasOwnProperty.call(config, key);

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -8948,7 +8948,8 @@ def wardriving_export(session_id):
             )
         else:
             device_name = engine.device_name or shared_data.config.get('wardriving_device_name', 'Ragnar')
-            content = session.export_wigle_csv(device_name=device_name)
+            include_zigbee = bool(shared_data.config.get('wardriving_wigle_include_zigbee', False))
+            content = session.export_wigle_csv(device_name=device_name, include_zigbee=include_zigbee)
             return app.response_class(
                 content, mimetype='text/csv',
                 headers={'Content-Disposition': f'attachment; filename=ragnar_wardriving_{session_id}.csv'}


### PR DESCRIPTION
This pull request adds an opt-in feature to include Zigbee/802.15.4 devices in WiGLE CSV exports. By default, Zigbee devices are excluded from WiGLE exports since WiGLE does not support a standard 802.15.4 record type. The new option is exposed in the configuration UI, is off by default, and is intended for users' own tooling, not for submission to WiGLE. The implementation updates the backend export logic, configuration defaults, and the web UI to support this feature.

**Zigbee Export Feature:**

* Added a new configuration option `wardriving_wigle_include_zigbee` (default: `False`) to control whether Zigbee devices are included in WiGLE CSV exports. This is surfaced in the UI with appropriate labeling and description. [[1]](diffhunk://#diff-2fe16068e367d29a7746514225b626b23603f7be39d2c1c98ea976ead3c9c3a9R862) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R508-R511) [[3]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L17871-R17875) [[4]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L18130-R18134)
* Updated the WiGLE CSV export logic in `wardriving.py` to accept an `include_zigbee` parameter and, if enabled, append Zigbee devices with a `ZIGBEE` type row. This applies to both manual and auto exports. [[1]](diffhunk://#diff-22fe1f64957729edb89cd0dc3b053ec11ce1ba58ed700fabf3e6e64fb9718052L1121-R1131) [[2]](diffhunk://#diff-22fe1f64957729edb89cd0dc3b053ec11ce1ba58ed700fabf3e6e64fb9718052R1207-R1232)
* Updated the documentation to explain the opt-in nature of Zigbee export, the rationale, and usage instructions.
* Modified the web app export endpoint to pass the user's configuration for including Zigbee devices into the export function.