### PR TITLE
Net-diag LCD: add BT and ZIGBEE scan cards to the 1.44" HAT

### DIFF
--- a/display.py
+++ b/display.py
@@ -30,6 +30,27 @@ from logger import Logger
 import subprocess  
 from shared import detect_wifi_interface
 
+def _short_scan_error(err):
+    """Squeeze a BT/Zigbee scanner error into the ~10 chars the net-diag card's
+    value column has. The scanners return sentence-length diagnostics (great in
+    the web UI, unreadable on a 128 px panel), so map the ones a field tester
+    actually hits to a short reason and clip anything unrecognised."""
+    e = str(err or '').lower()
+    if 'pyserial' in e:
+        return 'no pyserial'
+    # The radio check comes first: "this Huginn has no 802.15.4 radio" names a
+    # board that IS present, so it must not be reported as a missing one.
+    if '802.15.4' in e or 'not compiled' in e:
+        return 'no 15.4 rx'
+    if 'huginn' in e or 'companion' in e:
+        return 'no Huginn'
+    if 'busy' in e or 'in use' in e or 'permission' in e or 'cannot open' in e:
+        return 'port busy'
+    if 'controller' in e or 'adapter' in e or 'bluetoothd' in e or 'rfkill' in e:
+        return 'no adapter'
+    return str(err or 'failed')[:11]
+
+
 def _fmt_wd_speed(speed_kmh, unit, decimals=1):
     """Format a km/h speed for the wardriving display in the configured unit.
 
@@ -103,16 +124,16 @@ except ImportError:
     EPDButtonListener = None
     PAGE_MAIN, PAGE_NETWORK, PAGE_VULN, PAGE_DISCOVERED, PAGE_ADVANCED, PAGE_TRAFFIC = 0, 1, 2, 3, 4, 5
     NETDIAG_CARD_NAMES = ["LINK", "IP", "SWITCH", "DHCP", "WIFI", "SIGNAL",
-                          "SPECTRUM", "IFACE"]
+                          "SPECTRUM", "IFACE", "BT", "ZIGBEE"]
     NETDIAG_CARD_FUNCS = {}
     netdiag_card_funcs = (lambda page: [])
     netdiag_iface_choices = (lambda: [])
     netdiag_auto_iface = (lambda require_egress=False: None)
 
 # Network Diagnostic mode: number of auto-cycling sub-pages
-# (0=LINK, 1=IP, 2=SWITCH, 3=DHCP, 4=WIFI, 5=SIGNAL, 6=SPECTRUM, 7=IFACE). See
-# Display._render_netdiag_page.
-NETDIAG_PAGE_COUNT = 8
+# (0=LINK, 1=IP, 2=SWITCH, 3=DHCP, 4=WIFI, 5=SIGNAL, 6=SPECTRUM, 7=IFACE,
+# 8=BT, 9=ZIGBEE). See Display._render_netdiag_page.
+NETDIAG_PAGE_COUNT = 10
 NETDIAG_CYCLE_SECONDS = 5
 
 # Wardriving screens on the 1.44" ST7735S LCD HAT (128x128), paged with the
@@ -1281,9 +1302,17 @@ class Display:
         draw.text((int(4 * sx), h - int(16 * sy)), hint, font=font, fill=0)
         pad_x = int(8 * sx)
         n = len(NETDIAG_CARD_NAMES)
-        # Fit every card between the top and the footer divider.
-        top = int(4 * sy)
-        row_h = max(int(11 * sy), min(int(15 * sy), (foot_y - top) // max(1, n)))
+        # Fit every card between the top and the footer divider. The lower bound
+        # is the font's own height, not a fixed 11 px: with ten cards on the
+        # 128 px panel a taller floor would push the last row through the footer
+        # divider rather than tightening the rows.
+        top = int(3 * sy)
+        min_row = max(9, int(font.size) + 1) if hasattr(font, 'size') else 9
+        row_h = max(min_row, min(int(15 * sy), (foot_y - top) // max(1, n)))
+        # Only inset the text when the row is tall enough to spare the pixel —
+        # at the tightest packing it would push a descender into the next row's
+        # highlight bar.
+        text_dy = int(1 * sy) if row_h > min_row else 0
         y = top
         for i, nm in enumerate(NETDIAG_CARD_NAMES):
             sel = (i == highlight % n)
@@ -1291,9 +1320,9 @@ class Display:
             if sel:
                 draw.rectangle([int(3 * sx), y,
                                 w - int(3 * sx), y + row_h - int(1 * sy)], fill=0)
-                draw.text((pad_x, y + int(1 * sy)), label, font=font, fill=1)
+                draw.text((pad_x, y + text_dy), label, font=font, fill=1)
             else:
-                draw.text((pad_x, y + int(1 * sy)), label, font=font, fill=0)
+                draw.text((pad_x, y + text_dy), label, font=font, fill=0)
             y += row_h
 
     def _render_netdiag_page(self, image, draw, page, frozen=False, func_idx=-1):
@@ -1471,7 +1500,7 @@ class Display:
             self._draw_spectrum(draw, y, band, spectrum, st.get('bands') or {},
                                 st.get('iface'))
 
-        else:  # page 7: IFACE — which NIC the egress tests originate from.
+        elif page == 7:  # IFACE — which NIC the egress tests originate from.
             # Up/Down highlights Auto or an interface (footer hint), press pins
             # it. '*' marks the active selection; each row shows the NIC's IP
             # (usable), 'no IP' (link up but unaddressed) or 'down'.
@@ -1490,6 +1519,69 @@ class Display:
                 status = c['ipv4'] or ('no IP' if c['up'] else 'down')
                 rows.append((label, status))
             self._draw_stat_rows(draw, y, rows)
+
+        elif page == 8:  # BT — on-demand Bluetooth/BLE neighbours (press scans)
+            self._draw_neighbour_card(draw, y, 'bt')
+
+        else:  # page 9: ZIGBEE — on-demand 802.15.4 sniff (press scans)
+            self._draw_neighbour_card(draw, y, 'zigbee')
+
+    def _draw_neighbour_card(self, draw, y, which):
+        """The BT / ZIGBEE cards: the last on-demand 2.4 GHz neighbour scan.
+
+        Both are one-shot rather than background-polled — BT discovery and an
+        802.15.4 sniff each cost radio time, and Zigbee needs a HuginnESP that
+        wardriving may be holding — so the card shows the previous result (or a
+        prompt) and the joystick press runs a new scan. `which` is 'bt' or
+        'zigbee'; the payloads differ only in the per-device fields.
+        """
+        sy = getattr(self, 'render_sy', self.scale_factor_y)
+        bl = self.button_listener
+        res = getattr(bl, 'netdiag_bt' if which == 'bt' else 'netdiag_zb', None) if bl else None
+
+        if not res:
+            label = 'BT' if which == 'bt' else 'Zigbee'
+            self._draw_stat_rows(draw, y, [(label, 'no scan'),
+                                           ('Press', 'scans'),
+                                           ('Takes', '~8s')])
+            return
+        if res.get('error'):
+            self._draw_stat_rows(draw, y, [('Failed', _short_scan_error(res['error'])),
+                                           ('Press', 'retries')])
+            return
+
+        itf = res.get('interference') or {}
+        rows = [('Devices', res.get('device_count', 0))]
+        if which == 'bt':
+            rows.append(('LE/Clsc', f"{itf.get('le_count', 0)}/{itf.get('classic_count', 0)}"))
+        else:
+            rows.append(('Channels', itf.get('channel_count', 0)))
+        # Age matters on a one-shot card — a stale scan shouldn't read as live.
+        ts = res.get('timestamp')
+        if isinstance(ts, (int, float)) and ts > 0:
+            age = max(0, int(time.time() - ts))
+            rows.append(('Age', f"{age}s" if age < 120 else f"{age // 60}m"))
+        yy = self._draw_stat_rows(draw, y, rows)
+
+        # Strongest few neighbours as name/addr + signal bars — the same "who is
+        # loud near me" read the SIGNAL card gives for Wi-Fi.
+        devices = (res.get('devices') or [])[:3]
+        if devices:
+            aps = []
+            for d in devices:
+                if which == 'bt':
+                    name = d.get('name') or d.get('vendor') or (d.get('mac') or '')[-8:]
+                else:
+                    # Channel first (it's what decides Wi-Fi overlap) then the
+                    # device's own address — the PAN ID repeats across a mesh,
+                    # so it can't tell two rows apart in the narrow name column.
+                    addr = str(d.get('addr') or d.get('short_addr') or '')
+                    if addr.lower().startswith('0x'):
+                        addr = addr[2:]
+                    ch = d.get('channel')
+                    name = f"c{ch} {addr}" if ch is not None else addr
+                aps.append({'ssid': str(name), 'signal': d.get('rssi')})
+            self._draw_signal_bars(draw, yy + int(2 * sy), aps)
 
     def _draw_spectrum(self, draw, y, band, spectrum, supported, iface=None):
         """Channel-occupancy spectrum for one band on the LCD HAT: a bar per

--- a/docs/DISPLAY_CONTROLS.md
+++ b/docs/DISPLAY_CONTROLS.md
@@ -167,7 +167,7 @@ counter):
 ### Network Diagnostic mode
 
 Navigated as **cards**: `LINK · IP · SWITCH · DHCP · WIFI · SIGNAL · SPECTRUM ·
-IFACE`.
+IFACE · BT · ZIGBEE`.
 
 | Input | Action |
 |-------|--------|
@@ -194,6 +194,24 @@ adapter present** (so a tri-band dongle like the **Alfa AWUS036AXM** is used for
 name in the header — a band reads *"not supported"* when the chosen radio can't
 reach it. See the full
 [field‑test pad](nettools.md#field-test-pad-144-lcd-hat--joystick) table.
+
+The **BT** and **ZIGBEE** cards cover the other two occupants of 2.4 GHz, so the
+band's whole story is on the panel next to SPECTRUM. Both are **one-shot**: the
+centre press runs a scan (~8 s) and the card then shows that result until you
+scan again — unlike the Wi-Fi cards nothing polls in the background, because BT
+discovery and an 802.15.4 sniff each cost radio time and the auto-cycle would
+otherwise re-trigger them every few seconds. Each card shows the device count,
+an **Age** so a stale scan doesn't read as live, and the strongest few
+neighbours as signal bars:
+
+| Card | Needs | Shows |
+|------|-------|-------|
+| **BT** | a BlueZ controller (`rfkill unblock bluetooth`) | Devices, LE/Classic split, close-by count, adapter, and the Wi-Fi channel under the most BT pressure; then the loudest devices by name/vendor + RSSI |
+| **ZIGBEE** | a **HuginnESP** companion with an 802.15.4 radio (ESP32-C5/C6/H2) | Devices, distinct channels, close-by count, busiest channel; then the loudest devices as `c<channel> <addr>` + RSSI |
+
+When the hardware isn't there the card says why in short (`no adapter`,
+`no Huginn`, `no 15.4 rx`, `port busy`) and the press retries. These two cards
+are LCD-HAT only — the 2.7" e‑paper HAT still cycles just LINK/IP/SWITCH.
 
 The **IFACE** card picks which NIC the egress tests (**Speedtest**, **Ping GW**,
 **Ping WAN**) originate from: ↑/↓ highlights **Auto** or an interface, the

--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -168,6 +168,27 @@ The display auto-cycles six pages every **5 seconds**:
    a device-bound probe), so a plugged-in cable is what gets tested instead of
    whatever holds the default route. The selection resets to Auto each time the
    mode is switched on. *(LCD HAT only.)*
+9. **BT** — an on-demand **Bluetooth/BLE discovery sweep** (the same BlueZ
+   scanner behind the analyzer's [Bluetooth overlay](wifi-analyzer.md)), so the
+   card answers "what else is in 2.4 GHz?" next to SPECTRUM. Shows the device
+   count, the **LE/Classic** split, how many are close, the adapter, and the
+   **Wi-Fi channel carrying the most BT pressure**, then the loudest devices by
+   name/vendor with RSSI bars. Needs a controller that is present and unblocked
+   (`rfkill unblock bluetooth`), else the card reads *no adapter*.
+   *(LCD HAT only.)*
+10. **ZIGBEE** — an on-demand **802.15.4 sniff** via a **HuginnESP** companion
+    (the same capture behind the [Zigbee overlay](wifi-analyzer.md)). Shows the
+    device count, how many distinct channels are in use, how many are close, the
+    busiest channel, then the loudest devices as `c<channel> <addr>` with RSSI
+    bars. Needs a Huginn on USB with an 802.15.4 radio (ESP32-C5/C6/H2), else
+    the card reads *no Huginn* or *no 15.4 rx*. *(LCD HAT only.)*
+
+    **These two are one-shot, by design.** Unlike the Wi-Fi cards nothing polls
+    in the background: the **centre press runs the scan** (~8 s) and the card
+    then shows that result — with an **Age** so a stale scan can't be mistaken
+    for a live one — until you press again. BT discovery and an 802.15.4 sniff
+    each cost radio time (and the Huginn may be busy), so leaving them on the
+    5 s auto-cycle would re-trigger a scan every time the card came round.
 
    **Which radio it scans:** the SIGNAL and SPECTRUM cards auto-select the
    **widest-band adapter present** — so a tri-band dongle (e.g. the **Alfa
@@ -218,7 +239,7 @@ Network Diagnostic Mode on/off directly (no web UI needed). Select the HAT in
 **Display settings** as *"1.44" ST7735S LCD HAT + joystick"*.
 
 The mode is navigated as a stack of **cards** — `LINK · IP · SWITCH · DHCP ·
-WIFI · SIGNAL · SPECTRUM · IFACE`. **Left/Right move between cards; Up/Down
+WIFI · SIGNAL · SPECTRUM · IFACE · BT · ZIGBEE`. **Left/Right move between cards; Up/Down
 cycle the test functions *inside* a card; the centre press runs the highlighted
 one** (the footer shows `>` + its name). While the mode is on:
 
@@ -240,6 +261,8 @@ The functions selectable inside each card (Up/Down, then press):
 | **DHCP** / **WIFI** / **SIGNAL** | read-only (no functions) |
 | **SPECTRUM** | Up/Down selects the **band** (2.4 / 5 / 6 GHz) whose live channel-occupancy spectrum is drawn (scanned on the widest-band adapter — plug in the Alfa for 5/6 GHz); press does nothing (nothing to run) |
 | **IFACE** | Up/Down highlights **Auto** or a NIC; press **pins the egress tests** (Speed test / pings) to it. Auto = built-in eth → USB eth → wlan1 → wlan0 |
+| **BT** | **Scan BT** — press runs a ~8 s Bluetooth/BLE discovery sweep; the card then shows that result (with its age) until you scan again |
+| **ZIGBEE** | **Scan Zigbee** — press runs a ~8 s 802.15.4 sniff on the HuginnESP; the card then shows that result (with its age) until you scan again |
 
 In the **card-selection menu** any joystick direction moves the highlight and
 press opens that card. The joystick arrows above are **as you read them on the

--- a/epd_button.py
+++ b/epd_button.py
@@ -59,7 +59,7 @@ NETDIAG_PAGE_COUNT = 3
 # still fires them from its hardware keys. Kept module-level so both display.py
 # (for rendering) and the LCD listener (for dispatch) share one definition.
 NETDIAG_CARD_NAMES = ["LINK", "IP", "SWITCH", "DHCP", "WIFI", "SIGNAL",
-                      "SPECTRUM", "IFACE"]
+                      "SPECTRUM", "IFACE", "BT", "ZIGBEE"]
 NETDIAG_CARD_FUNCS = {
     0: [("Locate Port", "port"), ("L2 Health", "l2")],            # LINK
     1: [("Ping GW", "ping_gw"), ("Ping WAN", "ping_wan"),
@@ -77,6 +77,12 @@ NETDIAG_CARD_FUNCS = {
     # present — use netdiag_card_funcs(), not this dict. Pressing one pins the
     # egress tests (speedtest / pings) to that NIC; "Auto" restores the
     # priority pick (see netdiag_iface_choices).
+    # BT / ZIGBEE: the other two 2.4 GHz occupants, scanned on demand rather
+    # than continuously — BT discovery and an 802.15.4 sniff both cost radio
+    # time, and the Zigbee one needs a HuginnESP that wardriving may be holding.
+    # The card shows the last scan until you run another.
+    8: [("Scan BT", "bt_scan")],                                   # BT
+    9: [("Scan Zigbee", "zb_scan")],                               # ZIGBEE
 }
 
 # Which net-diag card is the interface selector (LCD HAT only).
@@ -224,6 +230,11 @@ class EPDButtonListener:
         self.netdiag_iface = None      # egress-test NIC pinned via the IFACE
                                        # card; None = Auto (priority pick)
         self.netdiag_seq = 0           # bumped on any key action to wake the display
+        # Last on-demand 2.4 GHz neighbour scans, kept so the BT/ZIGBEE cards
+        # still show their result after the popup is dismissed (None = never
+        # scanned this session). Written by the test worker, read by display.py.
+        self.netdiag_bt = None
+        self.netdiag_zb = None
         self._netdiag_busy = False     # a test thread is running
         self._held_keys = set()        # keys whose long-press already fired
 
@@ -459,7 +470,8 @@ class EPDButtonListener:
 
     _NETDIAG_TITLES = {'port': 'LOCATE PORT', 'l2': 'L2 HEALTH',
                        'ping_gw': 'PING GW', 'ping_wan': 'PING WAN',
-                       'speedtest': 'SPEEDTEST', 'dns': 'DNS DOCTOR'}
+                       'speedtest': 'SPEEDTEST', 'dns': 'DNS DOCTOR',
+                       'bt_scan': 'BLUETOOTH', 'zb_scan': 'ZIGBEE'}
 
     def _run_netdiag_test(self, kind):
         """Show a 'running' placeholder and run the test on a daemon thread so
@@ -622,5 +634,53 @@ class EPDButtonListener:
             return {'rows': [('Name', name[:20])],
                     'verdict': (big, verdict),
                     'note': reasons[0] if reasons else 'No poisoning signals detected.'}
+
+        if kind == 'bt_scan':
+            # The other 2.4 GHz occupant: a BlueZ discovery sweep, same scanner
+            # the Wi-Fi analyzer's Bluetooth overlay uses. Stashed on the
+            # listener so the BT card keeps showing it once the popup is gone.
+            import bt_scanner
+            r = bt_scanner.do_scan(duration=8)
+            self.netdiag_bt = r
+            if r.get('error'):
+                return {'rows': [('Bluetooth', 'no adapter')],
+                        'note': r.get('error')}
+            itf = r.get('interference') or {}
+            rows = [('Devices', r.get('device_count', 0)),
+                    ('LE/Classic', f"{itf.get('le_count', 0)}/{itf.get('classic_count', 0)}"),
+                    ('Close', itf.get('strong_count', 0)),
+                    ('Adapter', r.get('controller') or '—')]
+            # Which Wi-Fi channel this BT traffic leans on hardest — the reason
+            # a field tester cares about BT at all.
+            chans = itf.get('wifi_channels') or []
+            if chans:
+                worst = max(chans, key=lambda c: c.get('pressure') or 0)
+                rows.append(('Worst ch', f"{worst.get('wifi_channel')} {worst.get('level', '')}"))
+            return {'rows': rows}
+
+        if kind == 'zb_scan':
+            # 802.15.4 sniff via a HuginnESP companion. Gate on detect() so a
+            # missing/!802.15.4 board reports why instead of timing out.
+            import zigbee_scan
+            det = zigbee_scan.detect()
+            if not det.get('available'):
+                self.netdiag_zb = {'error': det.get('error') or 'no Huginn'}
+                return {'rows': [('Zigbee', 'no Huginn')],
+                        'note': det.get('error')}
+            r = zigbee_scan.scan(duration=8)
+            self.netdiag_zb = r
+            if r.get('error'):
+                return {'rows': [('Zigbee', 'scan failed')], 'note': r.get('error')}
+            itf = r.get('interference') or {}
+            rows = [('Devices', r.get('device_count', 0)),
+                    ('Channels', itf.get('channel_count', 0)),
+                    ('Close', itf.get('strong_count', 0))]
+            markers = itf.get('markers') or []
+            if markers:
+                busiest = max(markers, key=lambda m: m.get('intensity') or 0)
+                rows.append(('Busiest', f"ch{busiest.get('channel')}"))
+            if r.get('warning'):
+                rows.append(('Note', str(r['warning'])[:18]))
+            return {'rows': rows}
 
         return {'rows': [('Unknown test', kind)]}

--- a/lcdhat_input.py
+++ b/lcdhat_input.py
@@ -40,7 +40,7 @@
 #
 # Network Diagnostic layer (config network_diagnostic_mode) — a field-test pad,
 # navigated as a stack of "cards": LINK / IP / SWITCH / DHCP / WIFI (SSID+RSSI) /
-# SIGNAL (nearby strengths) / SPECTRUM / IFACE. Left/Right move between cards;
+# SIGNAL (nearby strengths) / SPECTRUM / IFACE / BT / ZIGBEE. Left/Right move between cards;
 # Up/Down cycle the test functions inside a card; the centre press runs the
 # highlighted one. The three keys are exits/toggles (everything acts on press —
 # no long-press here):
@@ -53,7 +53,9 @@
 #   KEY3          : pause / start auto-switch (auto-cycle the cards every 5 s)
 # Card functions (Up/Down + press): LINK/SWITCH → Locate Port · L2 Health;
 # IP → Ping GW · Ping WAN · DNS Doctor · Speedtest; DHCP/WIFI/SIGNAL are
-# read-only. The IFACE card pins which NIC the egress tests (speedtest, pings)
+# read-only. BT and ZIGBEE are the other two 2.4 GHz occupants — each is a
+# one-shot scan run with the centre press (~8 s), showing the last result until
+# you scan again. The IFACE card pins which NIC the egress tests (speedtest, pings)
 # originate from — Up/Down highlights Auto or an interface, press selects it;
 # Auto follows the priority order built-in eth → USB eth → wlan1 → wlan0.
 # In the card-selection menu any joystick direction moves the highlight and press
@@ -73,9 +75,9 @@ logger = logging.getLogger(__name__)
 AUTOSCROLL_INTERVAL = 5.0
 
 # Number of net-diag sub-pages (LINK / IP / SWITCH / DHCP / WIFI / SIGNAL /
-# SPECTRUM / IFACE). Mirrors display.NETDIAG_PAGE_COUNT; kept local so this
-# module needn't import display.py.
-NETDIAG_PAGE_COUNT = 8
+# SPECTRUM / IFACE / BT / ZIGBEE). Mirrors display.NETDIAG_PAGE_COUNT; kept
+# local so this module needn't import display.py.
+NETDIAG_PAGE_COUNT = 10
 
 # Number of wardriving screens the joystick pages through while wardriving runs
 # (STATS / MAP / GPS / SKY / SESSION / VIKING). Mirrors display.WARDRIVE_PAGE_COUNT.


### PR DESCRIPTION
The field-test pad could see Wi-Fi occupancy (SPECTRUM) but not the other two occupants of 2.4 GHz. Adds two cards, reusing the scanners behind the analyzer's Bluetooth and Zigbee overlays:

  BT      - BlueZ discovery: device count, LE/Classic split, close-by
            count, adapter, and the Wi-Fi channel under the most BT
            pressure, then the loudest devices as name + RSSI bars.
  ZIGBEE  - HuginnESP 802.15.4 sniff: device count, distinct channels,
            close-by count, busiest channel, then the loudest devices as
            'c<channel> <addr>' + RSSI bars.

Both are one-shot: the joystick centre press runs the scan (~8s, on the existing daemon-thread test path with its busy guard) and the card shows that result plus its age until scanned again. Background polling would mean the 5s auto-cycle re-triggering a radio-costly scan every pass. Missing hardware reports a short reason (no adapter / no Huginn / no 15.4 rx / port busy) rather than an overflowing sentence.

NETDIAG_PAGE_COUNT goes 8 -> 10 (LCD HAT only; the e-paper HAT stays at 3), and the card-selection menu now sizes its rows to the font so ten entries fit above the footer instead of overrunning it.