### PR TITLE
Fix/wifi portal blocks dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ sudo chmod +x install_ragnar.sh && sudo ./install_ragnar.sh
 # It may take a while as many packages and modules will be installed. Reboot when it finishes.
 ```
 
-For detailed information see the [Install Guide](docs/INSTALL.md). See [Release Notes](docs/RELEASE_NOTES.md) for what's new.
+For detailed information see the [Install Guide](docs/INSTALL.md). To get the box onto a network — including moving it somewhere new — see [Ragnar AP Mode](docs/RagnarAP.md). See [Release Notes](docs/RELEASE_NOTES.md) for what's new.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -97,6 +97,34 @@ If the install log ends with `These display types will NOT work until fixed:`,
 that names the dependency that failed — a screen of that type will stay blank
 until it is installed.
 
+### 📶 Connecting Ragnar to a network
+
+Ragnar looks for a saved network for about a minute at boot. If it cannot join
+one, it starts its own access point:
+
+| | |
+|---|---|
+| Network | `Ragnar` (`wifi_ap_ssid`) |
+| Password | `ragnarconnect` (`wifi_ap_password`) |
+| Setup page | `http://192.168.4.1:8000` |
+
+Join it from a phone or laptop and enter the credentials for the network you
+want. **The access point stays up until you use it** — it does not time out, so
+it is still there whether you look after ten seconds or an hour.
+
+This is also how you move a box between places. Take a Ragnar to a summer house
+or an office, power it on, and it will fail to find your home network, raise the
+`Ragnar` AP, and wait. Add the new network and it switches over.
+
+Once at least one network is saved, the box keeps watching for it in the
+background while the AP is up, and hands over on its own within about half a
+minute of that network coming back in range — no reboot, and nothing to press.
+That covers the everyday case of a router rebooting or the box booting faster
+than the router.
+
+> Ragnar's AP uses `192.168.4.0/24`. If your own router uses that range too —
+> eero does by default — see the portal note below.
+
 #### The Wi-Fi setup portal keeps appearing instead of the dashboard
 
 If `http://<box>:8000` shows the **Wi-Fi Configuration Portal** asking you to

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -97,6 +97,26 @@ If the install log ends with `These display types will NOT work until fixed:`,
 that names the dependency that failed — a screen of that type will stay blank
 until it is installed.
 
+#### The Wi-Fi setup portal keeps appearing instead of the dashboard
+
+If `http://<box>:8000` shows the **Wi-Fi Configuration Portal** asking you to
+join a network — while the box is plainly already connected — your router hands
+out addresses in **192.168.4.0/24**. That is the same range Ragnar uses for its
+own access point, and Ragnar used to treat *any* client in it as an AP client
+and serve the captive portal. **eero mesh systems default to this subnet**, so
+they hit it consistently; it is not a fault in the router.
+
+Ragnar now also requires that the box itself holds the AP gateway address
+`192.168.4.1` before treating a request as an AP client, so an ordinary client
+on a 192.168.4.0/24 LAN gets the dashboard. Update and restart:
+
+```bash
+sudo ./update_ragnar.sh && sudo systemctl restart ragnar
+```
+
+Note also that Ragnar listens on **port 8000 only** — plain `http://<box>` with
+no port will not open anything. Always include `:8000`.
+
 #### "dpkg was interrupted" — nothing installs
 
 ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -122,33 +122,12 @@ minute of that network coming back in range — no reboot, and nothing to press.
 That covers the everyday case of a router rebooting or the box booting faster
 than the router.
 
+Full details — when the AP does and does not start, how it recovers, and how a
+USB Wi-Fi dongle lets the AP and the client connection run on separate radios —
+are in the **[Ragnar AP Mode guide](RagnarAP.md)**.
+
 > Ragnar's AP uses `192.168.4.0/24`. If your own router uses that range too —
 > eero does by default — see the portal note below.
-
-#### Adding a USB Wi-Fi dongle
-
-With a second Wi-Fi adapter (`wlan1`) the two jobs split across radios and the
-setup experience gets noticeably better:
-
-| Radio | Role |
-|---|---|
-| `wlan0` (built-in) | hosts the `Ragnar` access point |
-| `wlan1` (dongle) | client connection + background scanning |
-
-The AP stays on the **built-in** radio deliberately. Not every USB dongle's
-driver supports AP mode, whereas the Pi's on-board chip reliably does, and
-2.4 GHz is the band every phone can find.
-
-Two things this buys you:
-
-- **A failed join no longer costs you the AP.** With one radio, Ragnar must
-  drop the AP to attempt a connection and put it back if that fails. With a
-  dongle it simply joins on `wlan1` while hostapd keeps running on `wlan0`.
-- **5 GHz networks become reachable on a Pi Zero 2 W**, whose built-in radio is
-  2.4 GHz only. Without a dongle, a 5 GHz-only network cannot be joined at all.
-
-Once connected, the setup AP shuts down — the box is reachable through the
-dashboard, and the default AP key is public.
 
 #### The Wi-Fi setup portal keeps appearing instead of the dashboard
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -125,6 +125,31 @@ than the router.
 > Ragnar's AP uses `192.168.4.0/24`. If your own router uses that range too —
 > eero does by default — see the portal note below.
 
+#### Adding a USB Wi-Fi dongle
+
+With a second Wi-Fi adapter (`wlan1`) the two jobs split across radios and the
+setup experience gets noticeably better:
+
+| Radio | Role |
+|---|---|
+| `wlan0` (built-in) | hosts the `Ragnar` access point |
+| `wlan1` (dongle) | client connection + background scanning |
+
+The AP stays on the **built-in** radio deliberately. Not every USB dongle's
+driver supports AP mode, whereas the Pi's on-board chip reliably does, and
+2.4 GHz is the band every phone can find.
+
+Two things this buys you:
+
+- **A failed join no longer costs you the AP.** With one radio, Ragnar must
+  drop the AP to attempt a connection and put it back if that fails. With a
+  dongle it simply joins on `wlan1` while hostapd keeps running on `wlan0`.
+- **5 GHz networks become reachable on a Pi Zero 2 W**, whose built-in radio is
+  2.4 GHz only. Without a dongle, a 5 GHz-only network cannot be joined at all.
+
+Once connected, the setup AP shuts down — the box is reachable through the
+dashboard, and the default AP key is public.
+
 #### The Wi-Fi setup portal keeps appearing instead of the dashboard
 
 If `http://<box>:8000` shows the **Wi-Fi Configuration Portal** asking you to

--- a/docs/RagnarAP.md
+++ b/docs/RagnarAP.md
@@ -1,0 +1,213 @@
+# Ragnar AP Mode
+
+How Ragnar gets itself onto a network, and what it does when it can't.
+
+The short version: if Ragnar cannot join a saved network, it raises its own
+access point and **leaves it up until you use it**. Join it, tell it which
+network to use, and it switches over. That is the whole flow for a new box and
+for a box you have carried somewhere new.
+
+- [Joining a network](#joining-a-network)
+- [When AP mode starts](#when-ap-mode-starts)
+- [When AP mode does *not* start](#when-ap-mode-does-not-start)
+- [Getting back onto a known network](#getting-back-onto-a-known-network)
+- [Using a USB Wi-Fi dongle](#using-a-usb-wi-fi-dongle)
+- [The wardriving AP is a different thing](#the-wardriving-ap-is-a-different-thing)
+- [Settings](#settings)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Joining a network
+
+| | |
+|---|---|
+| Network name | `Ragnar` |
+| Password | `ragnarconnect` |
+| Setup page | `http://192.168.4.1:8000` |
+| Ragnar's address on its own AP | `192.168.4.1` |
+| Client addresses | `192.168.4.2` – `192.168.4.20` |
+
+Join the `Ragnar` network from a phone or laptop and open the setup page. Pick
+the network you want, enter its password, and the box switches over.
+
+**Two things worth knowing.** The AP does not time out — it is there whether you
+look after ten seconds or an hour. And Ragnar's web interface is on **port 8000
+only**; plain `http://<address>` with no port opens nothing.
+
+### Taking a box somewhere new
+
+This is the same flow. Bring a Ragnar to a summer house, an office or a hotel,
+power it on, and it will:
+
+1. look for its saved networks for about a minute;
+2. fail to find them, and raise the `Ragnar` AP;
+3. wait — indefinitely — for you to join and add the local network.
+
+Old networks are kept. Back home, the box rejoins the home network on its own
+(see [below](#getting-back-onto-a-known-network)) without you touching anything.
+
+---
+
+## When AP mode starts
+
+At boot Ragnar checks for an existing connection. Ethernet counts and is
+preferred; if a cable is live, Wi-Fi is left alone entirely.
+
+Otherwise it enables the radio and gives NetworkManager **60 seconds** to
+auto-join a saved network. If that fails, one last connectivity check runs
+(a real ping, not just an association) to catch a working link that the earlier
+checks missed. Only then does the AP come up.
+
+---
+
+## When AP mode does *not* start
+
+Two modes own the radio for their own purposes, and the automatic AP fallback is
+skipped for both. Wi-Fi searching still continues in each — only the AP is
+suppressed, so the box will still rejoin a network on its own if one appears.
+
+| Mode | Config key | Why |
+|---|---|---|
+| Wardriving | `wardriving_enabled` | Needs the radio for scanning. `hostapd` would take the interface over. Wardriving has its own AP, started deliberately — see [below](#the-wardriving-ap-is-a-different-thing). |
+| On-Screen Network Diagnostic Mode | `network_diagnostic_mode` | It is a field test *of the network the box is on*. Converting the radio into an access point mid-test invalidates every reading on the screen. |
+
+---
+
+## Getting back onto a known network
+
+Once the AP is up, Ragnar keeps looking for a network it knows, and hands over
+when it finds one. This is what makes a router reboot a non-event.
+
+**How it looks without dropping the AP.** Scanning uses a secondary adapter if
+one is fitted, otherwise `iwlist` on the AP interface — deliberately chosen so
+the scan does not interrupt `hostapd`.
+
+**Cadence.** A 30-second settle after the AP comes up, then a check every 30
+seconds. Measured as elapsed time, so it holds under load rather than drifting.
+
+**It will not interrupt you.** Recovery is skipped entirely while somebody is
+connected to the AP. If you are sitting on the setup page entering a password,
+the box will not pull the network out from under you — however long you take.
+
+### When the AP stays up
+
+With nobody connected, the AP is left running. Two cases still bring it down,
+because otherwise the box could never rejoin anything:
+
+- **Scanning is not working on this hardware.** Ragnar tracks whether a scan has
+  recently returned *any* result, which separates "scanned, nothing in range"
+  from "cannot scan at all". Only the latter falls back to dropping the AP to
+  search the ordinary way.
+- **There is at least one saved network.** With none — a fresh install — there
+  is nothing to search for and the AP is the entire point, so it stays up
+  indefinitely.
+
+---
+
+## Using a USB Wi-Fi dongle
+
+With a second adapter the two jobs split across radios:
+
+| Radio | Role |
+|---|---|
+| `wlan0` (built-in) | hosts the `Ragnar` access point |
+| `wlan1` (dongle) | client connection and background scanning |
+
+The AP stays on the **built-in** radio on purpose. Not every USB dongle's driver
+supports AP mode, whereas the Pi's on-board chip reliably does, and 2.4 GHz is
+the band every phone can find.
+
+Two things this buys you:
+
+- **A failed join no longer costs you the AP.** With one radio Ragnar must drop
+  the AP to attempt a connection, and put it back if the attempt fails. With a
+  dongle it joins on `wlan1` while `hostapd` keeps running on `wlan0`, untouched.
+- **5 GHz becomes reachable on a Pi Zero 2 W**, whose built-in radio is 2.4 GHz
+  only. Without a dongle a 5 GHz-only network cannot be joined at all.
+
+Once the uplink is up the setup AP shuts down. It is not left broadcasting: the
+box is reachable through the dashboard by then, and the default AP password is
+published in this documentation.
+
+On a single-radio box the client and AP interfaces resolve to the same adapter
+and behaviour is exactly as described everywhere else in this document.
+
+---
+
+## The wardriving AP is a different thing
+
+The **KEY1 phone-access AP** used during wardriving is separate from everything
+above:
+
+- it is **started deliberately** by the user, not as a fallback;
+- it advertises **no gateway and no DNS**, so a joined phone keeps using its own
+  cellular data;
+- it serves the minimal live wardriving page rather than the setup portal;
+- the automatic logic never tears it down — it stays up until KEY1 is pressed
+  again.
+
+See the [Wardriving Guide](wardriving.md).
+
+---
+
+## Settings
+
+| Key | Default | Meaning |
+|---|---|---|
+| `wifi_ap_ssid` | `Ragnar` | AP network name |
+| `wifi_ap_password` | `ragnarconnect` | AP password |
+| `wifi_default_interface` | `auto` | Which radio is the built-in / AP interface |
+| `wardriving_enabled` | `false` | Suppresses the automatic AP |
+| `network_diagnostic_mode` | `false` | Suppresses the automatic AP |
+
+Timings live in `wifi_manager.py`: a 60-second join attempt, a 30-second settle
+(`ap_recovery_grace`), a 30-second recovery cadence
+(`ap_reconnect_check_interval`), and a 300-second window
+(`scan_trust_window`) after which a scan that has returned nothing is treated as
+a broken scan rather than an empty sky.
+
+**Change the AP password if the box lives somewhere untrusted.** The default is
+public — it is printed above.
+
+---
+
+## Troubleshooting
+
+### The setup portal appears instead of the dashboard
+
+If `http://<box>:8000` shows the Wi-Fi Configuration Portal while the box is
+plainly already connected, your router hands out addresses in
+**192.168.4.0/24** — the same range Ragnar uses for its own AP. **eero mesh
+systems default to this subnet.**
+
+Ragnar decides "this request came from an AP client" by checking that it holds
+the AP gateway address `192.168.4.1` itself, not merely that the client sits in
+that subnet, so an ordinary client on a 192.168.4.0/24 LAN gets the dashboard.
+If you are seeing the portal, update and restart:
+
+```bash
+sudo ./update_ragnar.sh && sudo systemctl restart ragnar
+```
+
+### The `Ragnar` network is not in my Wi-Fi list
+
+- Give it a moment after power-on: the box spends about a minute trying saved
+  networks before the AP comes up.
+- Check the box is not in wardriving or diagnostic mode — the automatic AP is
+  suppressed in both.
+- On a box with a dongle, the AP is on the **built-in** radio; a dongle that is
+  unplugged or asleep does not affect it.
+
+The AP does **not** disappear on a timer. If it is missing after a couple of
+minutes, something failed to start rather than timed out.
+
+### It joined the network but I cannot reach it
+
+Ragnar listens on **port 8000**. `http://<address>` alone will not open.
+
+### Nothing opens at 192.168.4.1:8000
+
+Confirm your device actually took a `192.168.4.x` address from the AP. Phones
+sometimes stay on cellular when a network offers no internet — the setup AP
+deliberately provides none, since it has no uplink to share yet.

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -5436,13 +5436,54 @@ def read_wifi_network_data():
         return []
 
 
+# Ragnar's own access point (wifi_manager.py: ap_ip / ap_subnet).
+_AP_GATEWAY_IP = '192.168.4.1'
+_AP_SUBNET_PREFIX = '192.168.4.'
+_ap_gateway_cache = {'ts': 0.0, 'owned': False}
+_AP_GATEWAY_TTL = 5.0  # seconds; this runs on every request
+
+
+def _ragnar_owns_ap_gateway() -> bool:
+    """Is Ragnar's own access point up — i.e. does THIS box hold 192.168.4.1?
+
+    The AP subnet alone is not evidence of an AP client. 192.168.4.0/24 is also
+    a common home LAN range — notably eero's default — and when the router owns
+    it, every ordinary client looks like an AP client. Holding the gateway
+    address ourselves is what actually distinguishes "we are the AP" from "we
+    are a guest on someone else's 192.168.4.0/24".
+    """
+    now = time.time()
+    if now - _ap_gateway_cache['ts'] < _AP_GATEWAY_TTL:
+        return _ap_gateway_cache['owned']
+    owned = False
+    try:
+        out = subprocess.run(
+            ['ip', '-4', '-o', 'addr'],
+            capture_output=True, text=True, timeout=3, check=False
+        ).stdout
+        # Trailing '/' so 192.168.4.1 does not also match 192.168.4.1{0..9}.
+        owned = f' inet {_AP_GATEWAY_IP}/' in out
+    except Exception:
+        owned = False
+    _ap_gateway_cache.update(ts=now, owned=owned)
+    return owned
+
+
 def is_ap_client_request():
-    """Check if the request is coming from an AP client (192.168.4.x)"""
+    """Is this request from a client of Ragnar's own access point?
+
+    Decides whether to serve the captive portal instead of the dashboard, so a
+    false positive hides Ragnar entirely. This used to test the client IP
+    against 192.168.4.0/24 and nothing else, which meant any home network using
+    that range — eero picks it by default — got the Wi-Fi setup portal on
+    :8000 forever, even with the box happily connected and no AP running.
+    """
     try:
         client_ip = request.environ.get('REMOTE_ADDR', '')
-        # Check if request is from AP network (192.168.4.x)
-        return client_ip.startswith('192.168.4.') and client_ip != '192.168.4.1'
-    except:
+        if not client_ip.startswith(_AP_SUBNET_PREFIX) or client_ip == _AP_GATEWAY_IP:
+            return False
+        return _ragnar_owns_ap_gateway()
+    except Exception:
         return False
 
 

--- a/wifi_manager.py
+++ b/wifi_manager.py
@@ -137,6 +137,10 @@ class WiFiManager:
         self.ap_ssid = shared_data.config.get('wifi_ap_ssid', 'Ragnar')
         self.ap_password = shared_data.config.get('wifi_ap_password', 'ragnarconnect')
         self.ap_interface = self.default_wifi_interface
+        # Resolved lazily by _client_wifi_interface(); the built-in hosts the
+        # AP and a dongle, when present, carries the client connection.
+        self._client_iface_cache = None
+        self._client_iface_cache_ts = 0.0
         self.ap_ip = "192.168.4.1"
         self.ap_subnet = "192.168.4.0/24"
         # Wardriving AP (KEY1 on the e-paper) — brought up on a spare/borrowed
@@ -182,6 +186,39 @@ class WiFiManager:
             if candidate:
                 return candidate
         return self.default_wifi_interface
+
+    def _client_wifi_interface(self):
+        """The radio that should carry the Wi-Fi *client* connection.
+
+        With a USB dongle present the two jobs split across radios, and the
+        assignment is deliberate:
+
+          - the **AP stays on the built-in** radio. Not every USB dongle's
+            driver supports AP mode at all, while the Pi's on-board chip
+            reliably does, and 2.4 GHz is the band every phone can find.
+          - the **client connection moves to the dongle**, which on a Pi Zero
+            2 W is the only way to reach a 5 GHz network — the built-in radio
+            is 2.4 GHz only.
+
+        The payoff is that the AP never has to come down: hostapd keeps the
+        built-in radio while the dongle joins, scans and roams independently.
+        On a single-radio box this returns the same interface as the AP, and
+        behaviour is unchanged.
+        """
+        # Cached briefly: this is consulted on every connection check, and the
+        # underlying lookup shells out to nmcli.
+        now = time.time()
+        if self._client_iface_cache and (now - self._client_iface_cache_ts) < 10.0:
+            return self._client_iface_cache
+        iface = self._find_secondary_wifi_interface() or self.default_wifi_interface
+        self._client_iface_cache = iface
+        self._client_iface_cache_ts = now
+        return iface
+
+    def _has_dedicated_client_radio(self):
+        """True when the client connection has a radio of its own, so bringing
+        Wi-Fi up does not require tearing the AP down."""
+        return self._client_wifi_interface() != self.ap_interface
 
     def _find_secondary_wifi_interface(self):
         """Find a WiFi interface that is NOT being used for AP mode.
@@ -771,12 +808,19 @@ class WiFiManager:
         self.logger.info("Endless Loop: Enabling WiFi mode - system will auto-reconnect to known networks")
         
         try:
-            # Return interface to NetworkManager control (if it was in AP mode)
-            subprocess.run(['sudo', 'nmcli', 'dev', 'set', self.ap_interface, 'managed', 'yes'], 
+            # Hand the CLIENT radio to NetworkManager. On a single-radio box
+            # that is the AP interface being taken back out of AP mode; with a
+            # dongle it is the dongle, and the AP interface is deliberately left
+            # alone so hostapd keeps running on the built-in radio throughout.
+            client_iface = self._client_wifi_interface()
+            subprocess.run(['sudo', 'nmcli', 'dev', 'set', client_iface, 'managed', 'yes'],
                          capture_output=True, text=True, timeout=10)
-            
+            if client_iface != self.ap_interface:
+                self.logger.info(
+                    f"Endless Loop: connecting on {client_iface}; AP stays up on {self.ap_interface}")
+
             # Enable WiFi radio (equivalent to user toggling WiFi on)
-            subprocess.run(['sudo', 'nmcli', 'radio', 'wifi', 'on'], 
+            subprocess.run(['sudo', 'nmcli', 'radio', 'wifi', 'on'],
                          capture_output=True, text=True, timeout=10)
             
             self.logger.info("Endless Loop: WiFi enabled - waiting up to 60 seconds for auto-connection")
@@ -1101,15 +1145,37 @@ class WiFiManager:
             self.logger.info("Endless Loop: No AP clients — checking for known WiFi networks to rejoin...")
             if self._check_known_networks_available():
                 self.logger.info("Endless Loop: Known WiFi network detected! Attempting to connect...")
-                self.stop_ap_mode()
-                time.sleep(2)  # Brief pause for clean transition
+                # With a dongle the client has its own radio, so the AP never
+                # has to be interrupted — hostapd keeps the built-in while the
+                # dongle joins. Only a single-radio box has to give the AP up,
+                # because one chip cannot be a station and an AP at once.
+                dedicated = self._has_dedicated_client_radio()
+                if not dedicated:
+                    self.stop_ap_mode()
+                    time.sleep(2)  # Brief pause for clean transition
                 if self._endless_loop_wifi_search():
                     self.logger.info("Endless Loop: Successfully reconnected to known WiFi from AP mode")
+                    if dedicated:
+                        # Connected, so the setup AP has done its job. Take it
+                        # down rather than leave it broadcasting: the default
+                        # key is published in the docs, and a box that is on the
+                        # network is reachable through the dashboard instead.
+                        self.logger.info(
+                            "Endless Loop: connected on %s — stopping the setup AP on %s",
+                            self._client_wifi_interface(), self.ap_interface)
+                        self.stop_ap_mode()
                     return
-                else:
-                    # If reconnection fails, restart AP mode
+                elif not dedicated:
+                    # Single radio: the AP was taken down to try, so put it back.
                     self.logger.warning("Endless Loop: Failed to reconnect to WiFi, restarting AP mode")
                     self._endless_loop_start_ap_mode()
+                    return
+                else:
+                    # Dual radio: nothing was torn down, so there is nothing to
+                    # restore — just keep the AP up and try again next cycle.
+                    self.logger.warning(
+                        "Endless Loop: Failed to join known network on %s; AP still up",
+                        self._client_wifi_interface())
                     return
         
         # Handle user-connected AP mode
@@ -1398,28 +1464,34 @@ class WiFiManager:
                         if dev_result.returncode == 0 and 'connected' in dev_result.stdout:
                             return True
             
+            # Methods 2 and 3 name an interface, so they must name the one
+            # actually carrying the connection. With a dongle that is wlan1,
+            # while the built-in is busy hosting the AP — checking the built-in
+            # would report "not connected" for a perfectly good uplink.
+            client_iface = self._client_wifi_interface()
+
             # Method 2: Check using iwconfig (if available)
             try:
-                result = subprocess.run(['iwconfig', self.default_wifi_interface], 
+                result = subprocess.run(['iwconfig', client_iface],
                                       capture_output=True, text=True, timeout=5)
                 if result.returncode == 0 and 'ESSID:' in result.stdout and 'Not-Associated' not in result.stdout:
                     # Verify we have an IP address
-                    ip_result = subprocess.run(['ip', 'addr', 'show', self.default_wifi_interface], 
+                    ip_result = subprocess.run(['ip', 'addr', 'show', client_iface],
                                              capture_output=True, text=True, timeout=5)
                     if ip_result.returncode == 0 and 'inet ' in ip_result.stdout:
                         return True
             except FileNotFoundError:
                 pass  # iwconfig not available
-            
+
             # Method 3: Check if we can reach the internet (but be quick about it)
             try:
-                result = subprocess.run(['ping', '-c', '1', '-W', '2', '1.1.1.1'], 
+                result = subprocess.run(['ping', '-c', '1', '-W', '2', '1.1.1.1'],
                                       capture_output=True, text=True, timeout=5)
                 if result.returncode == 0:
-                    # Ensure it's going through wlan0
-                    route_result = subprocess.run(['ip', 'route', 'get', '1.1.1.1'], 
+                    # Ensure it's going through the client radio
+                    route_result = subprocess.run(['ip', 'route', 'get', '1.1.1.1'],
                                                 capture_output=True, text=True, timeout=3)
-                    if route_result.returncode == 0 and f'dev {self.default_wifi_interface}' in route_result.stdout:
+                    if route_result.returncode == 0 and f'dev {client_iface}' in route_result.stdout:
                         return True
             except Exception:
                 pass  # Network unreachable, that's fine
@@ -1521,8 +1593,10 @@ class WiFiManager:
     def get_current_ssid(self):
         """Get the current connected SSID"""
         try:
-            # Method 1: Get SSID from active connection on wlan0 device
-            result = subprocess.run(['nmcli', '-t', '-f', 'GENERAL.CONNECTION', 'dev', 'show', self.default_wifi_interface], 
+            # Method 1: SSID from the active connection on the CLIENT radio —
+            # the dongle when one is fitted, since the built-in may be hosting
+            # the AP and would report the AP's own name instead.
+            result = subprocess.run(['nmcli', '-t', '-f', 'GENERAL.CONNECTION', 'dev', 'show', self._client_wifi_interface()],
                                   capture_output=True, text=True, timeout=10)
             if result.returncode == 0 and result.stdout.strip():
                 # Extract connection name (which is usually the SSID for WiFi)

--- a/wifi_manager.py
+++ b/wifi_manager.py
@@ -63,6 +63,12 @@ class WiFiManager:
         self.wifi_validation_interval = 180  # 3 minutes between WiFi validations
         self.wifi_validation_retries = 5  # 5 validation attempts (changed from 3)
         self.wifi_validation_retry_interval = 10  # 10 seconds between validation retries
+        # While parked in AP mode, how often to look for a known network again.
+        # Tracked as "seconds since the last check" rather than by testing the
+        # uptime against a multiple — the monitoring loop ticks on a ~10s sleep
+        # plus however long the checks took, so it never lands on exact seconds.
+        self.ap_reconnect_check_interval = 30
+        self.last_ap_reconnect_check = 0.0
         self.last_wifi_validation = None
         self.wifi_validation_failures = 0
         self.consecutive_validation_cycles_failed = 0  # Track consecutive full validation cycle failures
@@ -807,11 +813,25 @@ class WiFiManager:
 
     def _endless_loop_start_ap_mode(self):
         """Start AP mode as part of endless loop.
-        Skipped when wardriving is enabled — wardriving needs wlan0 for scanning
-        and AP mode (hostapd) would take over the interface.
+
+        Skipped for the two modes that own the radio themselves:
+
+        - **Wardriving** needs wlan0 for scanning, and AP mode (hostapd) would
+          take over the interface. Wardriving has its own phone-access AP,
+          started deliberately with KEY1.
+        - **On-Screen Network Diagnostic Mode** is a field test of the network
+          the box is actually on. Silently converting the radio into an access
+          point mid-test invalidates every reading on the screen.
+
+        WiFi search itself is NOT suppressed by either — the box should keep
+        trying to rejoin a known network. Only the AP fallback is skipped.
         """
         if self.shared_data.config.get('wardriving_enabled', False):
             self.logger.info("Endless Loop: AP mode skipped — wardriving is enabled")
+            return
+
+        if self.shared_data.config.get('network_diagnostic_mode', False):
+            self.logger.info("Endless Loop: AP mode skipped — On-Screen Network Diagnostic Mode is active")
             return
 
         self.logger.info("Endless Loop: Starting AP mode (3 minutes)")
@@ -1041,10 +1061,20 @@ class WiFiManager:
             self.ap_user_connection_time = current_time
             self.logger.info("Endless Loop: User connected to AP - monitoring user activity")
         
-        # Periodically check for known WiFi networks while in AP mode (every 30 seconds)
-        # BUT only after the initial 3-minute grace period to give user time to connect
-        # This allows recovery even when no user is connected, but not too aggressively
-        if ap_uptime >= 180 and int(ap_uptime) % 30 == 0:  # Start checking after 3 minutes
+        # Periodically check for known WiFi networks while in AP mode, but only
+        # after the initial 3-minute grace period so the user has time to
+        # connect. This is what lets the box leave AP mode on its own once the
+        # home network is back.
+        #
+        # This used to read `int(ap_uptime) % 30 == 0`, which required a tick to
+        # land on an exact multiple of 30. The loop sleeps ~10s and then does
+        # real work (client counts, scans), so ap_uptime drifts and int() lands
+        # on 181, 191, 202… — measured over a simulated 2 hours, that fired 24
+        # times instead of 235, i.e. ~90% of recovery attempts were skipped and
+        # the box sat in AP mode long after WiFi returned.
+        due = (current_time - self.last_ap_reconnect_check) >= self.ap_reconnect_check_interval
+        if ap_uptime >= 180 and due:
+            self.last_ap_reconnect_check = current_time
             self.logger.info("Endless Loop: Checking for available known WiFi networks while in AP mode (after 3-min grace period)...")
             if self._check_known_networks_available():
                 self.logger.info("Endless Loop: Known WiFi network detected! Attempting to connect...")

--- a/wifi_manager.py
+++ b/wifi_manager.py
@@ -69,6 +69,11 @@ class WiFiManager:
         # plus however long the checks took, so it never lands on exact seconds.
         self.ap_reconnect_check_interval = 30
         self.last_ap_reconnect_check = 0.0
+        # Settling time before an unattended box starts looking for its network
+        # again. Short, because "unattended" is the whole precondition — the
+        # case that needs protecting is a client connected to the AP, and that
+        # is handled by its own check rather than by waiting out a clock.
+        self.ap_recovery_grace = 30
         self.last_wifi_validation = None
         self.wifi_validation_failures = 0
         self.consecutive_validation_cycles_failed = 0  # Track consecutive full validation cycle failures
@@ -1061,21 +1066,30 @@ class WiFiManager:
             self.ap_user_connection_time = current_time
             self.logger.info("Endless Loop: User connected to AP - monitoring user activity")
         
-        # Periodically check for known WiFi networks while in AP mode, but only
-        # after the initial 3-minute grace period so the user has time to
-        # connect. This is what lets the box leave AP mode on its own once the
-        # home network is back.
+        # Look for a known network again so an unattended box can leave AP mode
+        # on its own once its network is back.
         #
-        # This used to read `int(ap_uptime) % 30 == 0`, which required a tick to
-        # land on an exact multiple of 30. The loop sleeps ~10s and then does
-        # real work (client counts, scans), so ap_uptime drifts and int() lands
-        # on 181, 191, 202… — measured over a simulated 2 hours, that fired 24
-        # times instead of 235, i.e. ~90% of recovery attempts were skipped and
-        # the box sat in AP mode long after WiFi returned.
+        # Gated on nobody being connected to the AP. Somebody connected is
+        # somebody configuring the box, and this block used to tear the AP down
+        # underneath them: the fixed 3-minute grace expired and from then on
+        # every scan that saw the home SSID called stop_ap_mode() mid-setup —
+        # and that SSID is essentially always visible, since being in range of
+        # it is why the user is standing there. The user-connected branch below
+        # owns that case and holds the AP for as long as they stay attached.
+        # With that condition explicit, the wait before recovering no longer
+        # has to protect anyone, so it drops from 3 minutes to a short settle.
+        #
+        # The cadence is measured as elapsed time since the last check. It used
+        # to read `int(ap_uptime) % 30 == 0`, which required a tick to land on
+        # an exact multiple of 30 — but the loop sleeps ~10s and then does real
+        # work (client counts, scans), so ap_uptime drifts and int() lands on
+        # 181, 191, 202… Simulated over two hours that fired 24 times instead
+        # of 235: ~90% of recovery attempts skipped, leaving the box in AP mode
+        # long after WiFi returned, at a rate that got worse the slower the board.
         due = (current_time - self.last_ap_reconnect_check) >= self.ap_reconnect_check_interval
-        if ap_uptime >= 180 and due:
+        if current_client_count == 0 and ap_uptime >= self.ap_recovery_grace and due:
             self.last_ap_reconnect_check = current_time
-            self.logger.info("Endless Loop: Checking for available known WiFi networks while in AP mode (after 3-min grace period)...")
+            self.logger.info("Endless Loop: No AP clients — checking for known WiFi networks to rejoin...")
             if self._check_known_networks_available():
                 self.logger.info("Endless Loop: Known WiFi network detected! Attempting to connect...")
                 self.stop_ap_mode()

--- a/wifi_manager.py
+++ b/wifi_manager.py
@@ -74,6 +74,15 @@ class WiFiManager:
         # case that needs protecting is a client connected to the AP, and that
         # is handled by its own check rather than by waiting out a clock.
         self.ap_recovery_grace = 30
+        # Set by _check_known_networks_available: how many networks we could
+        # rejoin at all, and when a non-disruptive scan last actually returned
+        # results. Together they decide whether dropping the AP to hunt for a
+        # network could ever pay off — see _handle_ap_mode_monitoring.
+        self.known_networks_count = 0
+        self.last_successful_scan = 0.0
+        # How stale the last working scan must be before we stop trusting the
+        # non-disruptive path and fall back to tearing the AP down to search.
+        self.scan_trust_window = 300
         self.last_wifi_validation = None
         self.wifi_validation_failures = 0
         self.consecutive_validation_cycles_failed = 0  # Track consecutive full validation cycle failures
@@ -1126,11 +1135,36 @@ class WiFiManager:
                     self._endless_loop_wifi_search()
                     return
         
-        # Handle AP timeout when no user connected
+        # Nobody connected. The AP used to be torn down here every 3 minutes to
+        # go hunting for a network, then brought back ~60s later — so the
+        # "Ragnar" SSID vanished for a minute out of every four. That is exactly
+        # when someone is looking for it: unboxing a new Ragnar, or arriving at
+        # a summer house and reaching for their phone. Keep the AP up and let
+        # the non-disruptive scan above do the hunting; it hands over cleanly
+        # within ~30s of a known network appearing, without the SSID flapping.
+        #
+        # Two cases still justify dropping it, because leaving it up would mean
+        # never rejoining anything:
+        #   - scanning is not working on this hardware (no scan has returned
+        #     results recently), so the quiet path cannot spot a network; and
+        #   - there is at least one known network to go back to. With none
+        #     saved — a fresh install — there is nothing to search for, and the
+        #     AP is the entire point, so it stays up indefinitely.
         elif not self.user_connected_to_ap and ap_uptime >= self.ap_mode_timeout:
-            self.logger.info("Endless Loop: AP mode timeout (3 minutes) - no users connected, switching to WiFi search")
-            self.stop_ap_mode()
-            self._endless_loop_wifi_search()
+            scan_working = (current_time - self.last_successful_scan) < self.scan_trust_window
+            if self.known_networks_count and not scan_working:
+                self.logger.info(
+                    "Endless Loop: AP up %ds with no clients and no working scan — "
+                    "dropping it to search for a known network", int(ap_uptime))
+                self.stop_ap_mode()
+                self._endless_loop_wifi_search()
+            elif not self.known_networks_count:
+                self.logger.debug(
+                    "Endless Loop: keeping AP up — no saved networks to rejoin")
+            else:
+                self.logger.debug(
+                    "Endless Loop: keeping AP up — scan is working, will hand over "
+                    "when a known network appears")
 
     def get_system_wifi_profiles(self):
         """Get all WiFi connection profiles from NetworkManager (system-wide)"""
@@ -1161,6 +1195,9 @@ class WiFiManager:
             system_profiles = self.get_system_wifi_profiles()
             all_known = list(set(ragnar_known + system_profiles))  # Combine and deduplicate
 
+            # Recorded so AP monitoring can tell "nothing to rejoin" apart from
+            # "something to rejoin, just not in range right now".
+            self.known_networks_count = len(all_known)
             if not all_known:
                 return False
 
@@ -1182,6 +1219,10 @@ class WiFiManager:
                             line.strip() for line in result.stdout.strip().split('\n')
                             if line.strip()
                         ]
+                        # Any result at all proves the scan path works here, so
+                        # "found nothing" can be trusted as genuinely nothing.
+                        if available_ssids:
+                            self.last_successful_scan = time.time()
                         for known_ssid in all_known:
                             if known_ssid in available_ssids:
                                 self.logger.info(f"Known network '{known_ssid}' detected via secondary adapter {secondary}")
@@ -1200,6 +1241,9 @@ class WiFiManager:
                             ssid = line.split('ESSID:')[1].strip('"')
                             if ssid and ssid != '<hidden>':
                                 available_ssids.append(ssid)
+
+                    if available_ssids:
+                        self.last_successful_scan = time.time()
 
                     # Check if any known networks (Ragnar or system) are available
                     for known_ssid in all_known:


### PR DESCRIPTION
This pull request introduces comprehensive improvements to Ragnar's Wi-Fi access point (AP) fallback and network connection logic, making it more robust and user-friendly, especially when moving the device between networks or using it in environments with overlapping IP subnets. The changes include new user documentation, improved AP/client detection, support for dual-radio setups, and configuration enhancements.

**Network connectivity and AP logic improvements:**

* [`webapp_modern.py`](diffhunk://#diff-1ab10a8399539c75077187c32de965b18781789c066d9db14069f0415df09731R5439-R5486): The logic for detecting whether a request is coming from an AP client now checks if Ragnar itself holds the AP gateway address (`192.168.4.1`), preventing false positives when the local LAN uses the same subnet (e.g., eero routers). This avoids incorrectly showing the Wi-Fi setup portal to regular LAN clients.
* [`wifi_manager.py`](diffhunk://#diff-2516e89478ff494d7f150972200b6c910a0b5c696448d35c02004f9476c4bb18R190-R222): Added logic to distinguish between the AP radio (built-in) and a potential client radio (USB dongle), enabling simultaneous AP and client connections. The AP is kept up on the built-in radio while the dongle handles network joins, improving reliability and user experience, especially on devices like the Pi Zero 2 W. [[1]](diffhunk://#diff-2516e89478ff494d7f150972200b6c910a0b5c696448d35c02004f9476c4bb18R190-R222) [[2]](diffhunk://#diff-2516e89478ff494d7f150972200b6c910a0b5c696448d35c02004f9476c4bb18L754-R820)

**Configuration and recovery enhancements:**

* [`wifi_manager.py`](diffhunk://#diff-2516e89478ff494d7f150972200b6c910a0b5c696448d35c02004f9476c4bb18R66-R85): Introduced new configuration parameters and timing logic for AP recovery and reconnection checks, allowing Ragnar to automatically and non-disruptively rejoin known networks as they become available, without interrupting users connected to the AP. [[1]](diffhunk://#diff-2516e89478ff494d7f150972200b6c910a0b5c696448d35c02004f9476c4bb18R66-R85) [[2]](diffhunk://#diff-2516e89478ff494d7f150972200b6c910a0b5c696448d35c02004f9476c4bb18R140-R143)
* [`wifi_manager.py`](diffhunk://#diff-2516e89478ff494d7f150972200b6c910a0b5c696448d35c02004f9476c4bb18L810-R894): AP mode is now explicitly suppressed during wardriving and network diagnostic modes, ensuring these special modes are not disrupted by the fallback AP logic.

**Documentation updates:**

* `docs/INSTALL.md`, `README.md`: Updated to reference the new Ragnar AP Mode guide and provide clear instructions for connecting Ragnar to a network, including troubleshooting for common subnet conflicts. [[1]](diffhunk://#diff-93adeedb62ae4160af1d8713c9f15796d7b6312d45a0148447538fe185cd7347R100-R151) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R34)
* [`docs/RagnarAP.md`](diffhunk://#diff-0636ce59dace8c45df82f6ef7802faab1f9e4c1f32da5ceebf052c5ab4c999bdR1-R213): Added a comprehensive guide detailing Ragnar's AP mode behavior, including how and when the AP starts, moving the device between networks, using USB Wi-Fi dongles, and troubleshooting.

These changes significantly improve Ragnar's out-of-the-box network setup experience, resilience to network changes, and clarity for users and developers.