### PR TITLE
Fix/kiosk mode

### DIFF
--- a/docs/kiosk.md
+++ b/docs/kiosk.md
@@ -86,6 +86,23 @@ reached `active`/`installed`. Two things it is *not*:
 If you still see it, the service exists but is stuck part-way (usually
 `activating`). Check both logs below.
 
+**"Nothing happened when I turned it on."** Use **Reinstall** in
+**Config → On-screen Display**. It runs the installer and the enable step for
+you — the same two commands people were resorting to by hand:
+
+```bash
+sudo bash scripts/install_kiosk.sh
+sudo systemctl enable --now ragnar-kiosk.service   # service mode only
+```
+
+Why it was needed: the toggle only acts on a *change*, and it used to skip the
+installer whenever anything already looked installed. An attempt that got as far
+as writing the unit file, or left an autostart entry behind, therefore counted as
+"installed" — so flipping the switch never re-ran the installer and never fixed
+what was missing, while running the script by hand did. The installer is
+idempotent, so it is now run on every enable, and **Reinstall** gives a box whose
+config already says enabled a way back without toggling off and on.
+
 **Start here — the Diagnose button.** In **Config → On-screen Display** it runs
 `scripts/kiosk_doctor.sh` on the box and prints the whole report in the card, so
 a blank screen can be diagnosed without an ssh session. Same thing from a

--- a/docs/kiosk.md
+++ b/docs/kiosk.md
@@ -133,6 +133,25 @@ wrapper and Xorg logs. Output is saved to `/tmp/kiosk_doctor_<timestamp>.log`
 > `journalctl -u ragnar-kiosk` is legitimately empty; those failures are logged
 > by Ragnar itself under `[kiosk]`.
 
+**Service starts and immediately fails with `status=1/FAILURE`, and there is no
+Xorg log at all.** This was Ragnar's own bug, fixed — the wrapper passed
+`-logfile` to Xorg, and Xorg *refuses* that flag whenever it runs with elevated
+privileges:
+
+```
+Invalid argument -logfile with elevated privileges
+```
+
+Elevated privileges is exactly how service mode runs it: the unit runs as a
+non-root user, so X can only start through the setuid `Xorg.wrap` the installer
+installs (`xserver-xorg-legacy` + `needs_root_rights=yes`). X therefore aborted
+while still parsing its arguments — before opening any log — which is why the
+journal showed a bare exit code with nothing to go on and the restart loop
+tripped the start limit. The wrapper no longer passes the flag; X writes to
+`~/.local/share/xorg/Xorg.0.log` and the wrapper copies that to
+`/var/log/ragnar/kiosk-Xorg.log`, so both paths keep working. Update and click
+**Reinstall**.
+
 **"Cannot establish any listening sockets — Make sure an X server isn't already
 running"** means service mode is trying to start its own X on `:0` while a
 desktop session already owns it. The kiosk has two modes and this box was set

--- a/docs/kiosk.md
+++ b/docs/kiosk.md
@@ -86,12 +86,22 @@ reached `active`/`installed`. Two things it is *not*:
 If you still see it, the service exists but is stuck part-way (usually
 `activating`). Check both logs below.
 
-**Start here — `scripts/kiosk_doctor.sh`.** One command that collects every
-answer in the right order, so you are not guessing which log to read:
+**Start here — the Diagnose button.** In **Config → On-screen Display** it runs
+`scripts/kiosk_doctor.sh` on the box and prints the whole report in the card, so
+a blank screen can be diagnosed without an ssh session. Same thing from a
+terminal:
 
 ```bash
 sudo ./scripts/kiosk_doctor.sh
 ```
+
+> `sudo journalctl -u ragnar-kiosk` returning **`-- No entries --`** is the most
+> common dead end, and it is usually not a fault: that unit only exists in
+> *service* mode. On a desktop image the kiosk runs as an autostart entry inside
+> your session and there is no unit at all — and if the installer failed, there
+> is no unit either. The web UI now says which of those applies instead of
+> naming a journal that cannot exist. Use Diagnose, or
+> `sudo journalctl -u ragnar | grep '\[kiosk\]'`.
 
 It reports install mode, browser, the whole X stack (including the suid
 `Xorg.wrap` that causes most Pi 5 crash loops), service state and restart
@@ -117,7 +127,9 @@ detects this and says so instead of crash-looping until the start limit trips.
 - Wrapper log: `/var/log/ragnar/kiosk-wrapper.log` — board, RAM, the
   `input: touchscreen=… keyboard=… osk=…` line, which OSK launched, target URL.
 - Xorg log (service mode): `/var/log/ragnar/kiosk-Xorg.log`.
-- Service state: `journalctl -u ragnar-kiosk`.
+- Service state: `journalctl -u ragnar-kiosk` — **service mode only**; empty by
+  design in autostart mode.
+- Install/enable failures, either mode: `journalctl -u ragnar | grep '\[kiosk\]'`.
 
 **Crash loop** (`status=1/FAILURE`, restart counter climbing) in service mode is
 almost always X failing to start. The service now stops itself after 5 failures

--- a/scripts/install_kiosk.sh
+++ b/scripts/install_kiosk.sh
@@ -48,32 +48,52 @@ detect_desktop_mode() {
 }
 
 # Find the user who actually owns the active graphical session.
-# loginctl shows seat0 sessions; pick the first non-greeter user.
+#
+# Deliberately asks each session what it is instead of parsing the columns of
+# `loginctl list-sessions`, whose layout has changed between systemd versions.
+# The old parse had two problems: its first pass compared the *user* column
+# against "seat0" so it never matched anything, and when no seated session
+# existed at all it fell back to whoever `who` listed first - an ssh login on a
+# pty. The autostart entry then landed in that user's home directory, so it
+# never ran for the person actually sitting at the screen. Returning nothing is
+# the right answer there: the caller falls back to detect_kiosk_user_bare.
+_session_prop() {   # _session_prop <session-id> <property>
+    local out
+    out="$(loginctl show-session "$1" -p "$2" --value 2>/dev/null)" && [[ -n "$out" ]] && {
+        echo "$out"; return 0
+    }
+    # --value predates systemd 238; fall back to Property=value output.
+    loginctl show-session "$1" -p "$2" 2>/dev/null | cut -d= -f2-
+}
+
 detect_session_user() {
     if command -v loginctl >/dev/null 2>&1; then
-        local user
-        user="$(loginctl list-sessions --no-legend 2>/dev/null \
-            | awk '$3 == "seat0" {print $3, $0}' \
-            | awk '{print $4}' \
-            | grep -v -E '^(lightdm|greeter|gdm|sddm|_)?$' \
-            | head -n1)"
-        if [[ -n "$user" ]]; then
-            echo "$user"
-            return 0
-        fi
-        # Alternative loginctl format: session-id, uid, user, seat, tty
-        user="$(loginctl list-sessions --no-legend 2>/dev/null \
-            | awk '/seat0/ {print $3}' \
-            | grep -v -E '^(lightdm|greeter|gdm|sddm|_)?$' \
-            | head -n1)"
-        if [[ -n "$user" ]]; then
-            echo "$user"
-            return 0
-        fi
+        local sid user stype pass
+        # Pass 1: a genuinely graphical session. Pass 2: any seated session.
+        for pass in graphical seated; do
+            while read -r sid; do
+                [[ -z "$sid" ]] && continue
+                user="$(_session_prop "$sid" Name)"
+                stype="$(_session_prop "$sid" Type)"
+                case "$user" in
+                    lightdm|gdm|gdm3|sddm|greeter|'') continue ;;
+                esac
+                if [[ "$pass" == "graphical" ]]; then
+                    case "$stype" in
+                        wayland|x11|mir) ;;
+                        *) continue ;;
+                    esac
+                else
+                    [[ "$(_session_prop "$sid" Seat)" == "" ]] && continue
+                fi
+                echo "$user"
+                return 0
+            done < <(loginctl list-sessions --no-legend 2>/dev/null | awk '{print $1}')
+        done
     fi
-    # Fallback: who is logged in on a real tty
+    # Fallback: whoever is logged in on a real (non-pty) tty.
     if command -v who >/dev/null 2>&1; then
-        who | awk '{print $1}' | head -n1
+        who 2>/dev/null | awk '$2 !~ /^pts/ {print $1; exit}'
     fi
 }
 

--- a/scripts/kiosk_doctor.sh
+++ b/scripts/kiosk_doctor.sh
@@ -176,13 +176,22 @@ fi
 # ---------------------------------------------------------------------------
 section "7. Xorg log (service mode)"
 # ---------------------------------------------------------------------------
-if [ -f "$LOG_DIR/kiosk-Xorg.log" ]; then
-    echo "  errors from $LOG_DIR/kiosk-Xorg.log:"
-    grep -E '\(EE\)|\(WW\).*fail|no screens found' "$LOG_DIR/kiosk-Xorg.log" | tail -20 | sed 's/^/  /' \
+# Xorg refuses -logfile under the setuid wrapper, so a non-root kiosk leaves its
+# log in the user's own directory instead. Check both, or a real X failure looks
+# like "X never started".
+XORG_LOGS="$LOG_DIR/kiosk-Xorg.log"
+for home in /home/* /root; do
+    [ -f "$home/.local/share/xorg/Xorg.0.log" ] && XORG_LOGS="$XORG_LOGS $home/.local/share/xorg/Xorg.0.log"
+done
+FOUND_XORG_LOG=0
+for xlog in $XORG_LOGS; do
+    [ -f "$xlog" ] || continue
+    FOUND_XORG_LOG=1
+    echo "  errors from $xlog:"
+    grep -E '\(EE\)|\(WW\).*fail|no screens found|elevated privileges' "$xlog" | tail -20 | sed 's/^/  /' \
         || echo "  (no (EE) lines — X did not report an error)"
-else
-    echo "  (no Xorg log — either autostart mode, or X never started)"
-fi
+done
+[ "$FOUND_XORG_LOG" -eq 0 ] && echo "  (no Xorg log — either autostart mode, or X never started)"
 
 # ---------------------------------------------------------------------------
 section "8. Display / session context"

--- a/scripts/kiosk_doctor.sh
+++ b/scripts/kiosk_doctor.sh
@@ -119,8 +119,10 @@ if [ "$MODE" = "service" ]; then
     else
         check "Xwrapper.config exists" 1 "re-run the kiosk installer (it writes allowed_users=anybody)"
     fi
-else
+elif [ "$MODE" = "autostart" ]; then
     echo "  (skipped — autostart mode launches inside the existing desktop session)"
+else
+    echo "  (skipped — nothing is installed yet, so no mode has been chosen)"
 fi
 
 # ---------------------------------------------------------------------------
@@ -138,10 +140,14 @@ if [ "$MODE" = "service" ]; then
         echo "  $(systemctl show "$SERVICE" -p NRestarts 2>/dev/null)"
         echo "        (if it hit the 5-in-2min cap: sudo systemctl reset-failed $SERVICE)"
     fi
-else
+elif [ "$MODE" = "autostart" ]; then
     RUNNING=$(pgrep -f 'ragnar-kiosk-chromium' >/dev/null 2>&1 && echo 0 || echo 1)
     check "Kiosk chromium process running" "$RUNNING" \
           "log in to the desktop session, or toggle the kiosk off/on in Config"
+else
+    # Counting "chromium is not running" as a failure when nothing is installed
+    # just adds a second [FAIL] for the one problem already reported above.
+    echo "  (skipped — nothing is installed, so nothing should be running)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/ragnar_kiosk_run.sh
+++ b/scripts/ragnar_kiosk_run.sh
@@ -240,6 +240,8 @@ fi
 
 XORG_LOG="$LOG_DIR/kiosk-Xorg.log"
 mkdir -p "$HOME/.local/share/xorg" 2>/dev/null || true
+# Where Xorg puts its log when we are NOT allowed to name one (see below).
+XORG_OWN_LOG="$HOME/.local/share/xorg/Xorg.0.log"
 rm -f /tmp/.X0-lock 2>/dev/null || true
 rm -f /tmp/.X11-unix/X0 2>/dev/null || true
 
@@ -333,13 +335,32 @@ if pgrep -x Xorg >/dev/null 2>&1 || pgrep -x X >/dev/null 2>&1; then
     exit 1
 fi
 
-xinit "$SESSION_SCRIPT" -- /usr/bin/X :0 vt7 -nolisten tcp \
-      -auth "$XAUTHORITY" -logfile "$XORG_LOG" -keeptty &
+# -logfile is REFUSED when Xorg runs with elevated privileges, and that is
+# precisely how this path runs it: the service runs as a non-root user, so X
+# only starts at all through the setuid Xorg.wrap that the installer puts there
+# (xserver-xorg-legacy + needs_root_rights=yes). Under that wrapper Xorg aborts
+# on sight of the flag —
+#     Invalid argument -logfile with elevated privileges
+# — before it opens anything, so the service died instantly with a bare
+# status=1/FAILURE, no Xorg log was ever written to point at, and the restart
+# loop then tripped the start limit. Let Xorg write its own log and copy that
+# where the doctor expects it afterwards.
+XORG_ARGS=(:0 vt7 -nolisten tcp -auth "$XAUTHORITY" -keeptty)
+if [[ "$(id -u)" -eq 0 ]]; then
+    # Genuine root: privileges are not "elevated", so naming the log is allowed.
+    XORG_ARGS+=(-logfile "$XORG_LOG")
+fi
+xinit "$SESSION_SCRIPT" -- /usr/bin/X "${XORG_ARGS[@]}" &
 XINIT_PID=$!
 if wait "$XINIT_PID"; then rc=0; else rc=$?; fi
+# Keep /var/log/ragnar/kiosk-Xorg.log as the one place to look, whichever log
+# Xorg was actually allowed to write.
+if [[ ! -s "$XORG_LOG" && -s "$XORG_OWN_LOG" ]]; then
+    cp -f "$XORG_OWN_LOG" "$XORG_LOG" 2>/dev/null || true
+fi
 if [[ "$rc" -ne 0 && "$rc" -ne 143 && "$rc" -ne 130 ]]; then
     echo "[kiosk-run] X/xinit exited with code $rc — last Xorg log lines:" >&2
-    tail -n 25 "$XORG_LOG" 2>/dev/null >&2 || true
+    { tail -n 25 "$XORG_LOG" 2>/dev/null || tail -n 25 "$XORG_OWN_LOG" 2>/dev/null; } >&2 || true
     echo "[kiosk-run] full detail: $XORG_LOG and $WRAPPER_LOG" >&2
 fi
 exit "$rc"

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -5929,9 +5929,14 @@
                             </div>
                             <div class="flex items-center justify-between mt-3 pt-2 border-t border-gray-700/50">
                                 <span class="text-xs text-gray-500">Service</span>
-                                <span id="kiosk-service-badge" class="text-xs px-2 py-0.5 rounded bg-gray-700 text-gray-300">unknown</span>
+                                <div class="flex items-center gap-2">
+                                    <button id="kiosk-diagnose-btn" onclick="runKioskDoctor()"
+                                            class="px-2 py-0.5 rounded bg-slate-600 hover:bg-slate-500 text-white text-xs">Diagnose</button>
+                                    <span id="kiosk-service-badge" class="text-xs px-2 py-0.5 rounded bg-gray-700 text-gray-300">unknown</span>
+                                </div>
                             </div>
                             <div id="kiosk-status-message" class="text-xs mt-2 hidden"></div>
+                            <pre id="kiosk-doctor-report" class="hidden mt-3 max-h-64 overflow-auto rounded bg-black/50 p-2 text-xs text-gray-300 whitespace-pre-wrap"></pre>
                         </div>
 
                         <!-- Wardriving on Boot Card -->
@@ -7040,7 +7045,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260726-update-robustness"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260726-kiosk-doctor"></script>
 
 </body>
 </html>

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -5930,6 +5930,9 @@
                             <div class="flex items-center justify-between mt-3 pt-2 border-t border-gray-700/50">
                                 <span class="text-xs text-gray-500">Service</span>
                                 <div class="flex items-center gap-2">
+                                    <button id="kiosk-repair-btn" onclick="repairKiosk()"
+                                            class="px-2 py-0.5 rounded bg-amber-700 hover:bg-amber-600 text-white text-xs"
+                                            title="Re-run the kiosk installer and start it, whatever state it is in">Reinstall</button>
                                     <button id="kiosk-diagnose-btn" onclick="runKioskDoctor()"
                                             class="px-2 py-0.5 rounded bg-slate-600 hover:bg-slate-500 text-white text-xs">Diagnose</button>
                                     <span id="kiosk-service-badge" class="text-xs px-2 py-0.5 rounded bg-gray-700 text-gray-300">unknown</span>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -25015,16 +25015,32 @@ function onKioskSettingChanged() {
     }, 500);
 }
 
+// Where the answer actually is when the kiosk misbehaves. `journalctl -u
+// ragnar-kiosk` is only worth naming when that unit exists: in autostart mode,
+// and whenever the installer failed, it was never created — so the first thing
+// everyone tried printed "-- No entries --" and the trail ended there.
+function _kioskWhereToLook(status) {
+    if (status && status.unit_exists) {
+        return 'Check `journalctl -u ragnar-kiosk` on the Pi, or click Diagnose.';
+    }
+    return 'There is no kiosk service unit on this box'
+        + (status && status.mode === 'autostart'
+            ? ' (autostart mode runs inside your desktop session)' : '')
+        + ', so `journalctl -u ragnar-kiosk` will be empty. Click Diagnose for the real state.';
+}
+
 function _pollKioskStatusUntilStable(expectEnabled, maxAttempts = 12) {
     // Stability differs by mode:
     //   service  → service_state reaches 'active' (enabled) or 'inactive' (disabled)
     //   autostart → installed=true is the success signal on enable; mode!=autostart on disable.
     if (_kioskPollTimer) clearTimeout(_kioskPollTimer);
     let attempts = 0;
+    let lastStatus = null;
     const tick = async () => {
         attempts++;
         try {
             const data = await fetchAPI('/api/kiosk/status');
+            lastStatus = data;
             _setKioskBadge(data.service_state || 'unknown');
 
             const isStableSuccess = (() => {
@@ -25080,10 +25096,7 @@ function _pollKioskStatusUntilStable(expectEnabled, maxAttempts = 12) {
                 return;
             }
             if (isStableFailure) {
-                _setKioskMessage(
-                    'Kiosk service failed. Check `journalctl -u ragnar-kiosk` on the Pi.',
-                    'error'
-                );
+                _setKioskMessage('Kiosk service failed. ' + _kioskWhereToLook(data), 'error');
                 return;
             }
         } catch (e) { /* keep polling */ }
@@ -25091,16 +25104,43 @@ function _pollKioskStatusUntilStable(expectEnabled, maxAttempts = 12) {
             _kioskPollTimer = setTimeout(tick, 2000);
         } else {
             // Genuinely stuck: no background job running, no reported error,
-            // and the state never settled. Name both places worth looking,
-            // since which one has the answer depends on how far it got.
-            _setKioskMessage(
-                'Kiosk state did not settle. Check `journalctl -u ragnar-kiosk` on the Pi, '
-                + 'and the Ragnar log for lines tagged [kiosk].',
-                'error'
-            );
+            // and the state never settled.
+            _setKioskMessage('Kiosk state did not settle. ' + _kioskWhereToLook(lastStatus), 'error');
         }
     };
     _kioskPollTimer = setTimeout(tick, 1500);
+}
+
+// Run scripts/kiosk_doctor.sh on the box and show its report here, so "the
+// screen is blank" can be diagnosed without an ssh session.
+async function runKioskDoctor() {
+    const btn = document.getElementById('kiosk-diagnose-btn');
+    const out = document.getElementById('kiosk-doctor-report');
+    if (btn) { btn.disabled = true; btn.textContent = 'Diagnosing…'; }
+    if (out) {
+        out.classList.remove('hidden');
+        out.textContent = 'Running the kiosk doctor — this checks the browser, display, session and logs…';
+    }
+    try {
+        const data = await postAPI('/api/kiosk/diagnose', {});
+        if (out) {
+            out.textContent = data.report || 'The kiosk doctor returned no output.';
+            out.scrollTop = 0;
+        }
+        if (data.failed_checks > 0) {
+            _setKioskMessage(`${data.failed_checks} check(s) failed — see the [FAIL] lines below.`, 'error');
+        } else {
+            _setKioskMessage('No failed checks. If the screen is still blank, the wrapper log '
+                             + 'section of the report has the detail.', 'info');
+        }
+    } catch (e) {
+        if (out) {
+            out.textContent = 'Could not run the kiosk doctor: ' + e.message
+                + '\n\nRun it directly on the Pi instead:\n  sudo bash scripts/kiosk_doctor.sh';
+        }
+    } finally {
+        if (btn) { btn.disabled = false; btn.textContent = 'Diagnose'; }
+    }
 }
 
 // Kiosk-mode bootstrap: when the page is loaded with ?kiosk=1 (the chromium

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -25111,6 +25111,26 @@ function _pollKioskStatusUntilStable(expectEnabled, maxAttempts = 12) {
     _kioskPollTimer = setTimeout(tick, 1500);
 }
 
+// Re-run the kiosk installer and start it, whatever state the box is in — the
+// same thing as `sudo bash scripts/install_kiosk.sh` followed by
+// `systemctl enable --now ragnar-kiosk`. The toggle only reacts to a *change*,
+// so this is the way back for a box whose config already says enabled.
+async function repairKiosk() {
+    const btn = document.getElementById('kiosk-repair-btn');
+    if (btn) { btn.disabled = true; btn.textContent = 'Reinstalling…'; }
+    try {
+        const data = await postAPI('/api/kiosk/repair', {});
+        _setKioskMessage(data.message || 'Reinstalling the kiosk…', 'info');
+        const cb = document.getElementById('kiosk-enabled');
+        if (cb) cb.checked = true;
+        _pollKioskStatusUntilStable(true);
+    } catch (e) {
+        _setKioskMessage('Could not start the kiosk reinstall: ' + e.message, 'error');
+    } finally {
+        if (btn) { btn.disabled = false; btn.textContent = 'Reinstall'; }
+    }
+}
+
 // Run scripts/kiosk_doctor.sh on the box and show its report here, so "the
 // screen is blank" can be diagnosed without an ssh session.
 async function runKioskDoctor() {

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -3599,6 +3599,36 @@ def _kiosk_running() -> bool:
         return False
 
 
+def _x11_display_for(uid: int) -> str:
+    """The DISPLAY of this user's X session, via loginctl. '' when there is none.
+
+    Pi OS Desktop is Wayland now, but plenty of boxes still run X11 — the user
+    switched it in raspi-config, or the image predates labwc. Those sessions have
+    no wayland-* socket at all, which is the only thing the spawn used to look
+    for, so enabling the kiosk from the web UI appeared to do nothing until the
+    person at the screen logged out and back in.
+    """
+    try:
+        listing = subprocess.run(['loginctl', 'list-sessions', '--no-legend'],
+                                 capture_output=True, text=True, timeout=5, check=False)
+        for line in listing.stdout.splitlines():
+            parts = line.split()
+            if not parts:
+                continue
+            sid = parts[0]
+            props = subprocess.run(
+                ['loginctl', 'show-session', sid, '-p', 'User', '-p', 'Type', '-p', 'Display'],
+                capture_output=True, text=True, timeout=5, check=False).stdout
+            values = dict(
+                line.split('=', 1) for line in props.splitlines() if '=' in line)
+            if values.get('Type') != 'x11' or values.get('User') != str(uid):
+                continue
+            return values.get('Display', '') or ':0'
+    except Exception as exc:
+        logger.debug(f"[kiosk] could not query X11 sessions: {exc}")
+    return ''
+
+
 def _spawn_kiosk_in_session() -> bool:
     """Find a user with an active wayland/X session and launch the kiosk
     wrapper into it. Returns True if we managed to dispatch a spawn — not a
@@ -3619,16 +3649,26 @@ def _spawn_kiosk_in_session() -> bool:
             ]
         except OSError:
             socket_names = []
-        if not socket_names:
-            continue
-        wl = sorted(socket_names)[0]
+
+        env_extra = []
+        if socket_names:
+            wl = sorted(socket_names)[0]
+            session_label = f"wayland ({wl})"
+            env_extra = [f"WAYLAND_DISPLAY={wl}", "DISPLAY=:0"]
+        else:
+            display = _x11_display_for(entry.pw_uid)
+            if not display:
+                continue
+            session_label = f"x11 ({display})"
+            env_extra = [f"DISPLAY={display}",
+                         f"XAUTHORITY={os.path.join(entry.pw_dir, '.Xauthority')}"]
+
         cmd = [
             'sudo', '-u', entry.pw_name, '-n',
             'env',
             f"HOME={entry.pw_dir}",
             f"XDG_RUNTIME_DIR={runtime_dir}",
-            f"WAYLAND_DISPLAY={wl}",
-            "DISPLAY=:0",
+        ] + env_extra + [
             f"RAGNAR_REPO={os.path.dirname(os.path.abspath(__file__))}",
             '/usr/local/bin/ragnar-kiosk-run',
         ]
@@ -3640,11 +3680,12 @@ def _spawn_kiosk_in_session() -> bool:
                 stdin=subprocess.DEVNULL,
                 start_new_session=True,
             )
-            logger.info(f"[kiosk] spawned into {entry.pw_name}'s session via {wl}")
+            logger.info(f"[kiosk] spawned into {entry.pw_name}'s session via {session_label}")
             return True
         except Exception as exc:
             logger.error(f"[kiosk] failed to spawn into {entry.pw_name}'s session: {exc}")
-    logger.warning("[kiosk] no active wayland session — will launch on next login")
+    logger.warning("[kiosk] no active desktop session (wayland or X11) — "
+                   "will launch on next login")
     return False
 
 
@@ -5991,6 +6032,11 @@ def kiosk_status():
         return jsonify({
             'installed': mode != 'not_installed',
             'mode': mode,
+            # Whether `journalctl -u ragnar-kiosk` can possibly have anything in
+            # it. In autostart mode, and whenever the install failed, no unit is
+            # ever created - pointing people at that journal sent them to "-- No
+            # entries --" and a dead end.
+            'unit_exists': os.path.exists(KIOSK_SERVICE_FILE),
             'enabled': bool(shared_data.config.get('kiosk_enabled', False)),
             'service_state': state,
             # Background install/teardown progress. 'busy' tells the UI to keep
@@ -6008,6 +6054,43 @@ def kiosk_status():
     except Exception as exc:
         logger.error(f"Error getting kiosk status: {exc}")
         return jsonify({'error': str(exc)}), 500
+
+
+@app.route('/api/kiosk/diagnose', methods=['POST'])
+def kiosk_diagnose():
+    """Run scripts/kiosk_doctor.sh and hand back its report.
+
+    "The kiosk shows nothing" has a dozen causes and the systemd journal answers
+    almost none of them: in autostart mode there is no unit, and when the
+    installer itself fails there is no unit either - so the first thing everyone
+    tries, `journalctl -u ragnar-kiosk`, prints "-- No entries --" and the trail
+    ends. The doctor checks the browser, the X stack, the session, the display
+    hardware and the configured URL, and reads the wrapper and Xorg logs where
+    the real detail lives. Exposing it here means a user can get that report
+    without an ssh session.
+    """
+    script = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          'scripts', 'kiosk_doctor.sh')
+    if not os.path.isfile(script):
+        return jsonify({'success': False,
+                        'error': 'scripts/kiosk_doctor.sh is missing - update Ragnar and retry'}), 404
+    try:
+        proc = subprocess.run(['sudo', '-n', 'bash', script],
+                              capture_output=True, text=True, timeout=180, check=False)
+    except subprocess.TimeoutExpired:
+        return jsonify({'success': False,
+                        'error': 'The kiosk doctor took longer than 3 minutes and was cancelled.'}), 500
+    except Exception as exc:
+        return jsonify({'success': False, 'error': f'Could not run the kiosk doctor: {exc}'}), 500
+
+    report = (proc.stdout or '') + (proc.stderr or '')
+    if not report.strip():
+        return jsonify({'success': False,
+                        'error': f'The kiosk doctor produced no output (exit {proc.returncode}).'}), 500
+    # The doctor counts its own failures and prints them; the exit code is 0
+    # either way, so success here means "the report was produced".
+    return jsonify({'success': True, 'report': report,
+                    'failed_checks': report.count('[FAIL]')})
 
 
 @app.route('/api/config/scan-intensity', methods=['GET', 'POST'])

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -3583,10 +3583,6 @@ def _kiosk_mode() -> str:
     return 'not_installed'
 
 
-def _kiosk_installed() -> bool:
-    return _kiosk_mode() != 'not_installed'
-
-
 def _kiosk_running() -> bool:
     """Best-effort: is a kiosk chromium process running right now?"""
     try:
@@ -3689,6 +3685,66 @@ def _spawn_kiosk_in_session() -> bool:
     return False
 
 
+def _kiosk_install_and_start() -> bool:
+    """Do exactly what `sudo bash scripts/install_kiosk.sh` + `systemctl enable
+    --now ragnar-kiosk` do by hand, and report why if it does not take.
+
+    The installer is idempotent by design - it says so at the top of the file
+    and only installs what is missing - so it is run on every enable rather than
+    skipped whenever something already looks installed. Skipping was the reason
+    the toggle and the manual command behaved differently: an earlier attempt
+    that got as far as writing the unit file (or left an autostart entry behind)
+    counted as "installed", so the toggle never re-ran the installer and never
+    fixed what was actually missing, while running the script by hand did.
+    """
+    logger.info(f"[kiosk] running installer: {KIOSK_INSTALL_SCRIPT}")
+    # Installing chromium: minutes on a Pi Zero 2 W. The UI shows this phase
+    # instead of timing the poll out.
+    _kiosk_task_set(phase='installing')
+    proc = subprocess.run(
+        ['sudo', '-n', 'bash', KIOSK_INSTALL_SCRIPT],
+        capture_output=True, text=True, timeout=900, check=False
+    )
+    if proc.returncode != 0:
+        output = (proc.stderr.strip() or proc.stdout.strip() or '')
+        detail = output.splitlines()[-1] if output else f'exit code {proc.returncode}'
+        logger.error(f"[kiosk] install failed (rc={proc.returncode}): {output}")
+        # Surface it. This failure never reaches the systemd journal - the unit
+        # does not exist yet - so telling the user to check journalctl sent them
+        # somewhere with nothing in it.
+        _kiosk_task_set(phase='failed',
+                        error=f'Installer failed: {detail}. Click Diagnose for the full picture.')
+        return False
+    logger.info("[kiosk] install completed")
+
+    mode = _kiosk_mode()
+    _kiosk_task_set(phase='starting')
+    if mode == 'service':
+        enable_proc = _run_systemctl(['enable', '--now', KIOSK_SERVICE])
+        if enable_proc.returncode != 0:
+            err = enable_proc.stderr.strip() or enable_proc.stdout.strip() or 'unknown error'
+            logger.error(f"[kiosk] enable --now failed: {err}")
+            _kiosk_task_set(phase='failed', error=f'Could not start the kiosk service: {err}')
+            return False
+        logger.info("[kiosk] systemd service enabled and started")
+        return True
+
+    if mode == 'autostart':
+        # Autostart mode: the entry covers next login, but spawn into the live
+        # session too so enabling from the web UI shows something now.
+        if not _kiosk_running():
+            _spawn_kiosk_in_session()
+        return True
+
+    # The installer returned success but left neither a unit nor an autostart
+    # entry. Saying "installed" here would be a lie the UI then waits on.
+    logger.error("[kiosk] installer succeeded but nothing was installed")
+    _kiosk_task_set(phase='failed',
+                    error='The installer reported success but installed neither a service nor an '
+                          'autostart entry. Click Diagnose for the full picture.')
+    return False
+
+
 def _dispatch_kiosk_change(prev_enabled: bool, new_enabled: bool, settings_changed: bool) -> None:
     """Background worker: install/start/stop the kiosk to match config.
     Handles both modes (autostart .desktop entry on Pi OS Desktop, systemd
@@ -3696,39 +3752,7 @@ def _dispatch_kiosk_change(prev_enabled: bool, new_enabled: bool, settings_chang
     _kiosk_task_set(busy=True, phase='starting', error=None, started=time.time())
     try:
         if new_enabled and not prev_enabled:
-            if not _kiosk_installed():
-                logger.info(f"[kiosk] running installer: {KIOSK_INSTALL_SCRIPT}")
-                # Installing chromium: minutes on a Pi Zero 2 W. The UI shows
-                # this phase instead of timing the poll out.
-                _kiosk_task_set(phase='installing')
-                proc = subprocess.run(
-                    ['sudo', 'bash', KIOSK_INSTALL_SCRIPT],
-                    capture_output=True, text=True, timeout=600, check=False
-                )
-                if proc.returncode != 0:
-                    detail = (proc.stderr.strip() or proc.stdout.strip() or '').splitlines()
-                    detail = detail[-1] if detail else f'exit code {proc.returncode}'
-                    logger.error(f"[kiosk] install failed (rc={proc.returncode}): {proc.stderr.strip() or proc.stdout.strip()}")
-                    # Surface it. This failure never reaches the systemd journal
-                    # — the unit does not exist yet — so telling the user to
-                    # check journalctl sent them somewhere with nothing in it.
-                    _kiosk_task_set(phase='failed', error=f'Installer failed: {detail}')
-                    return
-                logger.info("[kiosk] install completed")
-            mode = _kiosk_mode()
-            _kiosk_task_set(phase='starting')
-            if mode == 'service':
-                enable_proc = _run_systemctl(['enable', '--now', KIOSK_SERVICE])
-                if enable_proc.returncode != 0:
-                    err = enable_proc.stderr.strip() or enable_proc.stdout.strip() or 'unknown error'
-                    logger.error(f"[kiosk] enable --now failed: {err}")
-                    _kiosk_task_set(phase='failed', error=f'Could not start the kiosk service: {err}')
-                else:
-                    logger.info("[kiosk] systemd service enabled and started")
-            else:
-                # Autostart mode: install handles next-login flow. Spawn now too.
-                if not _kiosk_running():
-                    _spawn_kiosk_in_session()
+            _kiosk_install_and_start()
         elif prev_enabled and not new_enabled:
             _kiosk_task_set(phase='removing')
             # Kill any running kiosk chromium first (autostart mode)
@@ -6054,6 +6078,48 @@ def kiosk_status():
     except Exception as exc:
         logger.error(f"Error getting kiosk status: {exc}")
         return jsonify({'error': str(exc)}), 500
+
+
+@app.route('/api/kiosk/repair', methods=['POST'])
+def kiosk_repair():
+    """Re-run the kiosk installer and start it, whatever the current state.
+
+    The toggle only acts on a *change*, so a box whose config already says
+    kiosk_enabled - an install that failed halfway, a restored config, a unit
+    that was removed by hand - had no way back: turning the switch on when it is
+    already on does nothing. That is what left people running
+    `sudo bash scripts/install_kiosk.sh` themselves. This is that command,
+    automated, with the enable step included.
+    """
+    task = _kiosk_task_get()
+    if task.get('busy'):
+        return jsonify({'success': False,
+                        'error': f"A kiosk job is already running ({task.get('phase')})."}), 409
+
+    def worker():
+        _kiosk_task_set(busy=True, phase='installing', error=None, started=time.time())
+        try:
+            _kiosk_install_and_start()
+        except subprocess.TimeoutExpired:
+            logger.error("[kiosk] repair timed out")
+            _kiosk_task_set(phase='failed', error='Kiosk repair timed out.')
+        except Exception as exc:
+            logger.error(f"[kiosk] repair error: {exc}")
+            _kiosk_task_set(phase='failed', error=str(exc))
+        finally:
+            with _kiosk_task_lock:
+                _kiosk_task['busy'] = False
+
+    # Remember the intent, so a reboot mid-repair still comes up with the kiosk.
+    if not shared_data.config.get('kiosk_enabled'):
+        shared_data.config['kiosk_enabled'] = True
+        try:
+            shared_data.save_config()
+        except Exception as exc:
+            logger.warning(f"[kiosk] could not persist kiosk_enabled during repair: {exc}")
+
+    threading.Thread(target=worker, daemon=True).start()
+    return jsonify({'success': True, 'message': 'Reinstalling and starting the kiosk…'})
 
 
 @app.route('/api/kiosk/diagnose', methods=['POST'])

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -3685,6 +3685,38 @@ def _spawn_kiosk_in_session() -> bool:
     return False
 
 
+def _kiosk_failure_detail(max_chars: int = 400) -> str:
+    """The most specific line available about why the kiosk service died.
+
+    Prefers the wrapper's own error output over the unit journal: the journal
+    line people paste is almost always "Main process exited, status=1/FAILURE",
+    which names no cause at all, while the wrapper says things like "an X server
+    is already running" or dumps the Xorg error that actually killed it.
+    """
+    candidates = []
+    try:
+        journal = subprocess.run(
+            ['journalctl', '-u', KIOSK_SERVICE, '-n', '40', '--no-pager', '-o', 'cat'],
+            capture_output=True, text=True, timeout=15, check=False).stdout
+        candidates += [l.strip() for l in journal.splitlines()
+                       if 'kiosk-run' in l or '(EE)' in l or 'ERROR' in l]
+    except Exception:
+        pass
+    try:
+        with open('/var/log/ragnar/kiosk-wrapper.log', 'r', errors='replace') as fh:
+            tail = fh.readlines()[-40:]
+        candidates += [l.strip() for l in tail
+                       if 'ERROR' in l or 'WARN' in l or '(EE)' in l]
+    except OSError:
+        pass
+    if not candidates:
+        return ' Click Diagnose for the full picture.'
+    detail = ' '.join(candidates[-3:])
+    if len(detail) > max_chars:
+        detail = detail[:max_chars].rstrip() + '…'
+    return f' Last error: {detail} — click Diagnose for the full picture.'
+
+
 def _kiosk_install_and_start() -> bool:
     """Do exactly what `sudo bash scripts/install_kiosk.sh` + `systemctl enable
     --now ragnar-kiosk` do by hand, and report why if it does not take.
@@ -3720,11 +3752,32 @@ def _kiosk_install_and_start() -> bool:
     mode = _kiosk_mode()
     _kiosk_task_set(phase='starting')
     if mode == 'service':
+        # Clear a tripped start limit first. The unit gives up after 5 failures
+        # in 2 minutes and then refuses every later start with "start request
+        # repeated too quickly" until it is reset - so once a box has failed a
+        # few times, enabling it fails for a reason that has nothing to do with
+        # whatever is actually wrong, and the real error never gets a chance to
+        # reappear. This is the same `systemctl reset-failed` the kiosk doctor
+        # tells people to run by hand.
+        _run_systemctl(['reset-failed', KIOSK_SERVICE])
         enable_proc = _run_systemctl(['enable', '--now', KIOSK_SERVICE])
         if enable_proc.returncode != 0:
             err = enable_proc.stderr.strip() or enable_proc.stdout.strip() or 'unknown error'
             logger.error(f"[kiosk] enable --now failed: {err}")
-            _kiosk_task_set(phase='failed', error=f'Could not start the kiosk service: {err}')
+            _kiosk_task_set(phase='failed',
+                            error=f'Could not start the kiosk service: {err}{_kiosk_failure_detail()}')
+            return False
+        # `enable --now` returns as soon as the process is spawned, so a kiosk
+        # that dies a second later reported success and left the UI waiting on a
+        # service that was already gone. Give it a moment and say so instead.
+        time.sleep(5)
+        state = _systemctl_state_label('ragnar-kiosk')
+        if state not in ('active', 'activating'):
+            logger.error(f"[kiosk] service did not stay up (state={state})")
+            _kiosk_task_set(
+                phase='failed',
+                error=f'The kiosk service started and then stopped ({state}).'
+                      f'{_kiosk_failure_detail()}')
             return False
         logger.info("[kiosk] systemd service enabled and started")
         return True


### PR DESCRIPTION
This pull request delivers several improvements to the kiosk installation, troubleshooting, and user interface experience. The main focus is on making the kiosk service more robust and user-friendly—especially in diagnosing and recovering from installation or startup failures. Key changes include fixes for Xorg logging under elevated privileges, enhanced troubleshooting tools in both the web UI and scripts, and more reliable detection of desktop sessions.

**Troubleshooting and Recovery Improvements:**

- Added a **"Reinstall"** button to the web UI, which reruns the installer and enables the kiosk service regardless of current state, making recovery from partial or failed installs straightforward. [[1]](diffhunk://#diff-7a539845f7a3dbcb375c4f1fd20d0e033f28fd246928b5167f61ffef837e62f8R5932-R5942) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L25083-R25165)
- Added a **"Diagnose"** button to the web UI, which runs `scripts/kiosk_doctor.sh` and displays its report directly in the browser, allowing users to diagnose blank screens or startup issues without SSH access. [[1]](diffhunk://#diff-7a539845f7a3dbcb375c4f1fd20d0e033f28fd246928b5167f61ffef837e62f8R5932-R5942) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L25083-R25165)

**Xorg Logging and Service Robustness:**

- Fixed a bug where Xorg would fail to start in service mode due to the `-logfile` flag being refused under elevated privileges. The wrapper now lets Xorg write its default log and copies it to the expected location, ensuring logs are always available for troubleshooting. [[1]](diffhunk://#diff-eda6a67acfc8885738f6278339c77da71bb12a3ce91c37ca010eceb1364be21eL336-R363) [[2]](diffhunk://#diff-cf135308c1100276b29b8b6cfcd406af97e321e999edcb93a65cf4d74036e0bdR136-R154)
- Updated `scripts/kiosk_doctor.sh` to check both the standard and user-specific Xorg log locations, so errors are always captured regardless of how Xorg was started.

**Session Detection and User Identification:**

- Rewrote the logic for detecting the active desktop session in `scripts/install_kiosk.sh` to be more robust across different systemd versions and avoid misidentifying SSH users as the graphical session owner.
- Improved backend detection of X11 sessions in the web app, ensuring the kiosk can be launched reliably on systems still using X11 instead of Wayland.

**User Interface and Messaging:**

- Enhanced error messages in the web UI to direct users to the correct log or troubleshooting tool based on actual kiosk mode and installation state, reducing confusion when the service unit does not exist. [[1]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R25018-R25043) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L25083-R25165)

These changes collectively make the kiosk feature much more resilient, easier to recover, and simpler for users to diagnose and fix common problems.