### PR TITLE
Kiosk: find the Xorg log, and tell a live kiosk from a dead one

### DIFF
--- a/docs/kiosk.md
+++ b/docs/kiosk.md
@@ -147,10 +147,20 @@ non-root user, so X can only start through the setuid `Xorg.wrap` the installer
 installs (`xserver-xorg-legacy` + `needs_root_rights=yes`). X therefore aborted
 while still parsing its arguments — before opening any log — which is why the
 journal showed a bare exit code with nothing to go on and the restart loop
-tripped the start limit. The wrapper no longer passes the flag; X writes to
-`~/.local/share/xorg/Xorg.0.log` and the wrapper copies that to
-`/var/log/ragnar/kiosk-Xorg.log`, so both paths keep working. Update and click
-**Reinstall**.
+tripped the start limit. The wrapper no longer passes the flag. X then writes wherever its default is —
+`/var/log/Xorg.0.log` when it is really root (the setuid wrapper case, which is
+service mode) or `~/.local/share/xorg/Xorg.0.log` when it is rootless — and the
+wrapper copies whichever it finds to `/var/log/ragnar/kiosk-Xorg.log`, so that
+stays the one place to look. Update and click **Reinstall**.
+
+**Service `active (running)` but the screen is blank.** In service mode the unit
+uses `PAMName=login`, so logind moves the real work into the login session's own
+scope: `systemctl status` shows `Tasks: 0` and no browser, however healthy the
+kiosk is. That is normal and not a symptom. The doctor checks for the Chromium
+and X processes directly for exactly this reason — read those two lines, not the
+task count. On a 512 MB board (Pi Zero 2 W reports ~415 MB usable) a missing
+browser there is nearly always memory; confirm with
+`sudo dmesg | grep -i 'killed process'`.
 
 **"Cannot establish any listening sockets — Make sure an X server isn't already
 running"** means service mode is trying to start its own X on `:0` while a

--- a/scripts/kiosk_doctor.sh
+++ b/scripts/kiosk_doctor.sh
@@ -135,6 +135,19 @@ if [ "$MODE" = "service" ]; then
     STATE="$(systemctl is-active "$SERVICE" 2>/dev/null)"
     check "Service is active" "$([ "$STATE" = "active" ] && echo 0 || echo 1)" \
           "see the journal and wrapper log below"
+    # "active" only means the wrapper is alive. PAMName=login moves the real
+    # work into the login session's own scope, so the unit's own Tasks count
+    # reads 0 and the browser never shows up in `systemctl status` - checking
+    # for the process directly is the only way to tell a working kiosk from a
+    # wrapper sitting there with a dead browser.
+    if [ "$STATE" = "active" ]; then
+        check "Kiosk chromium process running" \
+              "$(pgrep -f 'ragnar-kiosk-chromium' >/dev/null 2>&1 && echo 0 || echo 1)" \
+              "X is up but the browser is not - see the wrapper log below (on a 512MB board it is usually memory)"
+        check "X server running" \
+              "$(pgrep -x Xorg >/dev/null 2>&1 || pgrep -x X >/dev/null 2>&1 && echo 0 || echo 1)" \
+              "the wrapper started but X did not - see section 7"
+    fi
     # A tripped start limit stays stopped until reset — easy to miss.
     if systemctl show "$SERVICE" -p NRestarts 2>/dev/null | grep -qv 'NRestarts=0'; then
         echo "  $(systemctl show "$SERVICE" -p NRestarts 2>/dev/null)"
@@ -179,7 +192,9 @@ section "7. Xorg log (service mode)"
 # Xorg refuses -logfile under the setuid wrapper, so a non-root kiosk leaves its
 # log in the user's own directory instead. Check both, or a real X failure looks
 # like "X never started".
-XORG_LOGS="$LOG_DIR/kiosk-Xorg.log"
+# /var/log/Xorg.0.log is where it lands in service mode: started through the
+# setuid Xorg.wrap, X is really root and uses the system default path.
+XORG_LOGS="$LOG_DIR/kiosk-Xorg.log /var/log/Xorg.0.log"
 for home in /home/* /root; do
     [ -f "$home/.local/share/xorg/Xorg.0.log" ] && XORG_LOGS="$XORG_LOGS $home/.local/share/xorg/Xorg.0.log"
 done
@@ -204,7 +219,19 @@ if [ -z "$(ls /dev/dri/card* 2>/dev/null)" ]; then
           "headless box: the kiosk needs a real display (HDMI/DSI) attached"
 fi
 echo "  model: $(tr -d '\0' < /proc/device-tree/model 2>/dev/null || echo unknown)"
-echo "  RAM  : $(awk '/^MemTotal:/{printf "%d MB", $2/1024}' /proc/meminfo 2>/dev/null)"
+RAM_MB="$(awk '/^MemTotal:/{printf "%d", $2/1024}' /proc/meminfo 2>/dev/null || echo 0)"
+SWAP_MB="$(awk '/^SwapTotal:/{printf "%d", $2/1024}' /proc/meminfo 2>/dev/null || echo 0)"
+echo "  RAM  : ${RAM_MB} MB (swap ${SWAP_MB} MB)"
+# Not a [FAIL] - the kiosk does run on these boards - but when the browser is
+# missing from section 4 on one of them, this is nearly always the reason.
+if [ "${RAM_MB:-0}" -gt 0 ] && [ "${RAM_MB:-0}" -lt 1024 ]; then
+    echo "  NOTE: under 1 GB of RAM. Chromium itself warns about this. The wrapper"
+    echo "        already applies its low-memory flags; if the browser keeps dying,"
+    echo "        check for OOM kills with:  sudo dmesg | grep -i 'killed process'"
+fi
+if pgrep -f 'ragnar-kiosk-chromium' >/dev/null 2>&1; then
+    echo "  chromium RSS: $(ps -o rss= -C chromium 2>/dev/null | awk '{s+=$1} END {printf "%d MB", s/1024}')"
+fi
 
 # ---------------------------------------------------------------------------
 section "9. Configured URL"

--- a/scripts/ragnar_kiosk_run.sh
+++ b/scripts/ragnar_kiosk_run.sh
@@ -240,8 +240,22 @@ fi
 
 XORG_LOG="$LOG_DIR/kiosk-Xorg.log"
 mkdir -p "$HOME/.local/share/xorg" 2>/dev/null || true
-# Where Xorg puts its log when we are NOT allowed to name one (see below).
-XORG_OWN_LOG="$HOME/.local/share/xorg/Xorg.0.log"
+# Where Xorg puts its log when we are NOT allowed to name one (see below). Which
+# of these it picks depends on how it ended up privileged: started through the
+# setuid Xorg.wrap it is really root and writes the system log, while a rootless
+# X writes into the user's own directory. Check both, newest first, or a real X
+# failure reads as "X never started".
+xorg_own_log() {
+    local newest=""
+    local candidate
+    for candidate in /var/log/Xorg.0.log "$HOME/.local/share/xorg/Xorg.0.log"; do
+        [[ -s "$candidate" ]] || continue
+        if [[ -z "$newest" || "$candidate" -nt "$newest" ]]; then
+            newest="$candidate"
+        fi
+    done
+    printf '%s' "$newest"
+}
 rm -f /tmp/.X0-lock 2>/dev/null || true
 rm -f /tmp/.X11-unix/X0 2>/dev/null || true
 
@@ -281,10 +295,16 @@ if [[ -n "\$PRIMARY" && "\$ROT" != "normal" ]]; then
     xrandr --output "\$PRIMARY" --rotate "\$ROT" || true
 fi
 
-if command -v openbox-session >/dev/null 2>&1; then
-    openbox-session &
-elif command -v openbox >/dev/null 2>&1; then
+# Plain openbox, deliberately not openbox-session. A kiosk wants a window
+# manager, not a desktop: openbox-session additionally runs every XDG autostart
+# entry on the box, which on a 512 MB Pi Zero 2 W is memory this cannot spare
+# and which produced the alarming-looking
+#   ERROR: openbox-xdg-autostart requires PyXDG to be installed
+# in the kiosk log, pointing at a component the kiosk never needed.
+if command -v openbox >/dev/null 2>&1; then
     openbox &
+elif command -v openbox-session >/dev/null 2>&1; then
+    openbox-session &
 fi
 
 if [[ "$KIOSK_HIDE_CURSOR" == "true" ]] && command -v unclutter >/dev/null 2>&1; then
@@ -355,12 +375,13 @@ XINIT_PID=$!
 if wait "$XINIT_PID"; then rc=0; else rc=$?; fi
 # Keep /var/log/ragnar/kiosk-Xorg.log as the one place to look, whichever log
 # Xorg was actually allowed to write.
-if [[ ! -s "$XORG_LOG" && -s "$XORG_OWN_LOG" ]]; then
-    cp -f "$XORG_OWN_LOG" "$XORG_LOG" 2>/dev/null || true
+OWN_LOG="$(xorg_own_log)"
+if [[ ! -s "$XORG_LOG" && -n "$OWN_LOG" ]]; then
+    cp -f "$OWN_LOG" "$XORG_LOG" 2>/dev/null || true
 fi
 if [[ "$rc" -ne 0 && "$rc" -ne 143 && "$rc" -ne 130 ]]; then
     echo "[kiosk-run] X/xinit exited with code $rc — last Xorg log lines:" >&2
-    { tail -n 25 "$XORG_LOG" 2>/dev/null || tail -n 25 "$XORG_OWN_LOG" 2>/dev/null; } >&2 || true
+    tail -n 25 "$XORG_LOG" 2>/dev/null >&2 || true
     echo "[kiosk-run] full detail: $XORG_LOG and $WRAPPER_LOG" >&2
 fi
 exit "$rc"


### PR DESCRIPTION
The doctor report from the field confirmed the -logfile diagnosis outright — the wrapper log opens with

    Invalid argument -logfile with elevated privileges

followed by the crash loop up to "Start request repeated too quickly". After updating, the same box starts X and the service stays active. Three things that report showed were still wrong or unhelpful:

The Xorg log was still reported missing. Started through the setuid Xorg.wrap X is really root, so it writes /var/log/Xorg.0.log — not the rootless ~/.local/share/xorg/Xorg.0.log this looked for. The wrapper now picks whichever of the two is newer and non-empty and copies that to kiosk-Xorg.log; the doctor reads all three. The one section that exists to explain an X failure was the one section with nothing in it.

"Service is active" was being read as "the kiosk works". It is not: PAMName=login means logind moves the real work into the login session's own scope, so the unit's own accounting reads Tasks: 0 and never lists the browser, however healthy the kiosk is. The doctor now checks for the Chromium and X processes directly, so a wrapper sitting there with a dead browser is visible instead of passing every check. Under 1 GB it also says so and names the OOM check — that board reports ~415 MB and Chromium warns about it itself.

And the kiosk started openbox-session, which runs every XDG autostart entry on the box: memory a 512 MB board cannot spare, and the source of the alarming

    ERROR: openbox-xdg-autostart requires PyXDG to be installed

in the log, pointing at a component the kiosk never needed. Plain openbox is what a kiosk wants — a window manager, not a desktop.