### PR TITLE
Wardriving and On-Screen Network Diagnostic mode are mutually exclusive

### DIFF
--- a/Ragnar.py
+++ b/Ragnar.py
@@ -84,6 +84,19 @@ class Ragnar:
         wardriving_boot = self.shared_data.config.get('wardriving_on_boot', False)
         if wardriving_boot:
             logger.info("Wardriving-on-boot enabled. Starting wardriving early, orchestrator will be suppressed.")
+            # Wardriving and On-Screen Network Diagnostic mode both hijack the
+            # e-Paper display and the HAT keys, and the diagnostic layer wins the
+            # render race (see display.py) — leaving Ragnar stuck on the netdiag
+            # field-test screen even though wardriving is scanning underneath.
+            # They are mutually exclusive, so if diagnostic mode was left on,
+            # turn it off before wardriving takes over the panel.
+            if self.shared_data.config.get('network_diagnostic_mode', False):
+                logger.info("Disabling On-Screen Network Diagnostic mode: wardriving-on-boot takes the display.")
+                self.shared_data.config['network_diagnostic_mode'] = False
+                try:
+                    self.shared_data.save_config()
+                except Exception as e:
+                    logger.warning(f"Could not persist network_diagnostic_mode off at boot: {e}")
             self.shared_data.manual_mode = True
             threading.Thread(
                 target=self._start_wardriving_on_boot,

--- a/docs/DISPLAY_CONTROLS.md
+++ b/docs/DISPLAY_CONTROLS.md
@@ -210,6 +210,12 @@ link's own gateway. The choice resets to Auto when the mode is switched on.
 
 - **Mode precedence:** Network Diagnostic mode takes over the keys/joystick while
   it's on; turning it off restores the Default (or Wardriving) behaviour.
+- **Diagnostic mode ⇄ wardriving are mutually exclusive:** both own the panel and
+  the HAT keys, and the diagnostic layer wins the render race, so they are never
+  on together. Starting wardriving (including `wardriving_on_boot` at boot) turns
+  Network Diagnostic mode **off**; turning Network Diagnostic mode on stops a live
+  wardriving session. Enabling wardriving-on-boot is safe even if you left
+  diagnostic mode enabled — it is cleared automatically at boot.
 - **Rotation:** `KEY2` cycles the screen rotation on both HATs. On the square
   128×128 LCD the panel realises two visual orientations (upright / 180°), and
   the joystick tracks whichever is shown.

--- a/docs/wardriving.md
+++ b/docs/wardriving.md
@@ -523,6 +523,11 @@ Falls back to linear when either endpoint speed is NULL or both are zero. The ch
 | POST | `/api/wardriving/device_name` | Set device name |
 | GET/POST | `/api/wardriving/on_boot` | Auto-start on boot |
 
+> **Mutually exclusive with On-Screen Network Diagnostic mode.** Both take over
+> the e-Paper panel and HAT keys, so starting wardriving turns Network Diagnostic
+> mode off (this includes `on_boot` — it is cleared at boot if it was left on),
+> and enabling Network Diagnostic mode stops a live wardriving session.
+
 ---
 
 ## Status Object

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -5557,6 +5557,18 @@ def update_config():
         # Save configuration
         shared_data.save_config()
 
+        # On-Screen Network Diagnostic mode and wardriving both own the e-Paper
+        # panel + HAT keys and can't coexist (the diagnostic layer wins the
+        # display render race). Turning diagnostic mode ON stops any live
+        # wardriving session so the panel isn't left in a half-and-half state.
+        if data.get('network_diagnostic_mode') is True:
+            try:
+                if _wardriving_engine is not None and getattr(_wardriving_engine, '_running', False):
+                    logger.info("Stopping wardriving: On-Screen Network Diagnostic mode enabled (mutually exclusive).")
+                    _wardriving_engine.stop()
+            except Exception as e:
+                logger.warning(f"Could not stop wardriving when enabling diagnostic mode: {e}")
+
         # Auto-install pyserial when wardriving is enabled
         if data.get('wardriving_enabled') is True:
             try:
@@ -8778,6 +8790,29 @@ def _get_wardriving_engine():
         _wardriving_engine = WardrivingEngine(shared_data)
     return _wardriving_engine
 
+def _disable_netdiag_for_wardriving(reason):
+    """Turn On-Screen Network Diagnostic mode off (persisting + notifying the UI).
+
+    Wardriving and diagnostic mode both take over the e-Paper panel and the HAT
+    keys, and the diagnostic layer wins the display render race, so they can't be
+    on at the same time. Called whenever wardriving takes the screen. No-op if
+    diagnostic mode is already off. Returns True if it flipped the flag.
+    """
+    if not shared_data.config.get('network_diagnostic_mode', False):
+        return False
+    logger.info(f"Disabling On-Screen Network Diagnostic mode: {reason}.")
+    shared_data.config['network_diagnostic_mode'] = False
+    setattr(shared_data, 'network_diagnostic_mode', False)
+    try:
+        shared_data.save_config()
+    except Exception as e:
+        logger.warning(f"Could not persist network_diagnostic_mode off: {e}")
+    try:
+        socketio.emit('config_updated', shared_data.config)
+    except Exception:
+        pass
+    return True
+
 @app.route('/api/wardriving/status')
 def wardriving_status():
     """Get wardriving engine status."""
@@ -8818,6 +8853,11 @@ def wardriving_start():
     try:
         if not shared_data.config.get('wardriving_enabled', False):
             return jsonify({'error': 'Wardriving not enabled in config'}), 400
+        # Wardriving and On-Screen Network Diagnostic mode are mutually exclusive:
+        # both own the e-Paper panel + HAT keys and the diagnostic layer wins the
+        # render race (display.py), which would strand the screen on the netdiag
+        # field-test view. Starting wardriving turns diagnostic mode off.
+        _disable_netdiag_for_wardriving('wardriving session started')
         data = request.get_json(silent=True) or {}
         interfaces = data.get('interfaces')  # optional list
         gps_port = data.get('gps_port')      # optional


### PR DESCRIPTION
Both take over the e-Paper panel and HAT keys, and the diagnostic layer wins the display render race (display.py) — so with both on Ragnar gets stranded on the netdiag field-test screen while wardriving scans unseen.

- Boot: wardriving_on_boot now clears network_diagnostic_mode before it takes the display, so on_boot is safe to enable even if diagnostic mode was left on.
- Web: starting a wardriving session turns diagnostic mode off; enabling diagnostic mode stops a live wardriving session.
- Docs updated (DISPLAY_CONTROLS, wardriving).