### PR TITLE
BLE provisioning: surface an under-voltage warning

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -5826,6 +5826,7 @@
                             </label>
                         </div>
                         <button id="ble-provisioning-readvertise" class="hidden mt-3 px-3 py-1.5 rounded-lg bg-Ragnar-600 hover:bg-Ragnar-500 text-white text-sm" onclick="readvertiseBle()">Re-advertise</button>
+                        <p id="ble-provisioning-power" class="hidden text-xs mt-3 px-3 py-2 rounded-lg bg-amber-900/40 border border-amber-700 text-amber-200"></p>
                         <p id="ble-provisioning-status" class="text-xs mt-3 text-gray-500">—</p>
                     </div>
                 </div>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -24113,6 +24113,17 @@ async function loadBleProvisioning() {
         // Show the Re-advertise button only once it has auto-stopped.
         const rebtn = document.getElementById('ble-provisioning-readvertise');
         if (rebtn) rebtn.classList.toggle('hidden', !(d.enabled && d.autostopped));
+        // Under-voltage warning: running BLE + a USB radio on a weak PSU can
+        // reset the whole Pi. Surface it so a "crash" reads as power, not code.
+        const pw = document.getElementById('ble-provisioning-power');
+        if (pw) {
+            if (d.power && d.power.message) {
+                pw.textContent = '⚠ ' + d.power.message;
+                pw.classList.remove('hidden');
+            } else {
+                pw.classList.add('hidden');
+            }
+        }
         const st = document.getElementById('ble-provisioning-status');
         if (st) st.textContent = _bleProvStatusText(d);
     } catch (e) { /* silent */ }

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -196,6 +196,20 @@ def _ble_adapters():
         return []
 
 
+def _ble_power():
+    """Pi power/under-voltage health. Running BLE + a USB radio on an
+    under-volting Pi can reset the whole board — surface it so the user knows
+    that a 'crash' is the PSU, not the software. Never raises."""
+    try:
+        import resource_monitor
+        p = resource_monitor.resource_monitor.get_power_status()
+        if p.get('supported') and p.get('status') in ('warning', 'critical'):
+            return {'status': p['status'], 'message': p['message']}
+    except Exception:
+        pass
+    return None
+
+
 @app.route('/api/ble/provisioning', methods=['GET'])
 def ble_provisioning_status():
     enabled = bool(shared_data.config.get('ble_provisioning_enabled', False))
@@ -224,6 +238,9 @@ def ble_provisioning_status():
         'autostop': bool(shared_data.config.get('ble_provisioning_autostop', False)),
         # True once a phone provisioned and the peripheral freed the adapter.
         'autostopped': autostopped,
+        # Power warning (under-voltage) — running BLE + a USB radio on a weak
+        # PSU can reset the Pi; None when healthy.
+        'power': _ble_power(),
     })
 
 


### PR DESCRIPTION
Running the BLE peripheral alongside a USB radio (Alfa) doing active discovery + the WiFi analyzer can pull the 5V rail under spec and reset the whole Pi — which looks like 'Ragnar crashed' with nothing in the logs. Code review confirmed there is no adapter collision (bt_scanner picks the USB Alfa, provisioning stays on the built-in radio), so a full reboot is power, not software. Surface resource_monitor's under-voltage state in the BLE provisioning status and card so the real cause (PSU) is visible.

Verified: /api/ble/provisioning now returns a power warning on this box (under-voltage has occurred since boot).