### PR TITLE
BT overlay: scan the controller we chose, not a cold-start stand-in

### DIFF
--- a/bt_scanner.py
+++ b/bt_scanner.py
@@ -69,6 +69,11 @@ if not os.path.exists(_BTCTL):
 _DEFAULT_DURATION = 12       # seconds of discovery per scan
 _MAX_DURATION = 30
 _INFO_TIMEOUT = 6            # per-device `info` enrichment
+# Cold-start grace: hciconfig lists a freshly-powered USB controller (an Alfa
+# just plugged/unblocked) a moment before bluetoothd exports its D-Bus object.
+# Wait this long for the *chosen* adapter to appear rather than scanning a
+# different radio — see _discover_dbus.
+_DBUS_ADAPTER_WAIT = 4.0
 _STRONG_RSSI = -70          # dBm; at/above this a device is "close" and hurts more
 
 # BLE advertising channels: the three fixed 2 MHz channels every advertiser
@@ -491,6 +496,20 @@ def _dbus_int(v):
         return None
 
 
+def _adapter_present(objs, adapter_path):
+    """The requested adapter's object path if BlueZ exposes it, else None.
+
+    Strict: it matches the chosen adapter only — never substitutes a different
+    controller — so a scan can't silently run on the wrong (e.g. onboard) radio
+    while the intended one is still registering. ``objs`` is
+    ObjectManager.GetManagedObjects().
+    """
+    ifaces = objs.get(adapter_path)
+    if ifaces and "org.bluez.Adapter1" in ifaces:
+        return adapter_path
+    return None
+
+
 def _discover_dbus(hci, duration):
     """Primary capture: drive a BlueZ discovery over D-Bus and snapshot every
     in-range device with RSSI + address type + class + company ID.
@@ -510,14 +529,25 @@ def _discover_dbus(hci, duration):
         bus = dbus.SystemBus()
         mgr = dbus.Interface(bus.get_object("org.bluez", "/"),
                              "org.freedesktop.DBus.ObjectManager")
+        # Resolve strictly to the adapter we were asked to use. Earlier this
+        # silently fell back to the *first* adapter BlueZ exposed when the
+        # chosen one wasn't on D-Bus yet — so the very first overlay scan after
+        # a USB controller powered up would run on the onboard hci0 (slow, and
+        # on a flaky board mislabelled as hci1) until bluetoothd caught up.
+        # Instead wait briefly for the chosen adapter, since hciconfig sees a
+        # fresh controller before its D-Bus object is exported.
         adapter_path = "/org/bluez/%s" % hci
         objs = mgr.GetManagedObjects()
-        if adapter_path not in objs:
-            # Fall back to the first adapter BlueZ actually exposes.
-            adapter_path = next((p for p, i in objs.items()
-                                 if "org.bluez.Adapter1" in i), None)
+        waited = 0.0
+        while _adapter_present(objs, adapter_path) is None and waited < _DBUS_ADAPTER_WAIT:
+            time.sleep(0.25)
+            waited += 0.25
+            objs = mgr.GetManagedObjects()
+        adapter_path = _adapter_present(objs, adapter_path)
         if not adapter_path:
-            return None, "no org.bluez adapter on D-Bus"
+            # Don't scan a different radio than the caller chose; let do_scan
+            # fall back to the bluetoothctl path (which targets this hci too).
+            return None, "%s not on D-Bus yet (bluetoothd still registering it)" % hci
         adapter = dbus.Interface(bus.get_object("org.bluez", adapter_path),
                                  "org.bluez.Adapter1")
         try:

--- a/docs/wifi-analyzer.md
+++ b/docs/wifi-analyzer.md
@@ -314,6 +314,13 @@ while the onboard radio is **UART**, so the scanner prefers the USB controller
 time-share the RF front-end, so the overlay is best-effort and duty-cycled —
 running BT discovery and Wi-Fi monitor capture flat-out can cost frames on both.
 
+The scan always runs on the controller it selected: a just-plugged USB dongle
+shows up in `hciconfig` a moment before `bluetoothd` registers it on D-Bus, so
+the scanner waits briefly for the chosen adapter to appear rather than falling
+back onto the onboard radio. That fallback used to make the *first* overlay
+scan run on the onboard `hci0` (slow, and mislabelled) before settling on the
+dongle — subsequent scans were always fast on the right controller.
+
 ## Zigbee / 802.15.4 overlay (via Huginn)
 
 Tick **🐝 Zigbee** to overlay nearby **Zigbee / Thread / 802.15.4** activity onto

--- a/tests/test_bt_scanner_adapter.py
+++ b/tests/test_bt_scanner_adapter.py
@@ -1,0 +1,48 @@
+"""The overlay scan must run on the controller it chose — not a stand-in.
+
+Background: the first Bluetooth overlay scan after a USB controller powered up
+was slow and ran on the wrong radio. `hciconfig` lists a freshly-enumerated
+controller (a just-plugged/unblocked Alfa) a moment before `bluetoothd` exports
+its D-Bus object, so `_discover_dbus("hci1")` found hci1 missing from
+ObjectManager and silently fell back to the *first* adapter it saw — the
+onboard hci0. On a box whose onboard radio is flaky/undervolting that first
+scan was both slow and mislabelled (reported as hci1 while scanning hci0);
+every later scan, once hci1 was registered, was correct and fast.
+
+The fix is `_adapter_present`: resolve strictly to the requested adapter, never
+a substitute. `_discover_dbus` then waits briefly for it to appear and, failing
+that, reports it rather than scanning a different radio.
+"""
+
+import bt_scanner
+
+
+def _objs(*hcis):
+    """A fake GetManagedObjects() exposing the given adapters (plus a device,
+    to prove non-adapter objects are ignored)."""
+    objs = {"/org/bluez/%s/dev_AA_BB_CC_DD_EE_FF" % hcis[0] if hcis else "x":
+            {"org.bluez.Device1": {}}}
+    for hci in hcis:
+        objs["/org/bluez/%s" % hci] = {"org.bluez.Adapter1": {}}
+    return objs
+
+
+def test_resolves_the_requested_adapter_when_present():
+    objs = _objs("hci0", "hci1")
+    assert bt_scanner._adapter_present(objs, "/org/bluez/hci1") == "/org/bluez/hci1"
+
+
+def test_returns_none_rather_than_substituting_another_radio():
+    # hci1 not yet on D-Bus — must NOT resolve to hci0. This is the whole bug.
+    objs = _objs("hci0")
+    assert bt_scanner._adapter_present(objs, "/org/bluez/hci1") is None
+
+
+def test_none_when_no_adapters_at_all():
+    assert bt_scanner._adapter_present({}, "/org/bluez/hci0") is None
+
+
+def test_a_non_adapter_object_at_the_path_does_not_count():
+    # A device object living under the path is not an adapter.
+    objs = {"/org/bluez/hci1": {"org.bluez.Device1": {}}}
+    assert bt_scanner._adapter_present(objs, "/org/bluez/hci1") is None


### PR DESCRIPTION
First Bluetooth overlay scan in the WiFi analyzer was slow and ran on the wrong radio. The overlay auto-picks the USB controller (Alfa, USB-first), but hciconfig lists a freshly-powered controller a moment before bluetoothd exports its D-Bus object. _discover_dbus then found the chosen adapter missing from ObjectManager and silently fell back to the *first* adapter it saw — the onboard hci0. On a box whose onboard radio is flaky/undervolting that first scan was both slow and mislabelled (reported as the dongle while actually scanning hci0); every later scan, once the dongle was registered on D-Bus, was correct and fast.

Resolve strictly to the requested adapter (_adapter_present, never a substitute) and wait briefly (up to _DBUS_ADAPTER_WAIT) for it to appear, since hciconfig sees a fresh controller before its D-Bus object exists. If it still isn't there, report it and let do_scan fall back to the bluetoothctl path for the same hci — rather than scanning a different physical radio.