### PR TITLE
Installer: repair a tarball install instead of skipping it

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -86,9 +86,15 @@ This has a knock-on effect worth knowing about. The installer checks git up
 front, and when it is unusable it downloads a release tarball instead of
 cloning. That produces a complete, working Ragnar — but with **no `.git`
 directory**, so every later update has no repository to update. If your box was
-installed that way, `update_ragnar.sh` now reattaches it to the upstream
-repository in place, keeping every file on disk, and continues with the update.
-Nothing needs to be reinstalled; just fix git and re-run the update.
+installed that way, both `update_ragnar.sh` and re-running `install_ragnar.sh`
+now reattach it to the upstream repository in place, keeping every file on disk.
+Nothing needs to be reinstalled; just fix git and re-run either one.
+
+Re-running the installer used to be a no-op here: it treats a directory
+containing `actions/` as an existing install and skips the clone, so a tarball
+tree stayed permanently without `.git`. Note that the installer never re-clones
+over an existing directory — the path that would `rm -rf` it would take your
+`data/` with it — so reattaching in place is the only safe repair.
 
 #### Ragnar installed to the wrong directory
 

--- a/install_ragnar.sh
+++ b/install_ragnar.sh
@@ -837,6 +837,35 @@ setup_ragnar() {
     if [ -d "Ragnar/.git" ] || [ -d "Ragnar/actions" ]; then
         log "INFO" "Using existing ragnar directory"
         echo -e "${GREEN}Using existing ragnar directory${NC}"
+        # A tree with actions/ but no .git is a tarball install (what this
+        # script produces when git is unusable at install time). It counts as
+        # "existing" above, so re-running the installer would skip the clone and
+        # leave it un-updatable forever — the one thing a user re-runs the
+        # installer to fix. Reattach it here instead. Deliberately NOT a
+        # re-clone: the else branch below does rm -rf, which would take the
+        # user's data/ with it.
+        if [ ! -d "Ragnar/.git" ] && [ "$GIT_WORKS" = true ]; then
+            log "WARNING" "Existing install has no .git (tarball install) — reattaching to upstream"
+            echo -e "${YELLOW}Reattaching this install to the git repository (your files are kept)...${NC}"
+            if git init -q Ragnar 2>/dev/null \
+               && git -C Ragnar remote add origin https://github.com/PierreGode/Ragnar.git 2>/dev/null \
+               && git -C Ragnar fetch --depth=1 origin main 2>/dev/null; then
+                # Mixed reset only: the working tree on disk is left untouched,
+                # so local edits and data files survive as ordinary changes.
+                git -C Ragnar reset -q --mixed FETCH_HEAD 2>/dev/null || true
+                git -C Ragnar branch -q -f main FETCH_HEAD 2>/dev/null || true
+                git -C Ragnar symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+                git -C Ragnar branch -q --set-upstream-to=origin/main main 2>/dev/null || true
+                # Restore only files upstream has that the tarball lacked.
+                git -C Ragnar ls-files -d -z 2>/dev/null \
+                    | xargs -0 -r git -C Ragnar checkout -- 2>/dev/null || true
+                log "SUCCESS" "Reattached existing install to the git repository"
+                echo -e "${GREEN}Reattached — future updates will work.${NC}"
+            else
+                rm -rf Ragnar/.git
+                log "WARNING" "Could not reattach to upstream (network?) — install continues, but updates will not work"
+            fi
+        fi
     else
         # Remove empty/invalid directory if it exists
         if [ -d "Ragnar" ]; then


### PR DESCRIPTION
Re-running install_ragnar.sh on a box with no .git did nothing to fix it. setup_ragnar treats a directory containing actions/ as an existing install and skips the clone, and a tarball install has actions/ — so the one thing a user re-runs the installer to fix was the one thing it would not touch. The box just spent 30+ minutes reinstalling packages and stayed un-updatable.

Reattach in place when the tree exists but .git does not: init, add remote, fetch main, mixed reset so the working tree is untouched, restore only the files the tarball lacked. Same sequence update_ragnar.sh uses.

Deliberately not a re-clone. The branch that would re-clone starts with rm -rf Ragnar, which would delete data/ragnar.db and the rest of the user's data along with it — so repairing in place is the only non-destructive fix. Guarded on GIT_WORKS, and skipped entirely when .git is already present.

Verified on a reproduction: repairs a tarball tree to current main with 0 spurious deletions, keeps a modified tracked file as ' M', leaves untracked local data alone, sets main to track origin/main, and is a no-op on a second run.