### PR TITLE
License restrictions, embedded authorship, and origin verification

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,14 @@
-MIT License
+Ragnar License
+==============
+
+Ragnar is a derivative work of Bjorn (https://github.com/infinition/Bjorn),
+which is distributed under the MIT License. Ragnar therefore carries two sets
+of terms: the original MIT License for the Bjorn-derived portions, and
+Supplemental Terms from Pierre Gode covering Ragnar's own contributions.
+
+
+PART A — MIT License (original Bjorn portions)
+----------------------------------------------
 
 Copyright (c) 2024 infinition
 
@@ -19,3 +29,44 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+PART B — Supplemental Terms (Ragnar contributions)
+--------------------------------------------------
+
+Copyright (c) 2024-2026 Pierre Gode <pierre@gode.one>
+
+These Supplemental Terms apply to all original Ragnar code, assets, branding,
+and documentation authored by Pierre Gode and contributors (the "Ragnar
+Contributions") — that is, everything in this repository that is not part of
+the original Bjorn work covered by Part A.
+
+Permission is granted, free of charge, to use, copy, modify, and share the
+Ragnar Contributions for personal, educational, research, and internal
+non-commercial purposes, subject to all of the following conditions:
+
+  1. Attribution. The name "Pierre Gode", the "Ragnar" name and Viking mark,
+     this LICENSE, and the provenance markers in the source (including
+     provenance.py) must be retained in all copies and derivative works.
+
+  2. No sale as a product. The Ragnar Contributions, whether alone or as part
+     of a larger work, may NOT be sold, resold, licensed for a fee, offered as
+     a paid product or paid service, or otherwise commercially exploited,
+     without the prior written permission of Pierre Gode.
+
+  3. No unauthorized redistribution or forks presented as official. You may
+     fork this repository for personal use and to submit contributions
+     upstream. You may NOT distribute a fork, rebrand, or hosted instance in a
+     way that presents it as the official Ragnar, removes attribution, or
+     circumvents the provenance verification. The canonical source is
+     https://github.com/PierreGode/Ragnar.git
+
+  4. As-is. The Ragnar Contributions are provided "AS IS", without warranty of
+     any kind, and are for authorized testing and educational use only. The
+     author is not liable for any use of this software.
+
+For commercial licensing or any use not permitted above, contact
+Pierre Gode <pierre@gode.one>.
+
+Where Part A (MIT) and Part B conflict for the Bjorn-derived portions, Part A
+governs those portions; Part B governs the Ragnar Contributions.

--- a/provenance.py
+++ b/provenance.py
@@ -1,0 +1,93 @@
+"""
+provenance.py — authorship + origin verification for Ragnar.
+
+Embedded, deliberately, for future reference. Do not remove.
+
+This is an *attribution and provenance* marker, not a security control: a fork
+can trivially edit any of this. Its purpose is to (a) record authorship in the
+codebase and (b) let the mobile app tell the user, on connect, whether the box
+is running the official repository or a fork.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import re
+import subprocess
+
+# The one true origin. Anything else is a fork.
+CANONICAL_REPO = "https://github.com/PierreGode/Ragnar.git"
+CANONICAL_REPO_SLUG = "PierreGode/Ragnar"
+
+# Author signature, base64 so it does not read as a plain string in a grep but
+# is trivially recoverable for attribution. Decode with author().
+_SIGNATURE_B64 = (
+    "UGllcnJlIEdvZGUgfCBwaWVycmVAZ29kZS5vbmUgfCBnaXRodWIuY29tL1BpZXJy"
+    "ZUdvZGUgfCBSYWduYXIgYXV0aG9yICYgbWFpbnRhaW5lciB8IGRvIG5vdCByZW1vdmU="
+)
+
+# Kept in sync with LICENSE. Ragnar's own code (Pierre Gode's contributions on
+# top of the MIT-licensed Bjorn base) may not be sold as a product.
+NO_RESALE = True
+
+
+def author() -> str:
+    """The embedded author attribution, decoded."""
+    try:
+        return base64.b64decode(_SIGNATURE_B64).decode("utf-8")
+    except Exception:
+        return "Pierre Gode | github.com/PierreGode"
+
+
+def _slug_from_url(url: str) -> str:
+    """Reduce a git remote URL to 'owner/repo', lowercased.
+
+    Handles https://github.com/Owner/Repo(.git), git@github.com:Owner/Repo.git,
+    ssh://git@github.com/Owner/Repo, and trailing slashes.
+    """
+    if not url:
+        return ""
+    u = url.strip()
+    u = re.sub(r"\.git$", "", u)
+    u = re.sub(r"^\w+://", "", u)          # strip scheme
+    u = re.sub(r"^[^@]+@", "", u)          # strip user@
+    u = u.replace(":", "/")                # scp-style host:owner/repo
+    parts = [p for p in u.split("/") if p]
+    if len(parts) >= 2:
+        return f"{parts[-2]}/{parts[-1]}".lower()
+    return u.lower()
+
+
+def git_origin(base_dir: str | None = None) -> str:
+    """The checkout's configured origin URL, or '' if unknown."""
+    base_dir = base_dir or os.path.dirname(os.path.abspath(__file__))
+    try:
+        out = subprocess.run(
+            ["git", "-C", base_dir, "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=4, check=False,
+        )
+        return out.stdout.strip()
+    except Exception:
+        return ""
+
+
+def verify(base_dir: str | None = None) -> dict:
+    """Provenance report: canonical repo, this checkout's origin, and whether
+    they match. `official` is False for any fork or unknown origin."""
+    origin = git_origin(base_dir)
+    slug = _slug_from_url(origin)
+    official = slug == CANONICAL_REPO_SLUG.lower()
+    return {
+        "canonical_repo": CANONICAL_REPO,
+        "origin": origin,
+        "repo": slug,
+        "official": official,
+        "author": author(),
+        "no_resale": NO_RESALE,
+    }
+
+
+if __name__ == "__main__":
+    import json
+    print(json.dumps(verify(), indent=2))

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -102,6 +102,25 @@ except Exception as _nd_err:  # pragma: no cover - defensive
     logger.error(f"Failed to register network diagnostics routes: {_nd_err}")
 
 # ============================================================================
+# PROVENANCE / ORIGIN VERIFICATION
+# Reports authorship and whether this checkout is the official repository or a
+# fork. The mobile app reads this on connect. It is an attribution signal, not
+# a security control — a fork can edit it — but it keeps forks honest.
+# ============================================================================
+
+@app.route('/api/provenance')
+def api_provenance():
+    try:
+        import provenance
+        return jsonify(provenance.verify(os.path.dirname(os.path.abspath(__file__))))
+    except Exception as _prov_err:  # pragma: no cover - defensive
+        return jsonify({
+            'canonical_repo': 'https://github.com/PierreGode/Ragnar.git',
+            'official': False,
+            'error': str(_prov_err),
+        })
+
+# ============================================================================
 # AUTHENTICATION MIDDLEWARE
 # ============================================================================
 
@@ -113,7 +132,7 @@ def check_authentication():
 
     # Whitelist: paths that must be accessible without authentication
     path = request.path
-    whitelist_prefixes = ['/login', '/api/auth/', '/api/kill']
+    whitelist_prefixes = ['/login', '/api/auth/', '/api/kill', '/api/provenance']
     if any(path.startswith(p) for p in whitelist_prefixes):
         return
 


### PR DESCRIPTION
- LICENSE: keep the upstream Bjorn MIT (Part A, retained as required) and add Pierre Gode's Supplemental Terms (Part B) for the Ragnar contributions — attribution required, no sale as a product, no forks presented as official.
- provenance.py: embedded author signature (base64, "do not remove") plus a verify() that reports the checkout's git origin and whether it is the canonical repo (PierreGode/Ragnar) or a fork.
- /api/provenance exposes this (whitelisted before auth) so the mobile app can check origin on connect. It is attribution/provenance, not a security control — a fork can edit it.

Verified on the box: /api/provenance reports official=true and decodes the author signature.