### PR TITLE
Wardrive companion role switch

### DIFF
--- a/docs/wardriving.md
+++ b/docs/wardriving.md
@@ -216,6 +216,17 @@ BLE — the live status bar and displays show a **Thread / Zigbee** total
 alongside `BT` and `Cell`, the "Thread / Zigbee" table view lists them with a
 Proto column, and `/api/wardriving/zigbee` returns the full list.
 
+> **One C5 can't do WiFi *and* Zigbee at once.** WiFi, BLE and 802.15.4 share a
+> single 2.4 GHz radio on the ESP32-C5 — once 802.15.4 starts receiving, the WiFi
+> scan can't reclaim the radio, so the wardrive cycle is WiFi + BLE only. To
+> capture Zigbee/Thread **simultaneously**, add a **second Huginn** and give it
+> the Zigbee role: on the wardrive dashboard, each Huginn companion bar has a
+> **Role** selector — set the dedicated node to **"Zigbee / Thread only"** and
+> Ragnar sends it the `zigbee` command (parks WiFi/BLE, continuous 802.15.4
+> sniff) while the other keeps wardriving WiFi. The role is stored per serial
+> port (`wardriving_companion_roles`), applied live, and exposed at
+> `GET/POST /api/wardriving/companion_role`.
+
 > **WiGLE export is opt-in.** WiGLE has no standard 802.15.4 record type, so
 > Zigbee devices are **excluded from WiGLE CSV export by default**. Enable
 > **Config → Wardriving → Include Zigbee in WiGLE CSV** (`wardriving_wigle_include_zigbee`)

--- a/shared.py
+++ b/shared.py
@@ -860,6 +860,7 @@ class SharedData:
             "wardriving_interfaces": [],
             "wardriving_auto_export": True,
             "wardriving_wigle_include_zigbee": False,
+            "wardriving_companion_roles": {},
             "wardriving_device_name": "",
             "wardriving_speed_unit": "kmh",
             "wardriving_on_boot": False,

--- a/wardriving.py
+++ b/wardriving.py
@@ -2591,8 +2591,13 @@ class WardrivingEngine:
             'esp_zigbee_count': self._esp_zigbee_count,
             'esp_alerts':    self._esp_alerts[-5:],
             'band_mode': self.band_mode,
-            # Multi-companion list: full per-device status for the UI
-            'companions': [c.as_dict() for c in self._companions.values()],
+            # Multi-companion list: full per-device status for the UI. Each gets
+            # its configured role ('wardrive' | 'zigbee') so the UI can show and
+            # toggle which Huginn is the dedicated Zigbee/Thread node.
+            'companions': [
+                {**c.as_dict(), 'role': self._companion_role(c)}
+                for c in self._companions.values()
+            ],
         }
         # Interface details (cached 30s — sysfs/udev calls are slow)
         now_if = time.time()
@@ -4008,19 +4013,41 @@ class WardrivingEngine:
         companion.connected = False
         logger.info(f"Serial listener stopped for {companion.port}")
 
+    def _companion_role(self, companion: '_CompanionState') -> str:
+        """Role for a Huginn companion, keyed by serial port.
+
+        'wardrive' (default) = WiFi + BLE wardriving.
+        'zigbee'             = 802.15.4 (Zigbee/Thread) only. On the C5 the one
+                               2.4 GHz radio can't do WiFi and 802.15.4 at once,
+                               so a dedicated second Huginn is put in this role to
+                               sniff Zigbee while the first does WiFi.
+        """
+        roles = self.shared_data.config.get('wardriving_companion_roles', {}) or {}
+        return 'zigbee' if roles.get(companion.port) == 'zigbee' else 'wardrive'
+
+    @staticmethod
+    def _role_command(role: str):
+        # (serial command, esp_mode label, is_wardrive)
+        if role == 'zigbee':
+            return (b"zigbee\r\n", 'zigbee', False)
+        return (b"wardrive\r\n", 'wardrive', True)
+
     def _run_huginn_wardrive_loop(self, ser, companion: '_CompanionState'):
-        companion.current_esp_mode = 'wardrive'
+        active_role = self._companion_role(companion)
+        cmd, mode, in_wd = self._role_command(active_role)
+        companion.current_esp_mode = mode
         try:
             self._drain_huginn_queue(ser, companion)
             ser.reset_input_buffer()
-            ser.write(b"wardrive\r\n")
-            companion.in_wardrive = True
-            logger.info(f"HuginnESP {companion.port}: entered fast wardrive mode")
+            ser.write(cmd)
+            companion.in_wardrive = in_wd
+            logger.info(f"HuginnESP {companion.port}: entered {mode} mode")
         except Exception as e:
-            logger.warning(f"Failed to start Huginn wardrive mode on {companion.port}: {e}")
+            logger.warning(f"Failed to start Huginn {mode} mode on {companion.port}: {e}")
             return
 
         last_config_drain = time.time()
+        last_role_check = time.time()
         while self._running and companion.port in self._companions:
             try:
                 raw = ser.readline()
@@ -4032,8 +4059,23 @@ class WardrivingEngine:
                 if now - last_config_drain > 5:
                     self._drain_huginn_queue(ser, companion)
                     last_config_drain = now
+                # Live role switch (from the Ragnar UI) without a replug.
+                if now - last_role_check > 3:
+                    last_role_check = now
+                    new_role = self._companion_role(companion)
+                    if new_role != active_role:
+                        active_role = new_role
+                        cmd, mode, in_wd = self._role_command(active_role)
+                        try:
+                            ser.reset_input_buffer()
+                            ser.write(cmd)
+                            companion.current_esp_mode = mode
+                            companion.in_wardrive = in_wd
+                            logger.info(f"HuginnESP {companion.port}: switched to {mode} mode")
+                        except Exception as e:
+                            logger.warning(f"Role switch failed on {companion.port}: {e}")
             except Exception as e:
-                logger.debug(f"Serial read error (wardrive) on {companion.port}: {e}")
+                logger.debug(f"Serial read error (huginn) on {companion.port}: {e}")
                 break
 
         if companion.serial_entry_buffer.get('bssid'):

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -23144,7 +23144,7 @@ function renderWardrivingDiagnostics(status) {
 const _ESP_MODE_LABELS = {
     wifi: 'WiFi', 'ble-flipper': '🐬 Flipper', 'ble-airtag': '🏷️ AirTag',
     'ble-skimmer': '💳 Skimmer', pineap: '🍍 PineAP', ble: 'BLE',
-    stations: 'Stations', wardrive: '🏎️ Wardrive (fast)'
+    stations: 'Stations', wardrive: '🏎️ Wardrive (fast)', zigbee: '🐝 Zigbee / Thread'
 };
 
 function _renderCompanionBars(status) {
@@ -23253,13 +23253,40 @@ function _companionBarHtml(c, single, status) {
         ? ''
         : '<span class="text-xs text-gray-400">Ragnar looking for Huginn or Piglet...</span>';
 
+    // Role selector (Huginn only). One C5 can't do WiFi + 802.15.4 at once, so a
+    // dedicated second Huginn can be flipped to Zigbee/Thread-only here.
+    let roleHtml = '';
+    if (c.connected && name === 'Huginn') {
+        const role = c.role === 'zigbee' ? 'zigbee' : 'wardrive';
+        roleHtml = `<span class="ml-auto flex items-center gap-1">
+            <span class="text-xs text-gray-500">Role:</span>
+            <select onchange="setCompanionRole('${escapeHtml(c.port)}', this.value)"
+                title="What this Huginn does. One ESP32-C5 shares a single 2.4 GHz radio, so it can wardrive WiFi+BLE OR sniff Zigbee/Thread — not both. Use a second Huginn for Zigbee."
+                class="text-xs bg-slate-900 border border-slate-600 rounded px-1 py-0.5 text-gray-200 focus:border-teal-500 focus:outline-none">
+                <option value="wardrive" ${role === 'wardrive' ? 'selected' : ''}>WiFi + BLE</option>
+                <option value="zigbee" ${role === 'zigbee' ? 'selected' : ''}>Zigbee / Thread only</option>
+            </select>
+        </span>`;
+    }
+
     return `<div class="bg-slate-800/40 border border-slate-700 rounded-lg px-4 py-2 flex items-center gap-3 flex-wrap">
             <span class="text-xs font-bold text-purple-400">${escapeHtml(name)}</span>
             ${statusText}
             <span class="w-2 h-2 rounded-full ${dotColor} animate-pulse"></span>
             ${chips.join('\n')}
             ${alertHtml}
+            ${roleHtml}
         </div>${_coordNodesHtml(c)}`;
+}
+
+// Flip a Huginn companion between WiFi+BLE wardriving and Zigbee/Thread-only.
+// Applied live server-side (the listener re-sends the mode command).
+async function setCompanionRole(port, role) {
+    try {
+        await postAPI('/api/wardriving/companion_role', { port, role });
+    } catch (e) {
+        console.error('[Wardriving] set companion role failed:', e);
+    }
 }
 
 // Per-node breakdown for a Piglet Coordinator / Core, rendered beneath its bar.

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -23175,6 +23175,8 @@ function _companionBarHtml(c, single, status) {
     const name     = c.name || 'Companion';
     const isPiglet = name === 'Piglet' || name === 'Piglet Coordinator';
     const isCoord  = name === 'Piglet Coordinator';
+    const isHuginn = name === 'Huginn';
+    const isZigbeeRole = isHuginn && c.role === 'zigbee';
     const dotColor = c.connected ? 'bg-green-500' : 'bg-gray-500';
 
     const chips = [];
@@ -23200,14 +23202,20 @@ function _companionBarHtml(c, single, status) {
                 <span class="text-xs text-gray-400">WiFi:</span>
                 <span class="text-xs font-bold text-emerald-400">${status.serial_seen_unique || 0}</span>`);
         }
+    } else if (c.connected && isZigbeeRole) {
+        // Dedicated Zigbee/Thread node — WiFi/BLE are parked, so show only the
+        // 802.15.4 tally (matches what this node actually captures).
+        chips.push(`${sep}
+            <span class="text-xs text-gray-400">Zigbee / Thread:</span>
+            <span class="text-xs font-bold text-teal-400">${c.esp_zigbee_count || 0}</span>`);
     } else if (c.connected) {
         chips.push(`${sep}
             <span class="text-xs text-gray-400">WiFi:</span>
             <span class="text-xs font-bold text-emerald-400">${c.networks || 0}</span>`);
-        // Per-band breakdown for dual-band companions. Only rendered once a
-        // 5 GHz network has actually been seen, so a 2.4-only board (plain
-        // ESP32-S3) keeps the compact single-total bar it had before.
-        if ((c.networks_5 || 0) > 0) {
+        // Per-band breakdown. Dual-band boards (Huginn on a C5) always show the
+        // 2.4/5 split so the two bands are legible; a 2.4-only board (ESP32-S3)
+        // only gets the split once a 5 GHz network has actually been seen.
+        if (isHuginn || (c.networks_5 || 0) > 0) {
             chips.push(`<span class="text-xs text-cyan-400">${c.networks_24 || 0}</span>
                 <span class="text-xs text-gray-500">2.4G</span>
                 <span class="text-xs text-purple-400">${c.networks_5 || 0}</span>
@@ -23215,16 +23223,15 @@ function _companionBarHtml(c, single, status) {
         }
     }
 
-    // BLE — hidden for Piglet / Coordinator (WiFi-only firmware).
-    if (c.connected && !isPiglet) {
+    // BLE — hidden for Piglet / Coordinator (WiFi-only) and for a Zigbee node.
+    if (c.connected && !isPiglet && !isZigbeeRole) {
         chips.push(`<span class="text-xs text-gray-400">BLE:</span>
             <span class="text-xs font-bold text-blue-400">${c.esp_ble_count || 0}</span>`);
     }
 
-    // Zigbee / 802.15.4 — only for companions with an 802.15.4 radio (ESP32-C5/
-    // C6). Shown once the board has reported any Zigbee device, so WiFi/BLE-only
-    // boards don't carry a permanent "Zig: 0" chip.
-    if (c.connected && c.esp_zigbee_count) {
+    // Zigbee chip for a normal companion that happens to report 802.15.4 (the
+    // dedicated Zigbee node already shows its tally above).
+    if (c.connected && !isZigbeeRole && c.esp_zigbee_count) {
         chips.push(`<span class="text-xs text-gray-400">Zig:</span>
             <span class="text-xs font-bold text-teal-400">${c.esp_zigbee_count}</span>`);
     }

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -9076,6 +9076,38 @@ def wardriving_huginn_config():
         logger.error(f"Wardriving huginn_config error: {e}")
         return jsonify({'error': str(e)}), 500
 
+@app.route('/api/wardriving/companion_role', methods=['GET', 'POST'])
+def wardriving_companion_role():
+    """Get or set a Huginn companion's role, keyed by serial port.
+
+    'wardrive' (default) = WiFi + BLE wardriving.
+    'zigbee'             = 802.15.4 (Zigbee/Thread) only — for a dedicated
+                           second Huginn, since one C5 can't do WiFi + 802.15.4
+                           at once (shared 2.4 GHz radio). The change is applied
+                           live (the listener re-sends the mode command).
+    """
+    try:
+        roles = dict(shared_data.config.get('wardriving_companion_roles', {}) or {})
+        if request.method == 'POST':
+            data = request.get_json(silent=True) or {}
+            port = str(data.get('port', '')).strip()
+            role = str(data.get('role', 'wardrive')).strip().lower()
+            if not port:
+                return jsonify({'error': 'port required'}), 400
+            if role not in ('wardrive', 'zigbee'):
+                return jsonify({'error': "role must be 'wardrive' or 'zigbee'"}), 400
+            if role == 'wardrive':
+                roles.pop(port, None)          # default — don't persist noise
+            else:
+                roles[port] = 'zigbee'
+            shared_data.config['wardriving_companion_roles'] = roles
+            shared_data.save_config()
+            return jsonify({'success': True, 'port': port, 'role': role, 'roles': roles})
+        return jsonify({'roles': roles})
+    except Exception as e:
+        logger.error(f"Wardriving companion_role error: {e}")
+        return jsonify({'error': str(e)}), 500
+
 @app.route('/api/wardriving/track')
 def wardriving_track():
     """Get GPS track for current session (for map display)."""


### PR DESCRIPTION
This pull request adds support for assigning and managing roles for Huginn companions in wardriving, allowing one ESP32-C5 device to focus on Zigbee/Thread (802.15.4) capture while another handles WiFi+BLE. This addresses hardware limitations by enabling live role switching from the UI, improves status reporting, and updates the UI to reflect the new functionality.

**Role management and backend support:**

* Added a new config option `wardriving_companion_roles` to track companion roles, and implemented the `/api/wardriving/companion_role` API endpoint to get/set roles per serial port. This enables live switching between "WiFi+BLE" and "Zigbee/Thread only" modes for Huginn devices. [[1]](diffhunk://#diff-2fe16068e367d29a7746514225b626b23603f7be39d2c1c98ea976ead3c9c3a9R863) [[2]](diffhunk://#diff-1ab10a8399539c75077187c32de965b18781789c066d9db14069f0415df09731R9079-R9110)
* Updated the backend logic so that each Huginn companion's role is checked and applied live, including support for switching roles without unplugging the device. The role is now included in the status output for the UI. [[1]](diffhunk://#diff-22fe1f64957729edb89cd0dc3b053ec11ce1ba58ed700fabf3e6e64fb9718052L2594-R2600) [[2]](diffhunk://#diff-22fe1f64957729edb89cd0dc3b053ec11ce1ba58ed700fabf3e6e64fb9718052R4016-R4050) [[3]](diffhunk://#diff-22fe1f64957729edb89cd0dc3b053ec11ce1ba58ed700fabf3e6e64fb9718052R4062-R4078)

**Frontend and UI enhancements:**

* Enhanced the companion status bar in the UI to display the role selector for Huginn devices, show the correct tally (WiFi/BLE or Zigbee/Thread), and reflect live role changes. Added the `setCompanionRole` function to interact with the new API. [[1]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L23147-R23147) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R23178-R23179) [[3]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R23205-R23234) [[4]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R23263-R23298)

**Documentation updates:**

* Updated `docs/wardriving.md` to explain the new role management, hardware limitations, and how to set up simultaneous WiFi and Zigbee/Thread capture using multiple Huginn devices.

These changes collectively allow for more flexible and accurate wardriving with multiple Huginn companions, improving both backend management and user experience.