### PR TITLE
BLE provisioning: confirm Invalid Parameters is the controller, not us

### DIFF
--- a/ble_provisioning.py
+++ b/ble_provisioning.py
@@ -1089,9 +1089,15 @@ _ADV_STATUS_HINTS = {
         'scanning (bt_scanner / WIDS overlay) and try again.'
     ),
     'invalid parameters': (
-        'The controller refused these advertising parameters even at minimum '
-        'size, which usually means a driver/firmware quirk. Check: '
-        'dmesg | grep -i bluetooth   (look for a failed firmware load)'
+        'The controller refused the advertisement even at minimum size, which '
+        'points at the radio/firmware, not the advertisement content. In order: '
+        '(1) if this is a USB dongle, switch provisioning to the built-in radio '
+        '(Config -> Bluetooth Provisioning) — it is the known-good one; '
+        '(2) enable BlueZ experimental support: add "Experimental = true" under '
+        '[General] in /etc/bluetooth/main.conf and "sudo systemctl restart '
+        'bluetooth" (some controllers only advertise via the newer kernel path); '
+        '(3) check for a failed firmware load: dmesg | grep -i bluetooth. '
+        'The doctor confirms whether BlueZ can advertise on this radio at all.'
     ),
     'no resources': (
         'The controller has no advertising slot left. Stop other advertisers '
@@ -1120,6 +1126,35 @@ def bluetoothd_adv_failure(since: str = '-2 min') -> str:
         out = _run(['tail', '-n', '400', '/var/log/syslog'], timeout=4.0)
     hits = [m.group(1) for m in (pat.search(ln) for ln in out.splitlines()) if m]
     return hits[-1] if hits else ''
+
+
+def bluez_can_advertise(hci: Optional[str] = None) -> Optional[bool]:
+    """Whether BlueZ's *own* minimal advertiser is accepted on this radio.
+
+    ``bluetoothctl advertise on`` registers an advertisement BlueZ builds
+    itself — flags only, no 128-bit service UUID, no name — so it is the
+    cleanest split between "this controller cannot advertise via BlueZ at all"
+    and "it refuses *our* advertisement (the service UUID / connectable type)".
+    Prints ``Advertising object registered`` on success, ``Failed to register
+    advertisement`` on a controller-level refusal.
+
+    Returns True (BlueZ advertised), False (refused), or None if the check
+    could not run (no bluetoothctl, timed out). ``--timeout`` makes
+    bluetoothctl exit and release the advertisement on its own. Never raises.
+    """
+    if not _run(['which', 'bluetoothctl']).strip():
+        return None
+    # bluetoothctl acts on its default (last-seen) controller; on a one-radio
+    # box that is the one we care about. Multi-controller boxes would need an
+    # interactive `select <address>`, which isn't worth scripting here — the
+    # probe is a best-effort tie-breaker, not a gate.
+    out = _run(['bluetoothctl', '--timeout', '3', 'advertise', 'on'], timeout=8.0)
+    low = out.lower()
+    if 'advertising object registered' in low and 'failed to register' not in low:
+        return True
+    if 'failed to register advertisement' in low or 'not registered' in low:
+        return False
+    return None
 
 
 def _raw_hci_note(raw: list) -> str:
@@ -1448,6 +1483,21 @@ def _cli_doctor(base_dir: str) -> int:
                 else:
                     print('        This controller refuses every advertisement, '
                           'connectable or not.')
+            # Whose fault: the controller, or our advertisement content?
+            # bluetoothctl registers BlueZ's OWN advertisement (flags only, no
+            # service UUID) — the cleanest tie-breaker there is.
+            own = bluez_can_advertise(st.get('adapter'))
+            if own is False:
+                print("        CONFIRMED: BlueZ's own advertiser "
+                      '(bluetoothctl advertise on) is refused here too — so '
+                      'this is the controller/firmware, NOT Ragnar. Use a '
+                      'different adapter (the built-in radio if this is a USB '
+                      'dongle).')
+            elif own is True:
+                print("        NOTE: BlueZ's own minimal advertiser WAS "
+                      'accepted, but ours (which carries the 128-bit service '
+                      'UUID) was not — please report this, including the block '
+                      'above.')
             # The reason BlueZ hides behind "Failed to register advertisement".
             reason = bluetoothd_adv_failure()
             if reason:
@@ -1470,6 +1520,18 @@ def _cli_doctor(base_dir: str) -> int:
                   if 'luetooth' in ln and ('fail' in ln.lower() or 'error' in ln.lower())]
             for ln in fw[-3:]:
                 print(f'        dmesg: {ln.strip()[-120:]}')
+            # If the failing radio is a dongle and a built-in one exists, point
+            # at it — the onboard Pi controller is the known-good path.
+            failing = st.get('adapter')
+            builtins_ = [c for c in controllers
+                         if c['builtin'] and c['hci'] != failing]
+            if builtins_ and not any(c['hci'] == failing and c['builtin']
+                                     for c in controllers):
+                b = builtins_[0]
+                print(f'        TRY: switch provisioning to the built-in radio '
+                      f'{b["hci"]} ({b.get("address") or "?"}) in Config -> '
+                      f'Bluetooth Provisioning — {failing} looks like a dongle '
+                      f'and the onboard controller is the known-good one.')
     else:
         check('Advertising starts', False, 'fix the failures above first')
 

--- a/docs/ble_provisioning.md
+++ b/docs/ble_provisioning.md
@@ -182,7 +182,7 @@ produces the same D-Bus text, but a different mgmt status:
 | --- | --- | --- |
 | `Rejected (0x0b)` | LE is disabled on the controller | remove `ControllerMode = bredr` from `/etc/bluetooth/main.conf`, then `sudo btmgmt --index hci0 le on` |
 | `Not Supported (0x0c)` | the radio has no LE advertising | use a BT 4.0+ adapter |
-| `Invalid Parameters (0x0d)` | refused even at minimum size — driver/firmware quirk | `dmesg \| grep -i bluetooth` — look for a failed firmware load |
+| `Invalid Parameters (0x0d)` | refused even at minimum size — the radio/firmware, not the advertisement | (1) if it's a USB dongle, switch to the **built-in** radio; (2) add `Experimental = true` under `[General]` in `/etc/bluetooth/main.conf` and restart bluetooth; (3) `dmesg \| grep -i bluetooth` for a failed firmware load |
 | `Busy (0x0a)` | the controller is mid-operation | stop the scanners (bt_scanner / WIDS overlay) |
 | `No Resources` | no advertising slot left | `bluetoothctl advertise off`, or another controller |
 | `Not Powered` | radio off / rfkill | `sudo rfkill unblock all && bluetoothctl power on` |
@@ -193,6 +193,22 @@ run the doctor with `sudo`, or read it directly:
 ```bash
 journalctl -u bluetooth -n 50 | grep -i advertis
 ```
+
+**Is it Ragnar or the controller?** When the advertise test fails, the doctor
+also runs BlueZ's *own* advertiser (`bluetoothctl advertise on`) — a bare,
+flags-only advertisement with no service UUID. If **that** is refused too, the
+controller cannot advertise via BlueZ at all and it is not Ragnar's
+advertisement content:
+
+```
+CONFIRMED: BlueZ's own advertiser (bluetoothctl advertise on) is refused here
+too — so this is the controller/firmware, NOT Ragnar. Use a different adapter.
+```
+
+An `Invalid Parameters (0x0d)` with that confirmation is a controller that
+simply won't advertise on this firmware/driver — the reliable fix is to
+provision on the **built-in** radio (the doctor names it) and leave the dongle
+for scanning.
 
 **Start with `doctor`.** It is the "the toggle does nothing" tool: it checks
 each prerequisite in turn — `python3-dbus` and `python3-gi` importable,

--- a/tests/test_ble_advertising.py
+++ b/tests/test_ble_advertising.py
@@ -261,6 +261,40 @@ def test_hint_prioritises_the_raw_hci_scan_over_the_mgmt_status():
     assert 'btmon' in hint
 
 
+def test_hint_for_invalid_parameters_points_at_radio_not_content():
+    hint = bp.adv_failure_hint('Invalid Parameters (0x0d)',
+                               {'roles': ['central', 'peripheral']}, 'hci0')
+    assert 'built-in' in hint
+    assert 'Experimental = true' in hint
+    assert 'dmesg' in hint
+
+
+# --- BlueZ's own advertiser: the "is it us or the controller?" tie-breaker --
+
+def test_bluez_can_advertise_true_on_registered(monkeypatch):
+    monkeypatch.setattr(bp, '_run', lambda cmd, **k: (
+        'bluetoothctl' if cmd[:1] == ['which'] else 'Advertising object registered\n'))
+    assert bp.bluez_can_advertise() is True
+
+
+def test_bluez_can_advertise_false_on_refusal(monkeypatch):
+    monkeypatch.setattr(bp, '_run', lambda cmd, **k: (
+        'bluetoothctl' if cmd[:1] == ['which']
+        else 'Failed to register advertisement: Invalid Parameters\n'))
+    assert bp.bluez_can_advertise() is False
+
+
+def test_bluez_can_advertise_none_without_bluetoothctl(monkeypatch):
+    monkeypatch.setattr(bp, '_run', lambda cmd, **k: '')  # `which` finds nothing
+    assert bp.bluez_can_advertise() is None
+
+
+def test_bluez_can_advertise_none_on_unparseable_output(monkeypatch):
+    monkeypatch.setattr(bp, '_run', lambda cmd, **k: (
+        'bluetoothctl' if cmd[:1] == ['which'] else 'Agent registered\n'))
+    assert bp.bluez_can_advertise() is None
+
+
 def test_caps_summary_lists_raw_hci_tools():
     summary = bp._caps_summary('hci0', {
         'known': False,


### PR DESCRIPTION
The user's latest error clears everything the earlier rounds added: tx-power supported, peripheral role present, 0/5 advertising slots used, length fine, no raw-HCI tool detected — and every ladder rung plus the power-cycle retry still hit 'bluetoothd: Invalid Parameters (0x0d)'. That is the controller refusing even a minimal connectable advertisement, and 0/5 slots points at a USB dongle rather than the onboard radio.

Add the clean tie-breaker: when advertising fails, the doctor runs BlueZ's OWN advertiser (bluetoothctl advertise on) — a bare, flags-only advertisement with no service UUID. If that is refused too, the controller cannot advertise via BlueZ at all, so it is the firmware/driver and not Ragnar's advertisement content; if it is accepted while ours is not, that is a genuine Ragnar bug worth reporting. Either way the doctor now says which.

Rewrite the Invalid Parameters hint from a vague 'driver quirk, check dmesg' into the order that actually fixes it: switch to the built-in radio (the known-good path — the doctor names it when the failing one is a dongle), enable BlueZ Experimental mode in main.conf (some controllers only advertise via the newer kernel path), then check dmesg for a failed firmware load.