### PR TITLE
Add BLE provisioning peripheral for the mobile app

### DIFF
--- a/ble_provisioning.py
+++ b/ble_provisioning.py
@@ -1,0 +1,710 @@
+#!/usr/bin/env python3
+"""
+ble_provisioning.py — BlueZ GATT peripheral that lets the Ragnar mobile app
+*find* a box over Bluetooth and learn how to reach it over IP.
+
+This is the Pi side of the contract in the Ragnarmobile repo's
+``docs/PROTOCOL.md``. It is deliberately a **provisioning** service, not a data
+transport:
+
+* iOS cannot speak Bluetooth Classic / RFCOMM without MFi hardware, so BLE GATT
+  is the only cross-platform option, and GATT manages only ~5-20 KB/s.
+* Ragnar's real API (hundreds of KB per response, plus a Socket.IO stream)
+  belongs on Wi-Fi. The box already runs hostapd for the no-infrastructure
+  case.
+
+So this service answers exactly one question — *where do I find this box on
+IP?* — and then gets out of the way. Everything it exposes fits inside a single
+512-byte GATT attribute, so neither side implements chunking.
+
+Adapter contention
+------------------
+The onboard controller cannot reliably advertise as a peripheral while
+:mod:`bt_scanner` is running an active discovery on the *same* adapter. This
+service is therefore **off by default** (``ble_provisioning_enabled``) and, when
+several controllers are present, prefers one that is not the scanner's. Turning
+it on is a deliberate choice, mirroring how the ESP provisioning flows work.
+
+Everything here is receive-mostly: the box advertises and answers reads. The
+only writes are the AP-control command, which requires a bonded (encrypted)
+link.
+
+Standalone use
+--------------
+    python3 ble_provisioning.py run          # register + advertise until Ctrl-C
+    python3 ble_provisioning.py selftest     # register, verify, unregister
+    python3 ble_provisioning.py info         # print the payloads, no Bluetooth
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+import subprocess
+import threading
+import time
+from typing import Callable, Optional
+
+# ---------------------------------------------------------------------------
+# GATT contract — these UUIDs are shared verbatim with the mobile app
+# (src/ble.ts). Do not change one side without the other.
+# ---------------------------------------------------------------------------
+
+SERVICE_UUID = 'fc453ae1-7464-49fb-9018-52ded4f4086d'
+CHAR_DEVICE_INFO = '8c310633-e7a1-45e9-b5c5-f7a556d8b24b'
+CHAR_NET_STATUS = '7322574d-8a33-4289-af0b-50f11cdd0ed9'
+CHAR_AP_CREDS = '2fdc016e-9fd2-405c-b7dc-c36bb2d9070c'
+CHAR_AP_CONTROL = 'b8a58eb8-6d03-4cb9-a94e-b4ce7f2f9b2d'
+
+# Single ATT attribute maximum. Payloads are asserted against this so an
+# oversized value is caught here, not silently truncated on the wire.
+MAX_ATTR_BYTES = 512
+
+BLUEZ = 'org.bluez'
+DBUS_OM = 'org.freedesktop.DBus.ObjectManager'
+DBUS_PROPS = 'org.freedesktop.DBus.Properties'
+GATT_MANAGER = 'org.bluez.GattManager1'
+GATT_SERVICE = 'org.bluez.GattService1'
+GATT_CHRC = 'org.bluez.GattCharacteristic1'
+LE_ADV_MANAGER = 'org.bluez.LEAdvertisingManager1'
+LE_ADVERTISEMENT = 'org.bluez.LEAdvertisement1'
+ADAPTER_IFACE = 'org.bluez.Adapter1'
+
+
+# ===========================================================================
+# Data providers — what the box tells a phone. All defensive: a failure to
+# read one field must never take the service down.
+# ===========================================================================
+
+
+def _run(cmd: list[str], timeout: float = 4.0) -> str:
+    try:
+        out = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, check=False
+        )
+        return out.stdout
+    except Exception:
+        return ''
+
+
+def _adapter_address(hci: str) -> str:
+    """BD address of an adapter, uppercase, or '' if unknown."""
+    out = _run(['hciconfig', hci])
+    m = re.search(r'BD Address:\s*([0-9A-Fa-f:]{17})', out)
+    return m.group(1).upper() if m else ''
+
+
+def _box_id(hci: str) -> str:
+    """Short stable id from the adapter address, e.g. 'b4e2'."""
+    addr = _adapter_address(hci)
+    if addr:
+        return addr.replace(':', '')[-4:].lower()
+    # Fall back to the machine-id so the name is still stable across reboots.
+    try:
+        with open('/etc/machine-id') as f:
+            return f.read().strip()[-4:]
+    except Exception:
+        return '0000'
+
+
+def _model() -> str:
+    try:
+        with open('/proc/device-tree/model') as f:
+            return f.read().replace('\x00', '').strip()
+    except Exception:
+        return 'unknown'
+
+
+def _version(base_dir: str) -> str:
+    for name in ('VERSION', 'version.txt'):
+        p = os.path.join(base_dir, name)
+        try:
+            with open(p) as f:
+                return f.read().strip()[:32]
+        except Exception:
+            pass
+    # Fall back to a short git description if this is a checkout.
+    desc = _run(['git', '-C', base_dir, 'describe', '--tags', '--always']).strip()
+    return desc[:32] or 'dev'
+
+
+# Interfaces we never advertise: loopback, container bridges, and virtual
+# veth pairs. Everything else (eth/wlan/usb/tailscale) is a real way in.
+_SKIP_IFACE = re.compile(r'^(lo|docker\d|br-|veth|virbr)')
+
+
+def _interfaces() -> list[dict]:
+    """[{name, ip}] for usable IPv4 interfaces, best-effort."""
+    out = _run(['ip', '-o', '-4', 'addr', 'show'])
+    seen: list[dict] = []
+    for line in out.splitlines():
+        # "3: wlan0    inet 192.168.1.195/24 ..."
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        name = parts[1]
+        if _SKIP_IFACE.match(name):
+            continue
+        m = re.search(r'inet (\d+\.\d+\.\d+\.\d+)', line)
+        if not m:
+            continue
+        ip = m.group(1)
+        if ip.startswith('127.'):
+            continue
+        seen.append({'name': name, 'ip': ip})
+    return seen
+
+
+class DataProviders:
+    """Everything the peripheral needs to answer a read, gathered behind
+    small callables so the webapp can inject live state and tests can stub it.
+    """
+
+    def __init__(
+        self,
+        base_dir: str,
+        hci: str,
+        get_config: Callable[[], dict],
+        get_ap_state: Optional[Callable[[], dict]] = None,
+        set_ap: Optional[Callable[[bool], bool]] = None,
+    ):
+        self.base_dir = base_dir
+        self.hci = hci
+        self._get_config = get_config
+        self._get_ap_state = get_ap_state
+        self._set_ap = set_ap
+        self._box_id = _box_id(hci)
+
+    @property
+    def box_id(self) -> str:
+        return self._box_id
+
+    @property
+    def local_name(self) -> str:
+        return f'Ragnar-{self._box_id}'
+
+    def device_info(self) -> dict:
+        return {
+            'name': 'Ragnar',
+            'hostname': socket.gethostname(),
+            'model': _model(),
+            'version': _version(self.base_dir),
+            'box_id': self._box_id,
+        }
+
+    def _api_port(self) -> int:
+        cfg = self._get_config() or {}
+        try:
+            return int(os.environ.get('RAGNAR_API_PORT') or cfg.get('web_port') or 8000)
+        except (TypeError, ValueError):
+            return 8000
+
+    def _ap(self) -> dict:
+        if self._get_ap_state:
+            try:
+                return self._get_ap_state() or {}
+            except Exception:
+                pass
+        return {}
+
+    def net_status(self) -> dict:
+        ap = self._ap()
+        return {
+            'api_port': self._api_port(),
+            'ifaces': _interfaces(),
+            'ap_active': bool(ap.get('active', False)),
+            'ap_ssid': ap.get('ssid'),
+        }
+
+    def ap_creds(self) -> dict:
+        cfg = self._get_config() or {}
+        return {
+            'ssid': cfg.get('wifi_ap_ssid', 'Ragnar'),
+            'psk': cfg.get('wifi_ap_password', 'ragnarconnect'),
+        }
+
+    def apply_ap(self, on: bool) -> bool:
+        if not self._set_ap:
+            raise RuntimeError('AP control is not wired up on this box')
+        return bool(self._set_ap(on))
+
+
+def _encode(payload: dict, what: str) -> bytes:
+    """JSON-encode a payload and enforce the single-attribute size limit."""
+    raw = json.dumps(payload, separators=(',', ':')).encode('utf-8')
+    if len(raw) > MAX_ATTR_BYTES:
+        # Keep the box answering rather than overflowing: drop to a marker the
+        # app can surface. This only trips if an interface list is enormous.
+        raw = json.dumps({'error': f'{what} too large'}).encode('utf-8')
+    return raw
+
+
+# ===========================================================================
+# BlueZ D-Bus GATT scaffolding
+#
+# dbus-python + a GLib main loop. Structure follows the canonical BlueZ
+# example-gatt-server / example-advertisement, trimmed to this one service.
+# Imported lazily inside the server so `info`/unit tests run with no D-Bus.
+# ===========================================================================
+
+
+class BleProvisioningServer:
+    """Runs the GATT peripheral in a private GLib main loop thread."""
+
+    def __init__(self, providers: DataProviders, logger=None):
+        self.providers = providers
+        self.logger = logger
+        self._thread: Optional[threading.Thread] = None
+        self._mainloop = None
+        self._error: Optional[str] = None
+        self._running = False
+        self._ready = threading.Event()
+        # Populated on the loop thread once registered, for clean teardown.
+        self._bus = None
+        self._app_path = None
+        self._adv_path = None
+        self._gatt_manager = None
+        self._adv_manager = None
+
+    # -- logging -----------------------------------------------------------
+    def _log(self, msg: str, level: str = 'info') -> None:
+        if self.logger is not None:
+            getattr(self.logger, level, self.logger.info)(f'[ble-prov] {msg}')
+        else:
+            print(f'[ble-prov] {msg}')
+
+    # -- public API --------------------------------------------------------
+    def start(self, timeout: float = 8.0) -> bool:
+        """Start the peripheral. Returns True once advertising, else False."""
+        if self._running:
+            return True
+        self._error = None
+        self._ready.clear()
+        self._thread = threading.Thread(
+            target=self._run_loop, name='ble-provisioning', daemon=True
+        )
+        self._thread.start()
+        # Wait for the loop thread to either come up or fail registering.
+        self._ready.wait(timeout)
+        return self._running and self._error is None
+
+    def stop(self) -> None:
+        if self._mainloop is not None:
+            try:
+                self._mainloop.quit()
+            except Exception:
+                pass
+        self._running = False
+
+    def status(self) -> dict:
+        return {
+            'running': self._running,
+            'error': self._error,
+            'adapter': self.providers.hci,
+            'name': self.providers.local_name,
+            'service_uuid': SERVICE_UUID,
+        }
+
+    # -- loop thread -------------------------------------------------------
+    def _run_loop(self) -> None:
+        try:
+            import dbus
+            import dbus.mainloop.glib
+            from gi.repository import GLib
+
+            dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+            bus = dbus.SystemBus()
+            self._bus = bus
+
+            adapter_path = f'/org/bluez/{self.providers.hci}'
+            adapter_obj = bus.get_object(BLUEZ, adapter_path)
+
+            # Powered on, and discoverable so a phone can find it by name too.
+            props = dbus.Interface(adapter_obj, DBUS_PROPS)
+            props.Set(ADAPTER_IFACE, 'Powered', dbus.Boolean(True))
+
+            self._gatt_manager = dbus.Interface(adapter_obj, GATT_MANAGER)
+            self._adv_manager = dbus.Interface(adapter_obj, LE_ADV_MANAGER)
+
+            app = _Application(bus, self.providers)
+            self._app_path = app.path
+            adv = _Advertisement(bus, 0, self.providers)
+            self._adv_path = adv.get_path()
+
+            self._mainloop = GLib.MainLoop()
+
+            def on_registered():
+                self._running = True
+                self._ready.set()
+                self._log(f'advertising as {self.providers.local_name} on {self.providers.hci}')
+
+            def on_error(err, what):
+                self._error = f'{what}: {err}'
+                self._log(self._error, 'error')
+                self._ready.set()
+                self.stop()
+
+            self._gatt_manager.RegisterApplication(
+                app.path, {},
+                reply_handler=lambda: None,
+                error_handler=lambda e: on_error(e, 'RegisterApplication'),
+            )
+            self._adv_manager.RegisterAdvertisement(
+                adv.get_path(), {},
+                reply_handler=on_registered,
+                error_handler=lambda e: on_error(e, 'RegisterAdvertisement'),
+            )
+
+            self._mainloop.run()
+
+            # Clean unregister on the way out.
+            try:
+                self._adv_manager.UnregisterAdvertisement(self._adv_path)
+                self._gatt_manager.UnregisterApplication(self._app_path)
+            except Exception:
+                pass
+
+        except Exception as e:  # pragma: no cover - hardware/D-Bus dependent
+            self._error = str(e)
+            self._log(f'failed to start: {e}', 'error')
+            self._ready.set()
+        finally:
+            self._running = False
+
+
+def _build_dbus_classes():
+    """Define the D-Bus service/characteristic/advertisement classes.
+
+    Done inside a function so importing this module never requires dbus/gi;
+    only starting the server does.
+    """
+    import dbus
+    import dbus.service
+
+    class InvalidArgs(dbus.exceptions.DBusException):
+        _dbus_error_name = 'org.freedesktop.DBus.Error.InvalidArgs'
+
+    class NotSupported(dbus.exceptions.DBusException):
+        _dbus_error_name = 'org.bluez.Error.NotSupported'
+
+    class Failed(dbus.exceptions.DBusException):
+        _dbus_error_name = 'org.bluez.Error.Failed'
+
+    class Application(dbus.service.Object):
+        def __init__(self, bus, providers):
+            self.path = '/one/gode/ragnar/ble'
+            self.services = []
+            super().__init__(bus, self.path)
+            self.services.append(ProvisioningService(bus, 0, providers))
+
+        @dbus.service.method(DBUS_OM, out_signature='a{oa{sa{sv}}}')
+        def GetManagedObjects(self):
+            response = {}
+            for service in self.services:
+                response[service.get_path()] = service.get_properties()
+                for chrc in service.characteristics:
+                    response[chrc.get_path()] = chrc.get_properties()
+            return response
+
+    class ProvisioningService(dbus.service.Object):
+        PATH_BASE = '/one/gode/ragnar/ble/service'
+
+        def __init__(self, bus, index, providers):
+            self.path = f'{self.PATH_BASE}{index}'
+            self.bus = bus
+            self.characteristics = []
+            super().__init__(bus, self.path)
+
+            self.characteristics = [
+                Characteristic(bus, 0, self, CHAR_DEVICE_INFO, ['read'],
+                               lambda: _encode(providers.device_info(), 'device info')),
+                Characteristic(bus, 1, self, CHAR_NET_STATUS, ['read', 'notify'],
+                               lambda: _encode(providers.net_status(), 'network status')),
+                Characteristic(bus, 2, self, CHAR_AP_CREDS, ['encrypt-read'],
+                               lambda: _encode(providers.ap_creds(), 'AP credentials')),
+                ApControlCharacteristic(bus, 3, self, providers),
+            ]
+
+        def get_path(self):
+            return dbus.ObjectPath(self.path)
+
+        def get_properties(self):
+            return {
+                GATT_SERVICE: {
+                    'UUID': SERVICE_UUID,
+                    'Primary': dbus.Boolean(True),
+                    'Characteristics': dbus.Array(
+                        [c.get_path() for c in self.characteristics], signature='o'
+                    ),
+                }
+            }
+
+    class Characteristic(dbus.service.Object):
+        def __init__(self, bus, index, service, uuid, flags, reader):
+            self.path = f'{service.path}/char{index}'
+            self.bus = bus
+            self.uuid = uuid
+            self.flags = flags
+            self.service = service
+            self.reader = reader
+            self.notifying = False
+            super().__init__(bus, self.path)
+
+        def get_path(self):
+            return dbus.ObjectPath(self.path)
+
+        def get_properties(self):
+            return {
+                GATT_CHRC: {
+                    'Service': self.service.get_path(),
+                    'UUID': self.uuid,
+                    'Flags': dbus.Array(self.flags, signature='s'),
+                }
+            }
+
+        @dbus.service.method(DBUS_PROPS, in_signature='s', out_signature='a{sv}')
+        def GetAll(self, interface):
+            if interface != GATT_CHRC:
+                raise InvalidArgs()
+            return self.get_properties()[GATT_CHRC]
+
+        @dbus.service.method(GATT_CHRC, in_signature='a{sv}', out_signature='ay')
+        def ReadValue(self, options):
+            try:
+                data = self.reader()
+            except Exception as e:
+                raise Failed(str(e))
+            return dbus.Array([dbus.Byte(b) for b in data], signature='y')
+
+        @dbus.service.method(GATT_CHRC, in_signature='aya{sv}')
+        def WriteValue(self, value, options):
+            raise NotSupported()
+
+        @dbus.service.method(GATT_CHRC)
+        def StartNotify(self):
+            self.notifying = True
+
+        @dbus.service.method(GATT_CHRC)
+        def StopNotify(self):
+            self.notifying = False
+
+        @dbus.service.signal(DBUS_PROPS, signature='sa{sv}as')
+        def PropertiesChanged(self, interface, changed, invalidated):
+            pass
+
+    class ApControlCharacteristic(Characteristic):
+        """Write-only AP control. Bonded link enforced via 'encrypt-write'."""
+
+        def __init__(self, bus, index, service, providers):
+            super().__init__(bus, index, service, CHAR_AP_CONTROL,
+                             ['encrypt-write'], reader=lambda: b'')
+            self.providers = providers
+
+        @dbus.service.method(GATT_CHRC, in_signature='aya{sv}')
+        def WriteValue(self, value, options):
+            try:
+                payload = json.loads(bytes(bytearray(value)).decode('utf-8'))
+                action = payload.get('action')
+            except Exception:
+                raise InvalidArgs()
+            if action == 'start_ap':
+                self.providers.apply_ap(True)
+            elif action == 'stop_ap':
+                self.providers.apply_ap(False)
+            else:
+                raise NotSupported()
+
+        @dbus.service.method(GATT_CHRC, in_signature='a{sv}', out_signature='ay')
+        def ReadValue(self, options):
+            raise NotSupported()
+
+    class Advertisement(dbus.service.Object):
+        PATH_BASE = '/one/gode/ragnar/ble/adv'
+
+        def __init__(self, bus, index, providers):
+            self.path = f'{self.PATH_BASE}{index}'
+            self.providers = providers
+            super().__init__(bus, self.path)
+
+        def get_path(self):
+            return dbus.ObjectPath(self.path)
+
+        def get_properties(self):
+            return {
+                LE_ADVERTISEMENT: {
+                    'Type': 'peripheral',
+                    # The 128-bit service UUID must be in the advertisement so
+                    # the app (which scans filtered by it) and iOS background
+                    # scanning can discover the box.
+                    'ServiceUUIDs': dbus.Array([SERVICE_UUID], signature='s'),
+                    'LocalName': dbus.String(self.providers.local_name),
+                    'Includes': dbus.Array(['tx-power'], signature='s'),
+                }
+            }
+
+        @dbus.service.method(DBUS_PROPS, in_signature='s', out_signature='a{sv}')
+        def GetAll(self, interface):
+            if interface != LE_ADVERTISEMENT:
+                raise InvalidArgs()
+            return self.get_properties()[LE_ADVERTISEMENT]
+
+        @dbus.service.method(LE_ADVERTISEMENT)
+        def Release(self):  # pragma: no cover - called by BlueZ on unregister
+            pass
+
+    return Application, Advertisement
+
+
+# Lazily bound the first time a server actually starts.
+_Application = None
+_Advertisement = None
+
+
+def _ensure_classes():
+    global _Application, _Advertisement
+    if _Application is None:
+        _Application, _Advertisement = _build_dbus_classes()
+
+
+# Wrap start so the D-Bus classes are built on demand.
+_orig_run_loop = BleProvisioningServer._run_loop
+
+
+def _run_loop_with_classes(self):
+    try:
+        _ensure_classes()
+    except Exception as e:  # pragma: no cover
+        self._error = f'dbus/gi unavailable: {e}'
+        self._log(self._error, 'error')
+        self._ready.set()
+        return
+    _orig_run_loop(self)
+
+
+BleProvisioningServer._run_loop = _run_loop_with_classes
+
+
+# ===========================================================================
+# Adapter selection
+# ===========================================================================
+
+
+def list_adapters() -> list[str]:
+    out = _run(['hciconfig'])
+    return re.findall(r'^(hci\d+):', out, re.MULTILINE)
+
+
+def choose_adapter(preferred: Optional[str] = None) -> Optional[str]:
+    """Pick an adapter to advertise on.
+
+    Preference order: an explicit choice, else the first adapter. When more
+    than one is present we still take the first — the caller (or config) can
+    pin a dedicated one to keep the scanner and the peripheral apart.
+    """
+    adapters = list_adapters()
+    if preferred and preferred in adapters:
+        return preferred
+    return adapters[0] if adapters else None
+
+
+# ===========================================================================
+# Webapp integration helper
+# ===========================================================================
+
+
+def build_server(base_dir, get_config, get_ap_state=None, set_ap=None,
+                 logger=None, adapter=None) -> Optional[BleProvisioningServer]:
+    """Construct (but do not start) a server, or None if no adapter exists."""
+    cfg = {}
+    try:
+        cfg = get_config() or {}
+    except Exception:
+        pass
+    hci = choose_adapter(adapter or cfg.get('ble_provisioning_adapter'))
+    if not hci:
+        if logger:
+            logger.warning('[ble-prov] no Bluetooth adapter available')
+        return None
+    providers = DataProviders(base_dir, hci, get_config, get_ap_state, set_ap)
+    return BleProvisioningServer(providers, logger=logger)
+
+
+# ===========================================================================
+# CLI
+# ===========================================================================
+
+
+def _cli_info(base_dir: str) -> int:
+    hci = choose_adapter() or 'hci0'
+    providers = DataProviders(base_dir, hci, lambda: {})
+    print(f'adapter:      {hci}')
+    print(f'advertised:   {providers.local_name}')
+    print(f'service uuid: {SERVICE_UUID}')
+    for name, fn in (
+        ('device_info', providers.device_info),
+        ('net_status', providers.net_status),
+        ('ap_creds', providers.ap_creds),
+    ):
+        payload = fn()
+        raw = _encode(payload, name)
+        print(f'\n{name} ({len(raw)} B):')
+        print('  ' + json.dumps(payload, indent=2).replace('\n', '\n  '))
+    return 0
+
+
+def _cli_run(base_dir: str, seconds: Optional[float] = None) -> int:
+    server = build_server(base_dir, lambda: {})
+    if server is None:
+        print('No Bluetooth adapter — cannot run.')
+        return 1
+    if not server.start():
+        print(f'Failed to start: {server.status().get("error")}')
+        return 1
+    print(f'Advertising as {server.providers.local_name}. Ctrl-C to stop.')
+    try:
+        if seconds:
+            time.sleep(seconds)
+        else:
+            while server.status()['running']:
+                time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.stop()
+    return 0
+
+
+def _cli_selftest(base_dir: str) -> int:
+    server = build_server(base_dir, lambda: {})
+    if server is None:
+        print('SELFTEST: no adapter (expected on a box without Bluetooth)')
+        return 0
+    ok = server.start(timeout=10)
+    st = server.status()
+    print(f'SELFTEST: registered={ok} status={st}')
+    server.stop()
+    time.sleep(0.5)
+    return 0 if ok else 1
+
+
+def main(argv=None) -> int:
+    import sys
+
+    argv = argv if argv is not None else sys.argv[1:]
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    cmd = argv[0] if argv else 'info'
+    if cmd == 'info':
+        return _cli_info(base_dir)
+    if cmd == 'run':
+        secs = float(argv[1]) if len(argv) > 1 else None
+        return _cli_run(base_dir, secs)
+    if cmd == 'selftest':
+        return _cli_selftest(base_dir)
+    print(__doc__)
+    return 2
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/docs/ble_provisioning.md
+++ b/docs/ble_provisioning.md
@@ -1,0 +1,86 @@
+# BLE Provisioning
+
+`ble_provisioning.py` is a BlueZ GATT peripheral that lets the **Ragnar mobile
+app** discover a box over Bluetooth and learn how to reach it over IP. It is
+the Pi side of the contract documented in the Ragnarmobile repo
+(`docs/PROTOCOL.md`).
+
+## What it is — and isn't
+
+It is **provisioning only**. No dashboard data ever crosses Bluetooth:
+
+- iOS cannot use Bluetooth Classic / RFCOMM without MFi hardware, so BLE GATT
+  is the only cross-platform option — and GATT manages only ~5–20 KB/s.
+- Ragnar's real API (hundreds of KB per response, plus a Socket.IO stream)
+  belongs on Wi-Fi. The box already runs hostapd for the no-infrastructure
+  case.
+
+So the peripheral answers exactly one question — *where do I find this box on
+IP?* — then gets out of the way. Everything it exposes fits inside a single
+512-byte GATT attribute, so neither side implements chunking.
+
+## Off by default
+
+The service is disabled unless `ble_provisioning_enabled` is set. Advertising
+as a peripheral contends with `bt_scanner.py`'s active discovery on the same
+adapter, so turning it on is a deliberate choice. On a box with a single
+controller, run the BLE overlay scans and the provisioning peripheral at
+different times; with two controllers, pin the peripheral to one with
+`ble_provisioning_adapter`.
+
+## Enabling it
+
+Once — over IP, from the mobile app's **Box** tab, or directly:
+
+```bash
+curl -X POST http://<box>:8000/api/ble/provisioning/toggle \
+     -H 'Content-Type: application/json' -d '{"enabled":true}'
+```
+
+After that the phone can discover the box over Bluetooth on every later
+connect. The setting persists and the peripheral comes back up on boot.
+
+- `GET  /api/ble/provisioning`        → `{enabled, running, error, name}`
+- `POST /api/ble/provisioning/toggle` → `{enabled}` (omit to flip)
+
+## GATT service
+
+Advertised name `Ragnar-<id>` (id = last 2 bytes of the adapter address).
+Service UUID `fc453ae1-7464-49fb-9018-52ded4f4086d`, in the advertisement so
+the app can scan filtered by it and iOS can discover in the background.
+
+| Characteristic | UUID | Access | Payload |
+|---|---|---|---|
+| Device info | `8c310633-…` | read | `{name, hostname, model, version, box_id}` |
+| Network status | `7322574d-…` | read, notify | `{api_port, ifaces:[{name,ip}], ap_active, ap_ssid}` |
+| AP credentials | `2fdc016e-…` | encrypted read | `{ssid, psk}` |
+| AP control | `b8a58eb8-…` | encrypted write | `{action: "start_ap"｜"stop_ap"}` |
+
+The two AP characteristics require a bonded (encrypted) link, so BlueZ runs
+pairing on first use — the hotspot key is never exposed on an open link, and
+an unauthenticated peer cannot toggle the box's uplink.
+
+The app picks a reachable address from the interface list the same way
+Ragnar's net-diag does: wired, then USB ethernet, then `wlan1`, then `wlan0`.
+
+## CLI / troubleshooting
+
+```bash
+python3 ble_provisioning.py info       # print the payloads, no Bluetooth
+python3 ble_provisioning.py selftest   # register with BlueZ, verify, unregister
+python3 ble_provisioning.py run        # advertise until Ctrl-C
+```
+
+Confirm it is really advertising while running:
+
+```bash
+busctl get-property org.bluez /org/bluez/hci0 \
+    org.bluez.LEAdvertisingManager1 ActiveInstances   # → y 1
+```
+
+New Bluetooth dongles come up soft-blocked — `rfkill unblock all` first.
+
+## Dependencies
+
+`bluez`, `python3-dbus`, and `python3-gi` (the GLib main loop). All three are
+installed by `install_ragnar.sh` and ensured by `update_ragnar.sh`.

--- a/install_ragnar.sh
+++ b/install_ragnar.sh
@@ -435,6 +435,7 @@ install_dependencies() {
         "bluez"
         "bluez-tools"
         "python3-dbus"
+        "python3-gi"
         "hackrf"
         "bridge-utils"
         "python3-pil"

--- a/update_ragnar.sh
+++ b/update_ragnar.sh
@@ -122,10 +122,12 @@ fi
 
 echo -e "${BLUE}Step 5.2: Ensuring Bluetooth overlay dependencies...${NC}"
 # The WiFi-analyzer Bluetooth/BLE 2.4 GHz overlay (bt_scanner.py) talks to BlueZ
-# over D-Bus via python3-dbus, and needs bluez/bluetoothctl. These ship in the
-# installer; ensure them here too so update-only boxes get the overlay. Guarded
-# and idempotent — only apt-installs a package that is actually missing.
-for _btpkg in python3-dbus bluez; do
+# over D-Bus via python3-dbus, and needs bluez/bluetoothctl. The BLE
+# provisioning peripheral (ble_provisioning.py) additionally needs python3-gi
+# for its GLib main loop. These ship in the installer; ensure them here too so
+# update-only boxes get both. Guarded and idempotent — only apt-installs a
+# package that is actually missing.
+for _btpkg in python3-dbus python3-gi bluez; do
     if ! dpkg -s "$_btpkg" >/dev/null 2>&1; then
         DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "$_btpkg" >/dev/null 2>&1 \
             && echo -e "  ${GREEN}✓${NC} Installed $_btpkg (Bluetooth overlay)" \

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -102,6 +102,104 @@ except Exception as _nd_err:  # pragma: no cover - defensive
     logger.error(f"Failed to register network diagnostics routes: {_nd_err}")
 
 # ============================================================================
+# BLE PROVISIONING
+# The Bluetooth GATT peripheral the mobile app uses to discover this box and
+# learn its IP (see ble_provisioning.py + Ragnarmobile docs/PROTOCOL.md). It is
+# provisioning-only: no dashboard data ever crosses Bluetooth. Off by default,
+# because advertising as a peripheral contends with bt_scanner's active scans
+# on the same adapter.
+# ============================================================================
+
+_ble_server = None
+_ble_lock = threading.Lock()
+
+
+def _ble_ap_state():
+    """Live hotspot state for the netStatus characteristic."""
+    active = bool(getattr(shared_data, 'wardrive_ap_active', False))
+    wm = getattr(shared_data, 'wifi_manager', None)
+    ssid = None
+    if active:
+        ssid = getattr(wm, 'ap_ssid', None) or shared_data.config.get('wifi_ap_ssid', 'Ragnar')
+    return {'active': active, 'ssid': ssid}
+
+
+def _ble_set_ap(on):
+    """Bring the hotspot up/down from a bonded AP-control write."""
+    wm = getattr(shared_data, 'wifi_manager', None)
+    if wm is None:
+        raise RuntimeError('Wi-Fi manager not available')
+    if on:
+        return bool(wm.enable_ap_mode_from_web())
+    return bool(wm.stop_ap_mode())
+
+
+def _start_ble_provisioning():
+    """Start the peripheral if config enables it. Never raises."""
+    global _ble_server
+    try:
+        if not shared_data.config.get('ble_provisioning_enabled', False):
+            return False
+        import ble_provisioning
+        with _ble_lock:
+            if _ble_server is not None and _ble_server.status().get('running'):
+                return True
+            base_dir = os.path.dirname(os.path.abspath(__file__))
+            _ble_server = ble_provisioning.build_server(
+                base_dir,
+                get_config=lambda: shared_data.config,
+                get_ap_state=_ble_ap_state,
+                set_ap=_ble_set_ap,
+                logger=logger,
+            )
+            if _ble_server is None:
+                return False
+            return _ble_server.start()
+    except Exception as e:  # pragma: no cover - hardware/D-Bus dependent
+        logger.error(f"BLE provisioning failed to start: {e}")
+        return False
+
+
+def _stop_ble_provisioning():
+    global _ble_server
+    with _ble_lock:
+        if _ble_server is not None:
+            _ble_server.stop()
+            _ble_server = None
+
+
+@app.route('/api/ble/provisioning', methods=['GET'])
+def ble_provisioning_status():
+    enabled = bool(shared_data.config.get('ble_provisioning_enabled', False))
+    running = False
+    error = None
+    name = None
+    with _ble_lock:
+        if _ble_server is not None:
+            st = _ble_server.status()
+            running = bool(st.get('running'))
+            error = st.get('error')
+            name = st.get('name')
+    return jsonify({'enabled': enabled, 'running': running, 'error': error, 'name': name})
+
+
+@app.route('/api/ble/provisioning/toggle', methods=['POST'])
+def ble_provisioning_toggle():
+    payload = request.get_json(silent=True) or {}
+    enable = bool(payload.get('enabled', not shared_data.config.get('ble_provisioning_enabled', False)))
+    shared_data.config['ble_provisioning_enabled'] = enable
+    shared_data.save_config()
+    if enable:
+        ok = _start_ble_provisioning()
+        if not ok:
+            with _ble_lock:
+                err = _ble_server.status().get('error') if _ble_server else 'no Bluetooth adapter'
+            return jsonify({'enabled': True, 'running': False, 'error': err}), 200
+        return jsonify({'enabled': True, 'running': True})
+    _stop_ble_provisioning()
+    return jsonify({'enabled': False, 'running': False})
+
+# ============================================================================
 # AUTHENTICATION MIDDLEWARE
 # ============================================================================
 
@@ -20729,6 +20827,17 @@ def run_server(host='0.0.0.0', port=8000, ssl_cert=None, ssl_key=None, https_por
         socketio.start_background_task(_rusense_notify_loop)
         socketio.start_background_task(net_integrity_monitor_loop)
         socketio.start_background_task(watchtower_monitor_loop)
+
+        # Bring up the BLE provisioning peripheral if the user has enabled it.
+        # Deferred so a slow/absent Bluetooth stack never delays the web server
+        # binding; it runs its own GLib loop thread regardless.
+        def _boot_ble():
+            try:
+                if _start_ble_provisioning():
+                    logger.info("BLE provisioning peripheral advertising")
+            except Exception as _ble_err:  # pragma: no cover
+                logger.error(f"BLE provisioning boot error: {_ble_err}")
+        socketio.start_background_task(_boot_ble)
 
         logger.info("✅ All background threads started successfully")
 


### PR DESCRIPTION
ble_provisioning.py is a BlueZ GATT peripheral that lets the Ragnar mobile app discover a box over Bluetooth and read its IP — the Pi side of the Ragnarmobile docs/PROTOCOL.md contract.

It is provisioning only: iOS cannot do Bluetooth Classic without MFi hardware and GATT manages ~5-20 KB/s, so no dashboard data crosses Bluetooth. The peripheral advertises the service UUID and answers four characteristics (device info, network status, and encrypted-only AP credentials + AP control); all payloads fit one 512-byte attribute, so neither side chunks. The app then reaches the box over Wi-Fi.

Off by default (ble_provisioning_enabled). Advertising as a peripheral contends with bt_scanner's active discovery on the same adapter, so enabling it is deliberate; ble_provisioning_adapter can pin a second controller.

Webapp integration: GET /api/ble/provisioning and a toggle that persists the setting, starts/stops the peripheral, and reports its live state. The peripheral comes up on boot when enabled, deferred so a slow Bluetooth stack never delays the web server binding. AP credentials come from the existing wifi_ap_ssid/password config; AP control drives wifi_manager.

Verified on hardware: registers with BlueZ 5.82 on hci0, and the HTTP toggle round-trips to LEAdvertisingManager1 ActiveInstances 1 -> 0. Phone-side discovery is not yet verified against a real handset.

Needs python3-gi (GLib loop) alongside the existing python3-dbus/bluez; added to install_ragnar.sh and update_ragnar.sh.