### PR TITLE
Fix/install package resilience

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -48,6 +48,24 @@ sudo chmod +x install_ragnar.sh && sudo ./install_ragnar.sh
 # Choose the choice 1 for automatic installation. It may take a while as a lot of packages and modules will be installed. You must reboot at the end.
 ```
 
+#### "Some packages won't install"
+
+Not every package is required. The installer splits them in two, and prints a
+summary of both when the dependency step ends:
+
+- **Required** — a miss here is a real `WARNING`, and the summary repeats the
+  exact `apt-get install` line to fix it. The install continues regardless.
+- **Optional** — `hackrf`, `nikto`, `sqlmap`, `whatweb`, `ffuf`,
+  `libatlas-base-dev`. These back single features (SDR Waterfall, the recon and
+  vulnerability scanners) that look their binary up at runtime and stay disabled
+  without it. Not every Debian suite carries all of them — `ffuf` only arrived in
+  trixie — so seeing these listed as unavailable is expected, not a failed
+  install.
+
+Two steps in the install are also slow and silent, which can look like a hang on
+a Pi Zero 2 W — the pip build of `sslyze`/`cryptography`, and
+`nmap --script-updatedb`. Give them time before interrupting.
+
 ### 🧰 Manual Install
 
 #### Step 1: Activate SPI & I2C

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -66,6 +66,45 @@ Two steps in the install are also slow and silent, which can look like a hang on
 a Pi Zero 2 W — the pip build of `sslyze`/`cryptography`, and
 `nmap --script-updatedb`. Give them time before interrupting.
 
+#### "No git command works" / updates fail
+
+Check this first:
+
+```bash
+git --version
+```
+
+If that prints **Illegal instruction** (or nothing), git itself is broken — not
+Ragnar. Debian Trixie arm64 can ship a git built with ARMv8.1+ atomics that
+crashes on a Cortex-A53, which is the Pi Zero 2 W's core. Reinstall it:
+
+```bash
+sudo apt update && sudo apt install --reinstall git
+```
+
+This has a knock-on effect worth knowing about. The installer checks git up
+front, and when it is unusable it downloads a release tarball instead of
+cloning. That produces a complete, working Ragnar — but with **no `.git`
+directory**, so every later update has no repository to update. If your box was
+installed that way, `update_ragnar.sh` now reattaches it to the upstream
+repository in place, keeping every file on disk, and continues with the update.
+Nothing needs to be reinstalled; just fix git and re-run the update.
+
+#### Ragnar installed to the wrong directory
+
+Ragnar always installs to `/home/ragnar/Ragnar`, and the `ragnar` user is
+created if missing. If you find the tree somewhere else — `/home/Ragnar`, or
+wherever you ran the installer from — you hit a bug in installers before this
+fix, where a failure to enter `/home/ragnar` was ignored and the relative clone
+landed in the current directory instead. Move it into place and re-run:
+
+```bash
+sudo systemctl stop ragnar.service
+sudo mv /home/Ragnar /home/ragnar/Ragnar        # adjust the source path
+sudo chown -R ragnar:ragnar /home/ragnar/Ragnar
+sudo /home/ragnar/Ragnar/update_ragnar.sh
+```
+
 ### 🧰 Manual Install
 
 #### Step 1: Activate SPI & I2C

--- a/docs/ble_provisioning.md
+++ b/docs/ble_provisioning.md
@@ -96,10 +96,33 @@ Ragnar's net-diag does: wired, then USB ethernet, then `wlan1`, then `wlan0`.
 ## CLI / troubleshooting
 
 ```bash
-python3 ble_provisioning.py info       # print the payloads, no Bluetooth
-python3 ble_provisioning.py selftest   # register with BlueZ, verify, unregister
-python3 ble_provisioning.py run        # advertise until Ctrl-C
+sudo python3 ble_provisioning.py doctor   # why isn't it advertising?
+python3 ble_provisioning.py info          # print the payloads, no Bluetooth
+python3 ble_provisioning.py selftest      # register with BlueZ, verify, unregister
+python3 ble_provisioning.py run           # advertise until Ctrl-C
 ```
+
+**Start with `doctor`.** It is the "the toggle does nothing" tool: it checks
+each prerequisite in turn — `python3-dbus` and `python3-gi` importable,
+`bluetoothctl` present, at least one controller found, Bluetooth not
+rfkill-blocked — then actually registers an advertisement for a few seconds and
+reports what BlueZ said. Every FAIL line carries the command that fixes it, and
+the controller list shows which radios it can see and which one is built-in:
+
+```
+  [PASS] python3-dbus importable
+  [PASS] python3-gi importable
+  [PASS] bluetoothctl present
+  [PASS] Bluetooth controller found (1)
+        - hci0 DC:A6:32:00:B4:E2 (built-in)
+  [PASS] Bluetooth not rfkill-blocked
+  [PASS] Advertising starts
+        advertising as "Ragnar-b4e2" on hci0
+```
+
+A pass here means the box is on the air — if the phone still can't see it, scan
+for that name with a generic BLE app (nRF Connect) to split "box isn't
+advertising" from "app isn't finding it".
 
 Confirm it is really advertising while running:
 

--- a/install_ragnar.sh
+++ b/install_ragnar.sh
@@ -814,8 +814,26 @@ setup_ragnar() {
         check_success "Created ragnar user"
     fi
 
+    # The home directory must exist before anything below can land in it. This
+    # cd used to be unguarded, and every path after it is relative ("Ragnar"),
+    # so a failure here silently installed the whole tree into whatever
+    # directory the installer happened to be run from — e.g. /home/Ragnar when
+    # started from /home. Fail loudly instead of scattering files.
+    if [ ! -d "/home/$ragnar_USER" ]; then
+        log "WARNING" "/home/$ragnar_USER does not exist — creating it"
+        mkdir -p "/home/$ragnar_USER" || {
+            log "ERROR" "Cannot create /home/$ragnar_USER — installation cannot continue"
+            clean_exit 1
+        }
+        chown "$ragnar_USER:$ragnar_USER" "/home/$ragnar_USER" 2>/dev/null || true
+    fi
+    cd "/home/$ragnar_USER" || {
+        log "ERROR" "Cannot enter /home/$ragnar_USER — installation cannot continue"
+        log "ERROR" "Refusing to continue, as Ragnar would be installed into $(pwd) instead"
+        clean_exit 1
+    }
+
     # Check for existing ragnar directory with a valid git clone
-    cd /home/$ragnar_USER
     if [ -d "Ragnar/.git" ] || [ -d "Ragnar/actions" ]; then
         log "INFO" "Using existing ragnar directory"
         echo -e "${GREEN}Using existing ragnar directory${NC}"

--- a/install_ragnar.sh
+++ b/install_ragnar.sh
@@ -290,12 +290,18 @@ install_package() {
         fi
     done
 
+    # Only announce a fallback when there actually is one — a single-candidate
+    # package was otherwise logged as "trying next fallback" with nothing left
+    # to try, which reads as a broken installer rather than a missing package.
+    local remaining
+    remaining=$(echo "$candidates" | wc -w)
     for candidate in $candidates; do
         if eval "$INSTALL_CMD $candidate" >/dev/null 2>&1; then
             log "SUCCESS" "Installed ${candidate}"
             return 0
         fi
-        log "WARNING" "Failed to install ${candidate}, trying next fallback"
+        remaining=$((remaining - 1))
+        [ "$remaining" -gt 0 ] && log "INFO" "${candidate} unavailable, trying next fallback"
     done
 
     log "WARNING" "Could not install package ${pkg} on ${PKG_MGR}"
@@ -436,7 +442,6 @@ install_dependencies() {
         "bluez-tools"
         "python3-dbus"
         "python3-gi"
-        "hackrf"
         "bridge-utils"
         "python3-pil"
         "libjpeg-dev"
@@ -470,25 +475,50 @@ install_dependencies() {
         "lldpd"
         "ethtool"
         "speedtest-cli"
-        "nikto"
-        "sqlmap"
-        "whatweb"
-        "ffuf"
     )
 
     if [ "$IS_ARM" = true ]; then
         packages+=("libgpiod-dev" "libi2c-dev" "dhcpcd5")
     fi
 
-    optional_packages=("libatlas-base-dev")
+    # Nice-to-have, never required. Ragnar resolves each of these at runtime and
+    # simply disables the feature that uses it (server_capabilities.py marks the
+    # scanners 'critical': False; recon_engine looks ffuf up in _tool_paths; the
+    # Waterfall button stays greyed without hackrf). Several are also genuinely
+    # absent from some suites — ffuf only entered Debian in trixie, and the
+    # 32-bit Raspbian builds for a Pi Zero 2 W carry a smaller set than arm64 —
+    # so a miss here must not read as a broken install.
+    optional_packages=(
+        "libatlas-base-dev"
+        "hackrf"
+        "nikto"
+        "sqlmap"
+        "whatweb"
+        "ffuf"
+    )
+
+    # Collect misses instead of letting them scroll past in a 2000-line log, so
+    # the end of the install answers "which packages didn't make it?" directly.
+    local failed_required=()
+    local failed_optional=()
 
     for package in "${packages[@]}"; do
-        install_package "$package"
+        install_package "$package" || failed_required+=("$package")
     done
 
     for package in "${optional_packages[@]}"; do
-        install_package "$package" || log "WARNING" "Optional package $package unavailable on ${PKG_MGR}"
+        install_package "$package" || failed_optional+=("$package")
     done
+
+    if [ ${#failed_optional[@]} -gt 0 ]; then
+        log "INFO" "Optional packages unavailable on ${PKG_MGR} (features that use them stay disabled): ${failed_optional[*]}"
+    fi
+    if [ ${#failed_required[@]} -gt 0 ]; then
+        log "WARNING" "These required packages did not install: ${failed_required[*]}"
+        log "WARNING" "Install continues, but fix them with: sudo ${INSTALL_CMD#DEBIAN_FRONTEND=noninteractive } ${failed_required[*]}"
+    else
+        log "SUCCESS" "All required system packages installed"
+    fi
 
     # Ensure vulners.nse script is available for vulnerability scanning
     local vulners_path="/usr/share/nmap/scripts/vulners.nse"

--- a/update_ragnar.sh
+++ b/update_ragnar.sh
@@ -23,18 +23,65 @@ if [ ! -d "$ragnar_PATH" ]; then
     exit 1
 fi
 
-if [ ! -d "$ragnar_PATH/.git" ]; then
-    echo -e "${RED}Error: This is not a git repository. Cannot update.${NC}"
-    echo -e "${YELLOW}Please reinstall ragnar using the installation script.${NC}"
-    exit 1
-fi
-
 cd "$ragnar_PATH"
 
 # Check if script is run as root
 if [ "$(id -u)" -ne 0 ]; then
     echo -e "${RED}This script must be run as root. Please use 'sudo'.${NC}"
     exit 1
+fi
+
+# A working git is a hard prerequisite, and on some boards it is exactly what is
+# broken: Debian Trixie arm64 can ship a git built with ARMv8.1+ atomics that
+# dies with SIGILL on a Cortex-A53 (Pi Zero 2 W). The installer detects this and
+# falls back to tarball downloads, so a box can be running Ragnar perfectly well
+# with no usable git at all. Say so plainly rather than failing on a git command.
+if ! git --version >/dev/null 2>&1; then
+    echo -e "${RED}Error: git does not run on this system.${NC}"
+    echo -e "${YELLOW}If this is a Pi Zero 2 W (or another Cortex-A53 board), the packaged"
+    echo -e "git may be built for a newer ARM revision and crash with 'Illegal"
+    echo -e "instruction'. Confirm with:${NC}"
+    echo -e "    git --version"
+    echo -e "${YELLOW}Then try reinstalling it:${NC}"
+    echo -e "    sudo apt update && sudo apt install --reinstall git"
+    echo -e "${YELLOW}Ragnar itself keeps running — only updates need git.${NC}"
+    exit 1
+fi
+
+# Repair a tarball install. When git was unusable at install time the installer
+# unpacks a release tarball instead of cloning, which leaves a complete, working
+# tree with no .git in it — and every update from then on had nothing to work
+# with. If git runs now, rebuild the repository metadata in place rather than
+# dead-ending the user into a full reinstall. The working tree is left alone;
+# only .git is created, so local data files are untouched.
+if [ ! -d "$ragnar_PATH/.git" ]; then
+    echo -e "${YELLOW}No .git found — this box was installed from a tarball.${NC}"
+    echo -e "${BLUE}Reattaching it to the upstream repository (your files are kept)...${NC}"
+    if git init -q "$ragnar_PATH" 2>/dev/null \
+       && git -C "$ragnar_PATH" remote add origin https://github.com/PierreGode/Ragnar.git 2>/dev/null \
+       && git -C "$ragnar_PATH" fetch --depth=1 origin main 2>/dev/null; then
+        # Point main at upstream WITHOUT touching the working tree, so the files
+        # already on disk (including local data) survive. Anything that differs
+        # from upstream simply shows up as a normal local modification, which
+        # the stash step below then handles like any other update.
+        git -C "$ragnar_PATH" reset -q --mixed FETCH_HEAD 2>/dev/null || true
+        git -C "$ragnar_PATH" branch -q -f main FETCH_HEAD 2>/dev/null || true
+        git -C "$ragnar_PATH" symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+        git -C "$ragnar_PATH" branch -q --set-upstream-to=origin/main main 2>/dev/null || true
+        # Restore only files upstream has that the tree is missing. A tarball
+        # can be short of files (.github, dotfiles) that would otherwise look
+        # like deliberate local deletions and get stashed by the step below.
+        # Deleted-only: modified files are left alone so real local edits still
+        # reach the stash/merge path intact.
+        git -C "$ragnar_PATH" ls-files -d -z 2>/dev/null \
+            | xargs -0 -r git -C "$ragnar_PATH" checkout -- 2>/dev/null || true
+        echo -e "${GREEN}Repository metadata rebuilt — continuing with the update.${NC}"
+    else
+        rm -rf "$ragnar_PATH/.git"
+        echo -e "${RED}Error: could not reattach to the upstream repository.${NC}"
+        echo -e "${YELLOW}Check network access to github.com, then re-run this script.${NC}"
+        exit 1
+    fi
 fi
 
 echo -e "\n${BLUE}Step 1: Stopping ragnar service...${NC}"

--- a/update_ragnar.sh
+++ b/update_ragnar.sh
@@ -134,12 +134,24 @@ for _btpkg in python3-dbus python3-gi bluez; do
             || echo -e "  ${YELLOW}⚠${NC} Could not install $_btpkg — the overlay falls back to bluetoothctl text mode"
     fi
 done
-# HackRF tools for the true-RF Waterfall view (sdr_spectrum.py). Optional — the
-# Waterfall button stays greyed out until both the tools and a board are present.
-if ! dpkg -s hackrf >/dev/null 2>&1; then
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends hackrf >/dev/null 2>&1 \
-        && echo -e "  ${GREEN}✓${NC} Installed hackrf (true-RF Waterfall)" \
-        || echo -e "  ${YELLOW}⚠${NC} Could not install hackrf — Waterfall stays disabled until installed"
+# Optional tooling. Each backs one feature that resolves the binary at runtime
+# and disables itself when it is missing (hackrf → the true-RF Waterfall view in
+# sdr_spectrum.py; the rest → the recon/vuln scanners, which server_capabilities
+# already marks 'critical': False). Not every suite ships all of them — ffuf only
+# entered Debian in trixie — so a miss is reported and skipped, never fatal.
+_missing_optional=()
+for _opt in hackrf:"true-RF Waterfall" nikto:"vuln scanner" sqlmap:"vuln scanner" \
+            whatweb:"vuln scanner" ffuf:"content discovery"; do
+    _pkg="${_opt%%:*}"; _why="${_opt#*:}"
+    dpkg -s "$_pkg" >/dev/null 2>&1 && continue
+    if DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "$_pkg" >/dev/null 2>&1; then
+        echo -e "  ${GREEN}✓${NC} Installed $_pkg ($_why)"
+    else
+        _missing_optional+=("$_pkg")
+    fi
+done
+if [ ${#_missing_optional[@]} -gt 0 ]; then
+    echo -e "  ${YELLOW}⚠${NC} Not available in this suite: ${_missing_optional[*]} — the features using them stay disabled"
 fi
 
 echo -e "${BLUE}Step 5.5: Restoring local runtime data...${NC}"


### PR DESCRIPTION
This pull request significantly improves the Ragnar installer and update scripts to provide clearer handling and messaging around missing dependencies, especially optional packages, and to robustly handle installation and update issues on ARM boards like the Pi Zero 2 W. It also enhances the documentation for troubleshooting common installation problems.

**Dependency management and installer improvements:**

- The installer now clearly distinguishes between required and optional packages, collecting and summarizing any missing packages at the end of the install, and provides explicit instructions for fixing required package failures (`install_ragnar.sh`).
- Optional packages (such as `hackrf`, `nikto`, `sqlmap`, `whatweb`, `ffuf`, `libatlas-base-dev`) are now grouped and handled separately, with missing optional packages simply disabling the features that depend on them, rather than causing the install to fail or appear broken (`install_ragnar.sh`).
- Improved fallback messaging when multiple candidate packages are attempted, only logging a fallback when there is actually another candidate to try (`install_ragnar.sh`).

**Robustness on ARM boards and update process:**

- The update script now detects when `git` is broken (common on Pi Zero 2 W due to ARMv8.1+ atomics) and provides clear instructions for reinstalling it. If Ragnar was installed from a tarball due to a broken `git`, the script will now automatically reattach the working tree to the upstream repository, preserving all local files and enabling updates without a full reinstall (`update_ragnar.sh`).
- The installer now ensures that the `/home/ragnar` directory exists and fails loudly if it cannot be created, preventing accidental installation into the wrong directory (`install_ragnar.sh`).

**Documentation enhancements:**

- Added comprehensive troubleshooting sections to `docs/INSTALL.md` covering missing packages, broken `git` binaries, and fixing installations to the wrong directory, with clear instructions and explanations for users.
- Updated `docs/ble_provisioning.md` to introduce the new `doctor` command for BLE troubleshooting, explaining its use and output.

These changes make installation and updates more reliable, especially on ARM hardware, and provide much clearer guidance and feedback to users when things go wrong.