### PR TITLE
Wardriving: classify Thread vs Zigbee (proto) and rename the card

### DIFF
--- a/docs/wardriving.md
+++ b/docs/wardriving.md
@@ -204,12 +204,17 @@ over-report. The companion status bar shows `2.4G` / `5G` alongside the total
 {"type":"BLE","mac":"AA:BB:CC:DD:EE:FF","name":"DeviceName","rssi":-60}
 ```
 
-#### Zigbee / 802.15.4 Devices (JSON, one line per sighting)
+#### Thread / Zigbee (802.15.4) Devices (JSON, one line per sighting)
 
-Emitted by HuginnESP builds with an IEEE 802.15.4 radio (ESP32-C5). Ragnar
-stores these in a dedicated `zigbee_devices` table and counts them separately
-from BLE — the live status bar and displays show a `Zigbee` total alongside
-`BT` and `Cell`, and `/api/wardriving/zigbee` returns the full list.
+Emitted by HuginnESP builds with an IEEE 802.15.4 radio (ESP32-C5). Zigbee and
+Thread share the same 802.15.4 radio and channels (11–26), so the companion
+sniffs both and tags each sighting with a `proto` field — `zigbee`, `thread`, or
+`802.15.4` (unknown). **Matter-over-Thread** is ordinary Thread traffic at the
+radio layer, so it reports as `thread`. Ragnar stores these in a dedicated
+`zigbee_devices` table (with the `proto` column) and counts them separately from
+BLE — the live status bar and displays show a **Thread / Zigbee** total
+alongside `BT` and `Cell`, the "Thread / Zigbee" table view lists them with a
+Proto column, and `/api/wardriving/zigbee` returns the full list.
 
 > **WiGLE export is opt-in.** WiGLE has no standard 802.15.4 record type, so
 > Zigbee devices are **excluded from WiGLE CSV export by default**. Enable
@@ -218,7 +223,7 @@ from BLE — the live status bar and displays show a `Zigbee` total alongside
 > not for submitting to WiGLE. Applies to both manual export and Auto Export on Stop.
 
 ```json
-{"type":"ZIGBEE","panid":"0x1A2B","addr":"AABBCCDDEEFF0011","short":"0x1234","channel":15,"rssi":-70,"lqi":180,"ftype":"beacon"}
+{"type":"ZIGBEE","panid":"0x1A2B","addr":"AABBCCDDEEFF0011","short":"0x1234","channel":15,"rssi":-70,"lqi":180,"ftype":"beacon","proto":"thread"}
 ```
 
 Each device is identified by its 64-bit extended address (`addr` / EUI-64) when

--- a/wardriving.py
+++ b/wardriving.py
@@ -386,6 +386,7 @@ class WardrivingSession:
                     panid TEXT DEFAULT '',
                     short_addr TEXT DEFAULT '',
                     device_type TEXT DEFAULT '',
+                    proto TEXT DEFAULT 'zigbee',
                     rssi INTEGER DEFAULT -100,
                     best_rssi INTEGER DEFAULT -100,
                     lqi INTEGER DEFAULT 0,
@@ -414,6 +415,14 @@ class WardrivingSession:
                         conn.execute(f"ALTER TABLE {_tbl} ADD COLUMN gps_backfilled INTEGER DEFAULT 0")
                 except Exception:
                     pass
+            # Add the 802.15.4 protocol column (zigbee/thread/802.15.4) to
+            # zigbee_devices tables created before Thread classification existed.
+            try:
+                zcols = {r[1] for r in conn.execute("PRAGMA table_info(zigbee_devices)").fetchall()}
+                if zcols and 'proto' not in zcols:
+                    conn.execute("ALTER TABLE zigbee_devices ADD COLUMN proto TEXT DEFAULT 'zigbee'")
+            except Exception:
+                pass
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS gps_track (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -728,15 +737,21 @@ class WardrivingSession:
                 logger.debug(f"Cell upsert error: {e}")
 
     def upsert_zigbee(self, addr, panid, short_addr, device_type,
-                      rssi, lqi, channel, lat, lon, alt):
-        """Insert or update a discovered Zigbee / 802.15.4 device.
+                      rssi, lqi, channel, lat, lon, alt, proto='zigbee'):
+        """Insert or update a discovered 802.15.4 device (Zigbee / Thread).
 
         `addr` is the stable identity (EUI-64 or "<panid>:<short>"). Best
         position is tracked at the strongest RSSI sighting, mirroring how
         Bluetooth devices are recorded so map exports stay consistent.
+
+        `proto` is the classified network layer ('zigbee' / 'thread' /
+        '802.15.4'). It's only upgraded to a *specific* protocol on re-sightings
+        so a later opaque (encrypted) frame can't downgrade a device that a
+        beacon already identified.
         """
         if not addr:
             return
+        proto = (proto or 'zigbee').lower()
         now = datetime.now(timezone.utc).isoformat()
         with self._lock:
             try:
@@ -756,6 +771,7 @@ class WardrivingSession:
                                 panid = COALESCE(NULLIF(?, ''), panid),
                                 short_addr = COALESCE(NULLIF(?, ''), short_addr),
                                 device_type = COALESCE(NULLIF(?, ''), device_type),
+                                proto = CASE WHEN ? IN ('zigbee','thread') THEN ? ELSE proto END,
                                 rssi = ?, lqi = ?,
                                 channel = CASE WHEN ? > 0 THEN ? ELSE channel END,
                                 best_rssi = ?,
@@ -766,18 +782,18 @@ class WardrivingSession:
                                 altitude = COALESCE(?, altitude),
                                 last_seen = ?, scan_count = ?
                             WHERE addr = ?
-                        """, (panid, short_addr, device_type,
+                        """, (panid, short_addr, device_type, proto, proto,
                               rssi, lqi, channel, channel,
                               new_best, best_lat_val, best_lon_val,
                               lat, lon, alt, now, count, addr))
                     else:
                         conn.execute("""
                             INSERT INTO zigbee_devices
-                                (addr, panid, short_addr, device_type, rssi, best_rssi,
+                                (addr, panid, short_addr, device_type, proto, rssi, best_rssi,
                                  lqi, channel, latitude, longitude, altitude,
                                  best_lat, best_lon, first_seen, last_seen, scan_count)
-                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
-                        """, (addr, panid, short_addr, device_type, rssi, rssi,
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+                        """, (addr, panid, short_addr, device_type, proto, rssi, rssi,
                               lqi, channel, lat, lon, alt, lat, lon, now, now))
             except Exception as e:
                 logger.debug(f"Zigbee upsert error: {e}")
@@ -4310,6 +4326,10 @@ class WardrivingEngine:
                         z_channel = 0
                     z_dtype = str(data.get('ftype') or data.get('dev')
                                   or data.get('name') or '')
+                    # Network layer riding on 802.15.4, classified by the
+                    # companion: 'zigbee' / 'thread' / '802.15.4'. Older firmware
+                    # omits it, so default to 'zigbee' for back-compat.
+                    z_proto = str(data.get('proto') or 'zigbee').lower()
                     z_lat, z_lon, z_alt, z_from = self._resolve_coords(
                         data.get('lat', data.get('latitude')),
                         data.get('lon', data.get('longitude')),
@@ -4318,7 +4338,8 @@ class WardrivingEngine:
                     )
                     self.session.upsert_zigbee(
                         addr, panid, short, z_dtype,
-                        z_rssi, z_lqi, z_channel, z_lat, z_lon, z_alt
+                        z_rssi, z_lqi, z_channel, z_lat, z_lon, z_alt,
+                        proto=z_proto
                     )
                     companion.esp_zigbee_count += 1
                     if z_from and self._gps is not None:

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -5343,9 +5343,9 @@
                         <div id="wd-cell-count" class="text-2xl font-bold text-fuchsia-400">0</div>
                         <div class="text-xs text-gray-500 mt-1">towers</div>
                     </div>
-                    <!-- Zigbee / 802.15.4 -->
+                    <!-- Thread / Zigbee (802.15.4) -->
                     <div class="bg-slate-800/50 rounded-lg p-3">
-                        <div class="text-xs text-gray-400 mb-1 uppercase tracking-wider">Zigbee</div>
+                        <div class="text-xs text-gray-400 mb-1 uppercase tracking-wider">Thread / Zigbee</div>
                         <div id="wd-zigbee-count" class="text-2xl font-bold text-teal-400">0</div>
                         <div class="text-xs text-gray-500 mt-1">802.15.4</div>
                     </div>
@@ -5376,7 +5376,7 @@
                         <option value="bluetooth">🔵 Bluetooth Devices</option>
                         <option value="cell">📶 Cell Towers</option>
                         <option value="cameras">📷 Cameras</option>
-                        <option value="zigbee">🐝 Zigbee Devices</option>
+                        <option value="zigbee">🧵 Thread / Zigbee</option>
                     </select>
                     <span id="wd-interfaces-info" class="text-xs text-gray-500 w-full sm:w-auto sm:ml-auto"></span>
                 </div>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -22985,7 +22985,7 @@ function renderWardrivingDiagnostics(status) {
             ? `${stats.band_2_4ghz || 0} / ${stats.band_5ghz || 0} / ${stats.band_6ghz || 0}` : null],
         ['Bluetooth', stats.bluetooth_devices],
         ['Cell towers', stats.cell_towers],
-        ['Zigbee devices', stats.zigbee_devices],
+        ['Thread / Zigbee', stats.zigbee_devices],
         ['Cameras', stats.cameras],
         ['GPS trackpoints', stats.gps_trackpoints],
         ['Strongest', strongest ? `${strongest.ssid || strongest.bssid || '?'}` +
@@ -24072,7 +24072,7 @@ const _WD_HEADERS = {
     bluetooth: '<tr><th class="px-3 py-2">Name</th><th class="px-3 py-2">MAC</th><th class="px-3 py-2">Type</th><th class="px-3 py-2">RSSI</th><th class="px-3 py-2 text-center">GPS</th><th class="px-3 py-2">First Seen</th><th class="px-3 py-2">Seen</th></tr>',
     cell: '<tr><th class="px-3 py-2">Provider</th><th class="px-3 py-2">Tech</th><th class="px-3 py-2">Cell ID</th><th class="px-3 py-2">MCC/MNC</th><th class="px-3 py-2">Signal</th><th class="px-3 py-2">Band</th><th class="px-3 py-2 text-center">GPS</th><th class="px-3 py-2">Seen</th></tr>',
     cameras: '<tr><th class="px-3 py-2">SSID</th><th class="px-3 py-2">BSSID</th><th class="px-3 py-2">Security</th><th class="px-3 py-2">Ch</th><th class="px-3 py-2">Band</th><th class="px-3 py-2">Signal</th><th class="px-3 py-2 text-center">GPS</th><th class="px-3 py-2">Seen</th></tr>',
-    zigbee: '<tr><th class="px-3 py-2">Address</th><th class="px-3 py-2">PAN ID</th><th class="px-3 py-2">Short</th><th class="px-3 py-2">Type</th><th class="px-3 py-2">Ch</th><th class="px-3 py-2">Signal</th><th class="px-3 py-2 text-center">LQI</th><th class="px-3 py-2 text-center">GPS</th><th class="px-3 py-2">Seen</th></tr>'
+    zigbee: '<tr><th class="px-3 py-2">Address</th><th class="px-3 py-2">Proto</th><th class="px-3 py-2">PAN ID</th><th class="px-3 py-2">Short</th><th class="px-3 py-2">Type</th><th class="px-3 py-2">Ch</th><th class="px-3 py-2">Signal</th><th class="px-3 py-2 text-center">LQI</th><th class="px-3 py-2 text-center">GPS</th><th class="px-3 py-2">Seen</th></tr>'
 };
 
 function _setWdTableHeaders(type) {
@@ -24184,7 +24184,7 @@ async function _loadWardrivingZigbee() {
         const sig = _wdSig('zigbee', devices, d => (d.scan_count || 0) + (d.rssi || 0));
         if (!_wdShouldRender('zigbee', sig)) return;
         if (devices.length === 0) {
-            _wdSetTbodyHTML(tbody, '<tr><td colspan="9" class="text-center text-gray-500 py-8">No Zigbee / 802.15.4 devices found yet. Needs a companion with an 802.15.4 radio (ESP32-C5/C6).</td></tr>');
+            _wdSetTbodyHTML(tbody, '<tr><td colspan="10" class="text-center text-gray-500 py-8">No Thread / Zigbee (802.15.4) devices found yet. Needs a companion with an 802.15.4 radio (ESP32-C5/C6).</td></tr>');
             return;
         }
         const html = devices.map(d => {
@@ -24196,8 +24196,12 @@ async function _loadWardrivingZigbee() {
                 : '<span class="text-gray-600">—</span>';
             const rssi = (d.best_rssi != null ? d.best_rssi : d.rssi);
             const sigColor = rssi > -50 ? 'text-emerald-400' : rssi > -70 ? 'text-yellow-400' : 'text-red-400';
+            const proto = (d.proto || 'zigbee').toLowerCase();
+            const protoLabel = proto === 'thread' ? 'Thread' : proto === 'zigbee' ? 'Zigbee' : '802.15.4';
+            const protoColor = proto === 'thread' ? 'text-purple-400' : proto === 'zigbee' ? 'text-teal-400' : 'text-gray-400';
             return `<tr class="hover:bg-slate-800/50">
                 <td class="px-3 py-1.5 font-mono text-xs text-teal-400" data-label="Address">${escapeHtml(d.addr || '-')}</td>
+                <td class="px-3 py-1.5 text-xs font-semibold ${protoColor}" data-label="Proto">${protoLabel}</td>
                 <td class="px-3 py-1.5 font-mono text-xs text-gray-400" data-label="PAN ID">${escapeHtml(d.panid || '-')}</td>
                 <td class="px-3 py-1.5 font-mono text-xs text-gray-400" data-label="Short">${escapeHtml(d.short_addr || '-')}</td>
                 <td class="px-3 py-1.5 text-xs text-orange-400" data-label="Type">${escapeHtml(d.device_type || '-')}</td>

--- a/web/wardrive_mobile.html
+++ b/web/wardrive_mobile.html
@@ -86,7 +86,7 @@
     <div class="stat"><div class="v" id="s-24">–</div><div class="l">2.4 GHz</div></div>
     <div class="stat"><div class="v" id="s-5">–</div><div class="l">5 GHz</div></div>
     <div class="stat"><div class="v" id="s-6">–</div><div class="l">6 GHz</div></div>
-    <div class="stat"><div class="v" id="s-zig">–</div><div class="l">Zigbee</div></div>
+    <div class="stat"><div class="v" id="s-zig">–</div><div class="l">Thread/Zig</div></div>
   </div>
 
   <div class="mapwrap">
@@ -456,7 +456,7 @@
         : null],
       ['Bluetooth', stats.bluetooth_devices],
       ['Cell towers', stats.cell_towers],
-      ['Zigbee devices', stats.zigbee_devices],
+      ['Thread / Zigbee', stats.zigbee_devices],
       ['Cameras', stats.cameras],
       ['GPS trackpoints', stats.gps_trackpoints],
       ['Strongest', strongest ? ((strongest.ssid || strongest.bssid || '?') +


### PR DESCRIPTION
HuginnESP now tags each 802.15.4 sighting with a proto field (zigbee / thread / 802.15.4); Thread rides the same radio/channels so it was always being captured, just labelled Zigbee. Matter-over-Thread reports as thread.

Backend:
- zigbee_devices gains a proto column (+ migration for existing DBs).
- upsert_zigbee stores proto, only upgrading to a specific protocol on re-sightings so an opaque encrypted frame can't downgrade a beacon- identified device.
- Parser reads data['proto'] (defaults to 'zigbee' for older firmware).

UI (reuses the existing Zigbee card, renamed 'Thread / Zigbee'):
- Dashboard tile + table-view option renamed; table gains a Proto column (Thread=purple, Zigbee=teal, 802.15.4=grey).
- Diagnostics row + mobile tile renamed.
- docs/wardriving.md updated.