### PR TITLE
BLE provisioning: fix the leak behind RegisterApplication AlreadyExists

### DIFF
--- a/ble_provisioning.py
+++ b/ble_provisioning.py
@@ -418,7 +418,51 @@ class BleProvisioningServer:
                 self._ready.set()
                 self._log(f'advertising as {self.providers.local_name} on {self.providers.hci}')
 
+            # One reclaim attempt per object path, so a retry that also fails
+            # reports the error instead of looping.
+            reclaimed = {'app': False, 'adv': False}
+
             def on_error(err, what):
+                # A stale registration left behind by an earlier run keeps the
+                # fixed object path claimed inside BlueZ, and every start then
+                # fails with AlreadyExists until the process restarts. Reclaim
+                # the path once and retry rather than staying broken. This also
+                # heals a box already stuck from the teardown bug above.
+                if 'AlreadyExists' in str(err):
+                    if what == 'RegisterApplication' and not reclaimed['app']:
+                        reclaimed['app'] = True
+                        self._log('GATT application path still registered — '
+                                  'reclaiming it and retrying', 'warning')
+                        try:
+                            self._gatt_manager.UnregisterApplication(app.path)
+                        except Exception:
+                            pass
+                        try:
+                            self._gatt_manager.RegisterApplication(
+                                app.path, {},
+                                reply_handler=lambda: None,
+                                error_handler=lambda e: on_error(e, 'RegisterApplication'),
+                            )
+                            return
+                        except Exception:
+                            pass
+                    elif what == 'RegisterAdvertisement' and not reclaimed['adv']:
+                        reclaimed['adv'] = True
+                        self._log('Advertisement path still registered — '
+                                  'reclaiming it and retrying', 'warning')
+                        try:
+                            self._adv_manager.UnregisterAdvertisement(adv.get_path())
+                        except Exception:
+                            pass
+                        try:
+                            self._adv_manager.RegisterAdvertisement(
+                                adv.get_path(), {},
+                                reply_handler=on_registered,
+                                error_handler=lambda e: on_error(e, 'RegisterAdvertisement'),
+                            )
+                            return
+                        except Exception:
+                            pass
                 self._error = f'{what}: {err}'
                 self._log(self._error, 'error')
                 self._ready.set()
@@ -437,12 +481,24 @@ class BleProvisioningServer:
 
             self._mainloop.run()
 
-            # Clean unregister on the way out.
+            # Clean unregister on the way out — each in its OWN try block.
+            # Sharing one meant a throwing UnregisterAdvertisement skipped
+            # UnregisterApplication entirely, and that throws routinely: BlueZ
+            # releases the advertisement itself on auto-stop, and it was never
+            # registered at all when advertising failed. The GATT application
+            # then stayed registered on the fixed path /one/gode/ragnar/ble, so
+            # every later start failed with
+            #   RegisterApplication: org.bluez.Error.AlreadyExists
+            # until the whole Ragnar process restarted and dropped the D-Bus
+            # connection. Re-advertise after an auto-stop hit this every time.
             try:
                 self._adv_manager.UnregisterAdvertisement(self._adv_path)
+            except Exception as _e:
+                self._log(f'UnregisterAdvertisement: {_e}', 'debug')
+            try:
                 self._gatt_manager.UnregisterApplication(self._app_path)
-            except Exception:
-                pass
+            except Exception as _e:
+                self._log(f'UnregisterApplication: {_e}', 'debug')
             # Free the local D-Bus object paths, or a restart on a new adapter
             # hits "there is already a handler for '/one/gode/ragnar/ble'".
             try:

--- a/docs/ble_provisioning.md
+++ b/docs/ble_provisioning.md
@@ -109,6 +109,18 @@ That is reported as `starting`, distinct from a failure, and the web UI keeps
 polling until it settles — a peripheral in this state is usually a second or
 two from advertising. If it stays there for more than ~20 s, run `doctor`.
 
+**`RegisterApplication: org.bluez.Error.AlreadyExists`.** The GATT application
+and advertisement use fixed D-Bus object paths (`/one/gode/ragnar/ble`), so a
+registration left behind by an earlier run blocks every later start — and it
+used to persist until the whole Ragnar process restarted. Two faults caused it,
+both fixed: teardown ran the advertisement and application unregisters in one
+`try`, so the routine failure of the first (BlueZ releases the advertisement
+itself on **auto-stop**) skipped the second; and restarting the peripheral
+replaced the server object without stopping the old one, orphaning its
+registration. A start that still meets `AlreadyExists` now reclaims the path and
+retries once, so a box already stuck heals itself on the next enable. If you see
+this on an older build, restarting Ragnar clears it.
+
 **Start with `doctor`.** It is the "the toggle does nothing" tool: it checks
 each prerequisite in turn — `python3-dbus` and `python3-gi` importable,
 `bluetoothctl` present, at least one controller found, Bluetooth not

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -160,10 +160,30 @@ def _start_ble_provisioning():
         if not shared_data.config.get('ble_provisioning_enabled', False):
             return False
         import ble_provisioning
+        # Retire any previous peripheral BEFORE building a new one. Overwriting
+        # the reference used to drop a still-registered server on the floor —
+        # its GLib thread and, worse, its BlueZ registration of the fixed path
+        # /one/gode/ragnar/ble survived, so the new server's
+        # RegisterApplication came back org.bluez.Error.AlreadyExists.
+        old = None
         with _ble_lock:
+            if _ble_server is not None:
+                if _ble_server.status().get('running'):
+                    return True
+                old, _ble_server = _ble_server, None
+        if old is not None:
+            # Outside the lock: stop() joins the loop thread and would otherwise
+            # stall the status endpoint the UI polls.
+            try:
+                old.stop()
+            except Exception:
+                pass
+
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        with _ble_lock:
+            # Another caller may have started one while we were stopping.
             if _ble_server is not None and _ble_server.status().get('running'):
                 return True
-            base_dir = os.path.dirname(os.path.abspath(__file__))
             _ble_server = ble_provisioning.build_server(
                 base_dir,
                 get_config=lambda: shared_data.config,


### PR DESCRIPTION
'Enabled, but not advertising: RegisterApplication: org.bluez.Error.AlreadyExists' was permanent once hit — the GATT application and advertisement use fixed D-Bus object paths, so a registration left behind by an earlier run blocked every later start until the Ragnar process restarted and dropped the D-Bus connection.

Two separate leaks produced it, and auto-stop reached the first every time.

Teardown ran both unregisters inside ONE try block:

    self._adv_manager.UnregisterAdvertisement(self._adv_path)
    self._gatt_manager.UnregisterApplication(self._app_path)

UnregisterAdvertisement throws routinely — BlueZ releases the advertisement itself when auto-stop fires, and it was never registered at all when advertising failed — and that skipped UnregisterApplication entirely, leaving /one/gode/ragnar/ble claimed. Re-advertise after an auto-stop then failed every time, which is exactly the reported configuration. Each unregister now gets its own try.

Second, _start_ble_provisioning replaced _ble_server without stopping the previous peripheral whenever it was not 'running', dropping a server whose GLib thread and BlueZ registration were still live. It now retires the old one first, outside the lock so stop()'s thread join cannot stall the status endpoint the UI polls.

A start that still meets AlreadyExists reclaims the path and retries once, so a box already stuck heals on the next enable rather than needing a restart. The reclaim is one-shot per path, so an unrecoverable failure reports the error instead of looping.

Verified on real BlueZ: three consecutive start/stop cycles register cleanly, doctor still passes end to end, teardown calls UnregisterApplication even when UnregisterAdvertisement throws, and the reclaim path registers successfully while a persistent failure surfaces exactly one error.