### PR TITLE
Kiosk: add a doctor, and stop crash-looping against a running X server

### DIFF
--- a/docs/kiosk.md
+++ b/docs/kiosk.md
@@ -86,6 +86,33 @@ reached `active`/`installed`. Two things it is *not*:
 If you still see it, the service exists but is stuck part-way (usually
 `activating`). Check both logs below.
 
+**Start here — `scripts/kiosk_doctor.sh`.** One command that collects every
+answer in the right order, so you are not guessing which log to read:
+
+```bash
+sudo ./scripts/kiosk_doctor.sh
+```
+
+It reports install mode, browser, the whole X stack (including the suid
+`Xorg.wrap` that causes most Pi 5 crash loops), service state and restart
+count, the kiosk unit's journal **filtered to that unit**, and the tail of the
+wrapper and Xorg logs. Output is saved to `/tmp/kiosk_doctor_<timestamp>.log`
+— paste that when reporting a problem.
+
+> Reading the *whole* journal instead is the common wrong turn. `journalctl`
+> without `-u ragnar-kiosk` returns unrelated boot chatter — cloud-init lines
+> like `Completed socket interaction for boot stage final` are not the kiosk.
+> And when the **installer** fails there is no unit at all, so
+> `journalctl -u ragnar-kiosk` is legitimately empty; those failures are logged
+> by Ragnar itself under `[kiosk]`.
+
+**"Cannot establish any listening sockets — Make sure an X server isn't already
+running"** means service mode is trying to start its own X on `:0` while a
+desktop session already owns it. The kiosk has two modes and this box was set
+up in the wrong one: disable the kiosk, then re-enable it **from inside the
+desktop session** so the installer picks autostart mode. The wrapper now
+detects this and says so instead of crash-looping until the start limit trips.
+
 **Logs (on the Pi):**
 - Wrapper log: `/var/log/ragnar/kiosk-wrapper.log` — board, RAM, the
   `input: touchscreen=… keyboard=… osk=…` line, which OSK launched, target URL.

--- a/scripts/install_kiosk.sh
+++ b/scripts/install_kiosk.sh
@@ -290,7 +290,10 @@ StandardError=journal
 Environment=HOME=$KIOSK_HOME
 Environment=RAGNAR_REPO=$REPO_ROOT
 Environment=RAGNAR_BROWSER=$BROWSER_BIN
-ExecStartPre=+/bin/sh -c 'rm -f /tmp/.X0-lock; rm -rf /tmp/.X11-unix/X0'
+# Clear a STALE X lock only. Guarded on no X running, because deleting the lock
+# and socket of a live desktop session would disrupt that session while still
+# leaving our own X unable to bind :0.
+ExecStartPre=+/bin/sh -c 'pgrep -x Xorg >/dev/null 2>&1 || pgrep -x X >/dev/null 2>&1 || { rm -f /tmp/.X0-lock; rm -rf /tmp/.X11-unix/X0; }'
 ExecStart=$WRAPPER_DST
 Restart=on-failure
 # 10s (not 5) so a dying Xorg releases the VT/DRM master before the next start.

--- a/scripts/kiosk_doctor.sh
+++ b/scripts/kiosk_doctor.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Ragnar on-screen kiosk doctor
+#
+# Diagnoses why the kiosk shows nothing. It answers the questions the systemd
+# journal cannot: the real detail lives in the wrapper and Xorg logs, and when
+# the *installer* fails there is no unit at all, so `journalctl -u ragnar-kiosk`
+# is empty and people paste unrelated boot lines instead.
+#
+# Usage:   sudo ./scripts/kiosk_doctor.sh
+#
+# Output is printed AND saved to /tmp/kiosk_doctor_<timestamp>.log
+# Paste the whole log back.
+# ---------------------------------------------------------------------------
+set -u
+
+if [ "$(id -u)" -ne 0 ]; then exec sudo -E bash "$0" "$@"; fi
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+LOG="/tmp/kiosk_doctor_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee "$LOG") 2>&1
+
+SERVICE="ragnar-kiosk.service"
+SERVICE_FILE="/etc/systemd/system/ragnar-kiosk.service"
+WRAPPER="/usr/local/bin/ragnar-kiosk-run"
+LOG_DIR="/var/log/ragnar"
+AUTOSTART_REL=".config/autostart/ragnar-kiosk.desktop"
+CONFIG_JSON="$REPO/config/shared_config.json"
+
+FAILED=0
+section() { echo; echo "===================== $* ====================="; }
+check() {   # check <label> <0|1> [hint]
+    if [ "$2" -eq 0 ]; then
+        echo "  [PASS] $1"
+    else
+        FAILED=$((FAILED + 1))
+        echo "  [FAIL] $1${3:+  -> $3}"
+    fi
+}
+
+echo "Ragnar kiosk doctor — $(date)"
+echo "repo: $REPO"
+
+# ---------------------------------------------------------------------------
+section "1. Install state"
+# ---------------------------------------------------------------------------
+MODE="not_installed"
+AUTOSTART_FOUND=""
+for home in /home/* /root; do
+    [ -f "$home/$AUTOSTART_REL" ] && AUTOSTART_FOUND="$home/$AUTOSTART_REL"
+done
+if [ -n "$AUTOSTART_FOUND" ]; then
+    MODE="autostart"
+elif [ -f "$SERVICE_FILE" ]; then
+    MODE="service"
+fi
+echo "  mode: $MODE"
+[ -n "$AUTOSTART_FOUND" ] && echo "  autostart entry: $AUTOSTART_FOUND"
+
+if [ "$MODE" = "not_installed" ]; then
+    check "Kiosk is installed" 1 "enable it in Config -> Kiosk, or run: sudo bash $REPO/scripts/install_kiosk.sh"
+    echo
+    echo "  Nothing is installed, so there is no unit and 'journalctl -u ragnar-kiosk'"
+    echo "  will be EMPTY. If enabling from the web UI did nothing, the installer"
+    echo "  itself failed — look in the Ragnar log for lines tagged [kiosk]:"
+    echo "      sudo journalctl -u ragnar | grep '\[kiosk\]' | tail -30"
+else
+    check "Kiosk is installed ($MODE mode)" 0
+fi
+
+check "Wrapper present ($WRAPPER)" "$([ -x "$WRAPPER" ] && echo 0 || echo 1)" \
+      "re-run the kiosk installer"
+
+# ---------------------------------------------------------------------------
+section "2. Browser"
+# ---------------------------------------------------------------------------
+BROWSER=""
+for bin in chromium-browser chromium firefox-esr; do
+    if command -v "$bin" >/dev/null 2>&1; then BROWSER="$bin"; break; fi
+done
+if [ -n "$BROWSER" ]; then
+    check "Browser found ($BROWSER)" 0
+    echo "        $("$BROWSER" --version 2>/dev/null | head -1)"
+else
+    check "Browser found" 1 "sudo apt install -y chromium-browser   (or chromium)"
+fi
+
+# ---------------------------------------------------------------------------
+section "3. X stack (service mode only)"
+# ---------------------------------------------------------------------------
+if [ "$MODE" = "service" ]; then
+    check "Xorg present" "$(command -v X >/dev/null 2>&1 && echo 0 || echo 1)" \
+          "sudo apt install -y xserver-xorg xinit"
+    check "xinit present" "$(command -v xinit >/dev/null 2>&1 && echo 0 || echo 1)" \
+          "sudo apt install -y xinit"
+    check "openbox present" "$(command -v openbox >/dev/null 2>&1 && echo 0 || echo 1)" \
+          "sudo apt install -y openbox"
+
+    # The documented Pi 5 / Bookworm crash-loop cause: non-root X needs the
+    # suid wrapper, which only ships with xserver-xorg-legacy.
+    WRAP=""
+    for p in /usr/lib/xorg/Xorg.wrap /usr/libexec/Xorg.wrap; do
+        [ -e "$p" ] && WRAP="$p"
+    done
+    if [ -n "$WRAP" ]; then
+        check "Xorg.wrap present ($WRAP)" 0
+        if [ -u "$WRAP" ]; then
+            check "Xorg.wrap is suid" 0
+        else
+            check "Xorg.wrap is suid" 1 "sudo chmod u+s $WRAP"
+        fi
+    else
+        check "Xorg.wrap present" 1 "sudo apt install -y xserver-xorg-legacy  (the usual Pi 5 / Bookworm crash-loop cause)"
+    fi
+
+    if [ -f /etc/X11/Xwrapper.config ]; then
+        echo "  /etc/X11/Xwrapper.config:"
+        sed 's/^/        /' /etc/X11/Xwrapper.config
+    else
+        check "Xwrapper.config exists" 1 "re-run the kiosk installer (it writes allowed_users=anybody)"
+    fi
+else
+    echo "  (skipped — autostart mode launches inside the existing desktop session)"
+fi
+
+# ---------------------------------------------------------------------------
+section "4. Service state"
+# ---------------------------------------------------------------------------
+if [ "$MODE" = "service" ]; then
+    echo "  is-enabled: $(systemctl is-enabled "$SERVICE" 2>&1)"
+    echo "  is-active : $(systemctl is-active "$SERVICE" 2>&1)"
+    systemctl --no-pager --full status "$SERVICE" 2>&1 | sed 's/^/        /' | head -20
+    STATE="$(systemctl is-active "$SERVICE" 2>/dev/null)"
+    check "Service is active" "$([ "$STATE" = "active" ] && echo 0 || echo 1)" \
+          "see the journal and wrapper log below"
+    # A tripped start limit stays stopped until reset — easy to miss.
+    if systemctl show "$SERVICE" -p NRestarts 2>/dev/null | grep -qv 'NRestarts=0'; then
+        echo "  $(systemctl show "$SERVICE" -p NRestarts 2>/dev/null)"
+        echo "        (if it hit the 5-in-2min cap: sudo systemctl reset-failed $SERVICE)"
+    fi
+else
+    RUNNING=$(pgrep -f 'ragnar-kiosk-chromium' >/dev/null 2>&1 && echo 0 || echo 1)
+    check "Kiosk chromium process running" "$RUNNING" \
+          "log in to the desktop session, or toggle the kiosk off/on in Config"
+fi
+
+# ---------------------------------------------------------------------------
+section "5. Kiosk unit journal (this unit only — no unrelated boot noise)"
+# ---------------------------------------------------------------------------
+if [ -f "$SERVICE_FILE" ]; then
+    journalctl -u "$SERVICE" --no-pager -n 40 2>&1 | sed 's/^/  /'
+else
+    echo "  No unit installed, so this journal does not exist."
+    echo "  Installer failures are logged by Ragnar itself instead:"
+    journalctl -u ragnar --no-pager -n 200 2>/dev/null | grep -i '\[kiosk\]' | tail -20 | sed 's/^/  /' \
+        || echo "  (no [kiosk] lines found in the ragnar unit journal)"
+fi
+
+# ---------------------------------------------------------------------------
+section "6. Wrapper log — where the real detail is"
+# ---------------------------------------------------------------------------
+if [ -f "$LOG_DIR/kiosk-wrapper.log" ]; then
+    echo "  $LOG_DIR/kiosk-wrapper.log (last 40 lines):"
+    tail -40 "$LOG_DIR/kiosk-wrapper.log" | sed 's/^/  /'
+else
+    check "Wrapper log exists ($LOG_DIR/kiosk-wrapper.log)" 1 \
+          "the wrapper never ran — the service failed before ExecStart, see section 5"
+fi
+
+# ---------------------------------------------------------------------------
+section "7. Xorg log (service mode)"
+# ---------------------------------------------------------------------------
+if [ -f "$LOG_DIR/kiosk-Xorg.log" ]; then
+    echo "  errors from $LOG_DIR/kiosk-Xorg.log:"
+    grep -E '\(EE\)|\(WW\).*fail|no screens found' "$LOG_DIR/kiosk-Xorg.log" | tail -20 | sed 's/^/  /' \
+        || echo "  (no (EE) lines — X did not report an error)"
+else
+    echo "  (no Xorg log — either autostart mode, or X never started)"
+fi
+
+# ---------------------------------------------------------------------------
+section "8. Display / session context"
+# ---------------------------------------------------------------------------
+echo "  seats/sessions:"
+loginctl list-sessions --no-pager 2>&1 | sed 's/^/        /'
+echo "  DRM cards: $(ls /dev/dri/card* 2>/dev/null | tr '\n' ' ' || echo 'NONE — no display hardware detected')"
+if [ -z "$(ls /dev/dri/card* 2>/dev/null)" ]; then
+    check "Display hardware present (/dev/dri/card*)" 1 \
+          "headless box: the kiosk needs a real display (HDMI/DSI) attached"
+fi
+echo "  model: $(tr -d '\0' < /proc/device-tree/model 2>/dev/null || echo unknown)"
+echo "  RAM  : $(awk '/^MemTotal:/{printf "%d MB", $2/1024}' /proc/meminfo 2>/dev/null)"
+
+# ---------------------------------------------------------------------------
+section "9. Configured URL"
+# ---------------------------------------------------------------------------
+URL="http://localhost:8000"
+if [ -f "$CONFIG_JSON" ]; then
+    U="$(python3 -c "import json;print(json.load(open('$CONFIG_JSON')).get('kiosk_url',''))" 2>/dev/null)"
+    [ -n "$U" ] && URL="$U"
+fi
+echo "  kiosk_url: $URL"
+if command -v curl >/dev/null 2>&1; then
+    CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$URL" 2>/dev/null)"
+    check "Kiosk URL reachable (HTTP $CODE)" \
+          "$([ "$CODE" = "200" ] || [ "$CODE" = "302" ] && echo 0 || echo 1)" \
+          "chromium will show an error page; is ragnar.service up?"
+fi
+
+# ---------------------------------------------------------------------------
+section "Summary"
+# ---------------------------------------------------------------------------
+if [ "$FAILED" -eq 0 ]; then
+    echo "  No failed checks. If the screen is still blank, the answer is in the"
+    echo "  wrapper log (section 6) or the Xorg log (section 7)."
+else
+    echo "  $FAILED check(s) failed — fix the [FAIL] lines above, then re-run."
+fi
+echo
+echo "Full log saved to: $LOG"
+echo "Paste that file when reporting the problem."
+exit 0

--- a/scripts/ragnar_kiosk_run.sh
+++ b/scripts/ragnar_kiosk_run.sh
@@ -310,6 +310,29 @@ chmod +x "$SESSION_SCRIPT"
 # undebuggable remotely — here we tail the Xorg log on any non-signal exit.
 _kiosk_term() { [[ -n "${XINIT_PID:-}" ]] && kill -TERM "$XINIT_PID" 2>/dev/null || true; }
 trap _kiosk_term TERM INT
+
+# Do not fight an X server that is already running.
+#
+# MODE A above only triggers when DISPLAY / WAYLAND_DISPLAY are set in the
+# environment, and the systemd unit sets neither — so a service-mode run always
+# reaches here and starts its own X on :0. On a box that has a desktop session
+# (installed in service mode, then a desktop added; or session detection failed
+# at install time) that display is already taken, and X dies with
+#   (EE) Cannot establish any listening sockets -
+#        Make sure an X server isn't already running
+# on every restart until the start limit trips. That message never names the
+# actual conflict, so the failure is undebuggable from the journal alone.
+if pgrep -x Xorg >/dev/null 2>&1 || pgrep -x X >/dev/null 2>&1; then
+    echo "[kiosk-run] ERROR: an X server is already running on this box, so the" >&2
+    echo "[kiosk-run] kiosk cannot start its own on :0. This box wants AUTOSTART" >&2
+    echo "[kiosk-run] mode (launch into the existing session), not service mode." >&2
+    echo "[kiosk-run] Fix: disable the kiosk in Config -> Kiosk, then re-enable it" >&2
+    echo "[kiosk-run] from inside the desktop session so the installer picks" >&2
+    echo "[kiosk-run] autostart mode. Running X processes:" >&2
+    pgrep -ax Xorg >&2 2>/dev/null || pgrep -ax X >&2 2>/dev/null || true
+    exit 1
+fi
+
 xinit "$SESSION_SCRIPT" -- /usr/bin/X :0 vt7 -nolisten tcp \
       -auth "$XAUTHORITY" -logfile "$XORG_LOG" -keeptty &
 XINIT_PID=$!


### PR DESCRIPTION
A user reporting 'kiosk still does not work' sent two cloud-init lines ('Completed socket interaction for boot stage final'). That is the expected outcome of the advice we give: the kiosk's real detail lives in the wrapper and Xorg logs, not the journal, and when the installer fails there is no unit at all so journalctl -u ragnar-kiosk is legitimately empty. People then paste whatever the unfiltered journal showed.

Add scripts/kiosk_doctor.sh, matching the existing wifidef_doctor pattern. It collects install mode, browser, the X stack (including the suid Xorg.wrap behind most Pi 5 crash loops), service state and restart count, the journal filtered to the kiosk unit, and the tail of the wrapper and Xorg logs — with the [kiosk] lines from Ragnar's own journal substituted when no unit exists. Saves to /tmp/kiosk_doctor_<timestamp>.log to paste back.

Running it here surfaced a real failure signature in this box's wrapper log:

  (EE) Cannot establish any listening sockets -
       Make sure an X server isn't already running

MODE A (attach to an existing session) only triggers when DISPLAY or WAYLAND_DISPLAY is set in the environment, and the systemd unit sets neither. So a service-mode run always starts its own X on :0 — and on a box that has a desktop session it loses that race on every restart until the start limit trips, with a message that never names the conflict. The wrapper now detects a running X server and reports which mode the box actually needs instead.

The unit's ExecStartPre also removed /tmp/.X0-lock and the X0 socket unconditionally, which would disrupt a live desktop session while still leaving our own X unable to bind :0. Now guarded on no X running, so it only clears a genuinely stale lock.

Verified: all three scripts pass bash -n, the doctor runs end to end on this box (correctly reporting not-installed and surfacing the historical Xorg failure), and both guards were exercised with X present and absent.