### PR TITLE
Make Traffic Analysis available on every board, not just servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   </tr>
 </table>
 
-Ragnar is a fork of the awesome [Bjorn](https://github.com/infinition/Bjorn) project — a Tamagotchi-like autonomous network scanning, vulnerability assessment, and offensive security tool. It runs on a **Raspberry Pi** with a 2.13-inch e-Paper HAT, as a **headless server** on Debian-based systems (AMD64/ARM/ARM64) with Ethernet-first connectivity, or on the **WiFi Pineapple Pager** with full-color LCD display. On servers with 8GB+ RAM, Ragnar unlocks advanced capabilities including real-time traffic analysis and enhanced vulnerability scanning.
+Ragnar is a fork of the awesome [Bjorn](https://github.com/infinition/Bjorn) project — a Tamagotchi-like autonomous network scanning, vulnerability assessment, and offensive security tool. It runs on a **Raspberry Pi** with a 2.13-inch e-Paper HAT, as a **headless server** on Debian-based systems (AMD64/ARM/ARM64) with Ethernet-first connectivity, or on the **WiFi Pineapple Pager** with full-color LCD display. On servers with 8GB+ RAM, Ragnar unlocks advanced capabilities including enhanced vulnerability scanning and parallel scanning.
 
 > [!IMPORTANT]
 > **For educational and authorized testing purposes only.**
@@ -83,7 +83,8 @@ the adapter with the BLE overlay scanner); enable it from the app's Box tab or
 - **AI-Powered Analysis** — GPT-5 Nano integration for security summaries, vulnerability prioritization, and remediation advice. See [AI Integration Guide](docs/AI_INTEGRATION.md)
 - **System Attacks** — Brute-force attacks on FTP, SSH, SMB, RDP, Telnet, SQL
 - **File Stealing** — Extracts data from vulnerable services
-- **Advanced Server Features (8GB+ RAM)** — Real-time traffic analysis, advanced vulnerability scanning with Nuclei/Nikto/SQLMap/ZAP, parallel scanning, and CVE correlation. See [Server Mode](#-server-mode-advanced-features-8gb-ram)
+- **Traffic Analysis** — Live `tcpdump` capture in its own web-UI tab: per-host bandwidth and top talkers, connection tracking, protocol mix, DNS logging, and detection of **port scans**, **DNS tunnelling** and **C2 beacons** (interval/size-regularity scoring). Also drives **passive host discovery** — firewalled hosts that never answer a scan still land in the hosts DB. **Detection-only**, it never sends a packet. Needs only `tcpdump`, so it runs on **any board**, Pi Zero included (measured: 0.4% of one Pi 5 core and 18MB RSS at ~90 pkt/s); only the optional `tshark` JA3/IRC sidecars need a bigger board. See [Traffic Analysis](docs/traffic-analysis.md)
+- **Advanced Server Features (8GB+ RAM)** — Advanced vulnerability scanning with Nuclei/Nikto/SQLMap/ZAP, parallel scanning, and CVE correlation. See [Server Mode](#-server-mode-advanced-features-8gb-ram)
 - **LAN-First Connectivity** — Prefers Ethernet when present, manages WiFi as fallback
 - **Smart WiFi Management** — Auto-connects to known networks, falls back to AP mode, captive portal for configuration
 - **E-Paper Display** — Real-time status showing targets, vulnerabilities, credentials, and network info
@@ -133,7 +134,7 @@ See [Gen 2 Hardware Requirements](docs/hardware-gen2.md) for the full BOM, assem
 
 - Debian 11+ or Ubuntu 20.04+ (AMD64, ARM64, or ARMv7)
 - Minimum: 2GB RAM, 2 CPU cores, 10GB free disk
-- Recommended: 8GB+ RAM for advanced features (traffic analysis, Nuclei, Nikto, SQLMap)
+- Recommended: 8GB+ RAM for advanced features (Nuclei, Nikto, SQLMap, ZAP). Traffic analysis is not in this tier — it needs only `tcpdump`
 
 ### WiFi Pineapple Pager
 
@@ -164,6 +165,11 @@ For the full installation walkthrough see [Install Guide](docs/INSTALL.md). For 
 
 When deployed on systems with 8GB+ RAM, Ragnar automatically unlocks advanced security capabilities.
 
+> **Traffic Analysis is not one of them any more.** It is a `tcpdump` pipe, not
+> OpenVAS-class work, so it has its own much lower gate and runs on any board
+> with `tcpdump` installed — see [Traffic Analysis](docs/traffic-analysis.md).
+> Only its optional `tshark` JA3/IRC sidecars need a 4GB-class board.
+
 > **Fresh installs:** The main installer detects 8GB+ RAM and installs advanced tools automatically.
 >
 > **Existing installs:** Run the advanced tools installer separately:
@@ -172,14 +178,6 @@ When deployed on systems with 8GB+ RAM, Ragnar automatically unlocks advanced se
 > sudo ./scripts/install_advanced_tools.sh
 > sudo systemctl restart ragnar
 > ```
-
-### Real-Time Traffic Analysis
-- Live packet capture with tcpdump and tshark
-- Connection tracking with detailed TCP/UDP statistics
-- Deep protocol inspection (HTTP, DNS, SMB, SSH)
-- Per-host bandwidth monitoring and top talkers
-- Automated security risk scoring and anomaly detection
-- DNS query logging and port activity monitoring
 
 ### Advanced Vulnerability Scanning
 - **OWASP ZAP** — Spider + AJAX spider + active scan with automatic browser detection

--- a/docs/grade.md
+++ b/docs/grade.md
@@ -49,7 +49,7 @@ Legend: `✅✅` strong · `✅` yes · `⚠️` partial · `❌` no
 | Nessus | Vuln scanning (commercial) | Huge QA'd plugin DB, low FP, compliance audits | 6/10 |
 | OWASP ZAP | Web app scanning | Ragnar *is* ZAP + a custom context-aware fuzzer → automation parity-plus | 7/10 |
 | Burp Suite | Web app pentest | Burp Pro's manual proxy/Repeater/Intruder + Collaborator OOB still ahead | 6/10 |
-| Zeek | NSM (passive/defensive) | `traffic_analyzer` does C2/DNS-tunnel/port-scan detection — same categories, heuristic depth, 8GB-gated | 4/10 |
+| Zeek | NSM (passive/defensive) | `traffic_analyzer` does C2/DNS-tunnel/port-scan detection — same categories, heuristic depth; runs on any board (only the tshark sidecars are gated) | 4/10 |
 | Wazuh | SIEM/XDR/HIDS | `threat_intelligence` (MISP/VT/Shodan/OpenCTI) gives enrichment — but no agents, FIM, compliance, fleet scale | 3/10 |
 | Kali-on-Pi (drop box) | Portable pentest | More raw power, but manual, headless, no autonomy/UX/hardening | 7/10 |
 
@@ -64,8 +64,10 @@ auth layer that most hobby tools lack.
 
 1. **Breadth over depth** — every module trails its specialist (Zeek / Wazuh /
    Nessus / Burp) on depth, QA, and false-positive discipline.
-2. **8GB-gating** — traffic analysis, advanced vuln scanning, and the heavy intel
-   features do not run on the Pi Zero tier.
+2. **8GB-gating** — advanced vuln scanning and the heavy intel features do not
+   run on the Pi Zero tier. (Traffic analysis used to be in this list; it is a
+   tcpdump pipe, so it now runs on any board — see
+   [Traffic Analysis](traffic-analysis.md).)
 3. **Unverified claims** — e.g. the "predictive ML / threat attribution" in
    `threat_intelligence.py` is credited from docstrings, not confirmed behavior.
 4. **Solo maintenance, no ecosystem** — the one weakness that appears in every
@@ -80,7 +82,8 @@ auth layer that most hobby tools lack.
   a custom `ragnar-fuzz` engine with a 19-category payload library and
   context-aware reflection triage. Also wires Nuclei, Nikto, SQLMap, WhatWeb.
 - `traffic_analyzer.py` — tcpdump capture, C2 beacon detection, DNS tunneling and
-  port-scan detection (server-mode / 8GB+).
+  port-scan detection; 0.4% of one Pi 5 core and 18MB RSS at ~90 pkt/s, with
+  capped/evicted tracked state so it is safe on a 512MB board.
 - `threat_intelligence.py` — multi-source TI fusion (MISP, OpenCTI, VirusTotal,
   Shodan), risk scoring, IOC management.
 - `network_intelligence.py` — network-aware, active/resolved vuln + credential

--- a/docs/traffic-analysis.md
+++ b/docs/traffic-analysis.md
@@ -1,0 +1,107 @@
+# Traffic Analysis
+
+Live packet capture and passive network monitoring, in its own web-UI tab
+(**Traffic**). It runs `tcpdump` on one interface and reads the output line by
+line: per-host bandwidth, connection tracking, protocol mix, DNS logging, and
+detection of port scans, DNS tunnelling and C2 beacons.
+
+**Detection-only.** It never sends a packet.
+
+## Where it runs
+
+Traffic Analysis used to be gated behind server mode (7.5GB+ RAM), alongside
+OpenVAS-class vulnerability scanning. That was the wrong bar — the two have
+nothing in common in what they cost. Measured on a Pi 5 against a live LAN at
+~90 packets/sec:
+
+| Component | Cost |
+|---|---|
+| Analyzer (Python parse loop) | **0.4%** of one core, **18MB** RSS |
+| `tcpdump` | **8MB** RSS |
+| JA3 / IRC sidecars (`tshark`, optional) | ~**290MB** RSS *each*, plus a ~155MB `dumpcap` child |
+
+So the capture core is a Pi Zero workload, and it is now available on **any
+board Ragnar runs on**. The single hard requirement is `tcpdump`:
+
+```bash
+sudo apt-get install tcpdump
+```
+
+If it is missing, the Traffic tab is hidden and the API says so by name rather
+than blaming the hardware.
+
+The gates live in `server_capabilities.py`:
+
+| Gate | Floor | Why |
+|---|---|---|
+| `traffic_capable` | `tcpdump` present, supported arch, RAM readable (`TRAFFIC_MIN_RAM_GB`) | the capture core |
+| `traffic_sidecars_enabled` | `tshark` present **and** 3.5GB RAM (`TRAFFIC_SIDECAR_MIN_RAM_GB`) | a tshark pair outweighs everything a Zero has |
+| `is_server_capable` | 7.5GB RAM | unrelated — OpenVAS, Nuclei, big dictionaries |
+
+A board below the sidecar bar loses only JA3 fingerprinting and IRC DPI. Packet
+capture, host/connection stats, port-scan, DNS-tunnel and beacon detection are
+unaffected, and the skip is logged with the board's actual numbers.
+
+## Memory on a small board
+
+Alerts and DNS queries were already ring buffers, but tracked hosts,
+connections and beacon flow history gain an entry per new peer seen — on a
+capture left running for a week, that is the only state without a ceiling.
+`TrafficAnalyzer._prune_state()` runs every 60s off the packet path and evicts
+the least-recently-seen entries back under the caps:
+
+| | ≥1GB RAM | <1GB RAM (Pi Zero class) |
+|---|---|---|
+| Hosts | 4000 | 500 |
+| Connections | 8000 | 1000 |
+| Beacon flows | 2000 | 250 |
+
+At the low-memory numbers the tracked state tops out around 3MB. A RAM read of
+0 (detection failed) takes the low-memory branch — that is when conservative
+numbers are wanted most. Per-IP side tables (MAC, hostname, listening ports,
+DNS timing) are dropped along with the host they belong to; they rebuild from
+the next packet.
+
+## What it detects
+
+| Category | Signal |
+|---|---|
+| `port_scan` | many distinct ports from one source (vertical), or one port across many hosts (horizontal sweep). Default gateway gets a softer threshold |
+| `c2_beacon` | repeated contact with an external `(ip, port)` at low-jitter intervals and consistent payload sizes — scored `0.6 × interval regularity + 0.4 × size regularity` |
+| `dns_tunneling` | query rate from a single host over threshold |
+| `suspicious_port` | traffic to known backdoor / C2 / Tor ports (TCP unicast only for the ports where a UDP broadcast would just be IoT noise) |
+| `data_exfiltration`, `high_bandwidth`, `brute_force`, `protocol_anomaly` | volume and pattern heuristics |
+
+Alerts are rate-limited (10/min) and deduplicated in a 300s window.
+
+Capture also feeds **passive host discovery**: LAN hosts seen only in traffic —
+firewalled boxes that never answer a scan — are flushed into the hosts DB every
+30s, with MACs learned from ARP replies and services inferred from the ports
+they answer on.
+
+## API
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/traffic/status` | availability + `reason` when unavailable, plus the summary |
+| `POST /api/traffic/start` / `stop` | control capture (optional `interface`) |
+| `GET /api/traffic/hosts` `?limit=&sort=` | top talkers |
+| `GET /api/traffic/connections` | active connections |
+| `GET /api/traffic/alerts` `?limit=&level=` | alert feed |
+| `GET /api/traffic/beacons` | scored beacon candidates |
+| `GET /api/traffic/ja3` / `irc` | sidecar output (empty when sidecars are gated off) |
+| `GET /api/traffic/debug` | tcpdump path, sudo check, queue depth, interface list |
+| `GET /api/server/capabilities` | `features.traffic_analysis`, `features.traffic_sidecars` |
+
+`POST /api/server/install-tools` with `{"feature": "traffic_analysis"}` installs
+the capture tools, and unlike the vulnerability-scanner tools it works on any
+board — that is the path that installs the missing `tcpdump`.
+
+## Notes
+
+- Capture excludes ports 22 and 8000 so SSH and the web UI do not analyze
+  themselves.
+- `tcpdump` runs under `sudo`; the installer's sudoers rules cover it.
+- On a managed-mode Wi-Fi interface you see the host's own traffic plus
+  broadcast, not the whole segment. For full visibility, capture on a wired port
+  with a SPAN/mirror.

--- a/install_ragnar.sh
+++ b/install_ragnar.sh
@@ -2253,7 +2253,7 @@ except:
         echo -e "${CYAN}  Installing Advanced Security Tools${NC}"
         echo -e "${CYAN}═══════════════════════════════════════════════════════════════${NC}"
         echo -e "${GREEN}Your system has sufficient resources for advanced features:${NC}"
-        echo -e "  ${BLUE}•${NC} Real-time traffic analysis (tcpdump, tshark, ngrep)"
+        echo -e "  ${BLUE}•${NC} Deep traffic analysis extras (tshark JA3/IRC sidecars, ngrep)"
         echo -e "  ${BLUE}•${NC} Advanced vulnerability scanning (Nuclei, Nikto, SQLMap)"
         echo -e "  ${BLUE}•${NC} Web application security testing (OWASP ZAP)"
         echo -e "  ${BLUE}•${NC} Enhanced Nmap vulnerability scripts"

--- a/server_capabilities.py
+++ b/server_capabilities.py
@@ -6,11 +6,16 @@ This module detects when Ragnar is running on a capable server (AMD64/ARM64 with
 and unlocks advanced features that would be impossible on a Pi Zero W2.
 
 Features unlocked in server mode:
-- Traffic Analysis (packet capture, network monitoring)
 - Advanced Vulnerability Assessment (OpenVAS, Nuclei, Nikto)
 - Parallel scanning
 - Large dictionary attacks
 - Local AI/LLM integration
+
+Not everything heavy-sounding belongs behind that bar. Two features have their
+own, much lower gates because what they actually cost has nothing to do with
+OpenVAS-class work:
+- Traffic Analysis - a tcpdump pipe parsed in Python (see TRAFFIC_MIN_RAM_GB)
+- The on-screen kiosk - one Chromium (see KIOSK_MIN_RAM_GB)
 """
 
 import os
@@ -41,6 +46,8 @@ class SystemCapabilities:
     is_pi_zero: bool = False
     kiosk_capable: bool = False
     kiosk_block_reason: str = ""
+    traffic_capable: bool = False
+    traffic_block_reason: str = ""
     hostname: str = ""
     os_name: str = ""
     os_version: str = ""
@@ -48,6 +55,7 @@ class SystemCapabilities:
     
     # Feature flags
     traffic_analysis_enabled: bool = False
+    traffic_sidecars_enabled: bool = False
     advanced_vuln_enabled: bool = False
     parallel_scanning_enabled: bool = False
     local_ai_enabled: bool = False
@@ -83,6 +91,19 @@ class ServerCapabilities:
     # firmware/kernel reservations mean a real 2GB Pi 4 reports ~1.9GB.
     KIOSK_MIN_RAM_GB = 1.8
     KIOSK_MIN_CORES = 2
+    # Traffic Analysis is a tcpdump pipe read line by line in Python. Measured
+    # on a Pi 5 against a live LAN at ~90 packets/sec: 0.4% of one core, 18MB
+    # RSS for the analyzer and 8MB for tcpdump. That is a Pi Zero 2 W workload,
+    # not a server one - so it gets its own floor rather than server mode's
+    # 7.5GB. Kept above zero only to fail closed when RAM cannot be read; a
+    # 512MB Zero 2 W reports ~0.42GB after the GPU split.
+    TRAFFIC_MIN_RAM_GB = 0.3
+    TRAFFIC_MIN_CORES = 1
+    # The JA3 and IRC sidecars are the exception: each spawns a full tshark
+    # dissector (measured ~290MB RSS each, plus a ~155MB dumpcap child), so the
+    # pair costs more than a Zero has in total. They stay a big-board feature
+    # while the tcpdump core runs everywhere.
+    TRAFFIC_SIDECAR_MIN_RAM_GB = 3.5
     # Include armv8l which is 32-bit userspace on 64-bit ARM (Pi 4/5 with 32-bit OS)
     SUPPORTED_ARCHS = ['x86_64', 'amd64', 'aarch64', 'arm64', 'armv8l', 'armv7l']
     
@@ -247,10 +268,18 @@ class ServerCapabilities:
         # question about running Chromium, not about running OpenVAS.
         caps.kiosk_capable, caps.kiosk_block_reason = self._evaluate_kiosk_support()
 
+        # Traffic Analysis is likewise its own gate: parsing tcpdump output is
+        # cheap enough for a Pi Zero, so it is not tied to server mode.
+        caps.traffic_capable, caps.traffic_block_reason = self._evaluate_traffic_support()
+        caps.traffic_analysis_enabled = caps.traffic_capable
+        # tshark sidecars (JA3 fingerprinting, IRC DPI) are the heavy part.
+        caps.traffic_sidecars_enabled = (
+            caps.traffic_capable
+            and caps.total_ram_gb >= self.TRAFFIC_SIDECAR_MIN_RAM_GB
+            and caps.available_tools.get('tshark', False)
+        )
+
         if caps.is_server_capable:
-            # Traffic Analysis: needs tcpdump at minimum
-            caps.traffic_analysis_enabled = caps.available_tools.get('tcpdump', False)
-            
             # Advanced Vuln: needs nmap (which Ragnar already uses)
             caps.advanced_vuln_enabled = caps.available_tools.get('nmap', False)
             
@@ -263,8 +292,8 @@ class ServerCapabilities:
             # Large dictionaries: enabled on 7.5GB+ RAM (8GB devices report ~7.87GB)
             caps.large_dictionaries_enabled = caps.total_ram_gb >= 7.5
         else:
-            # All advanced features disabled on Pi Zero / low-spec systems
-            caps.traffic_analysis_enabled = False
+            # Server-class features stay off on Pi Zero / low-spec systems.
+            # Traffic Analysis is deliberately not in this list - see above.
             caps.advanced_vuln_enabled = False
             caps.parallel_scanning_enabled = False
             caps.local_ai_enabled = False
@@ -301,6 +330,52 @@ class ServerCapabilities:
             )
         return True, ""
 
+    def _evaluate_traffic_support(self) -> Tuple[bool, str]:
+        """Can this box run Traffic Analysis (tcpdump capture + parsing)?
+
+        Returns (capable, reason), same contract as _evaluate_kiosk_support:
+        `reason` is empty when capable and is shown verbatim otherwise.
+
+        Unlike the vulnerability scanners this needs no dictionaries, no
+        parallel scan fleet and no dissector - just a tcpdump pipe - so a Pi
+        Zero passes. The only hard requirement is tcpdump itself.
+        """
+        caps = self.capabilities
+        ram_gb = caps.total_ram_gb
+
+        if not caps.available_tools.get('tcpdump', False):
+            return False, (
+                "Traffic Analysis needs tcpdump, which is not installed. "
+                "Install it with: sudo apt-get install tcpdump"
+            )
+        if caps.architecture not in self.SUPPORTED_ARCHS:
+            return False, (
+                f"Traffic Analysis does not support this architecture "
+                f"({caps.architecture or 'unknown'})."
+            )
+        # A RAM read of 0 means psutil and /proc/meminfo both failed. Fail
+        # closed rather than start a capture on a box we cannot measure.
+        if ram_gb <= 0:
+            return False, "Traffic Analysis could not read this system's RAM size."
+        if ram_gb < self.TRAFFIC_MIN_RAM_GB:
+            return False, (
+                f"Traffic Analysis needs at least {self.TRAFFIC_MIN_RAM_GB:.1f}GB RAM. "
+                f"This board reports {ram_gb:.2f}GB."
+            )
+        if caps.cpu_cores < self.TRAFFIC_MIN_CORES:
+            return False, (
+                f"Traffic Analysis needs at least {self.TRAFFIC_MIN_CORES} CPU core."
+            )
+        return True, ""
+
+    def is_traffic_capable(self) -> bool:
+        """Check if Traffic Analysis may run on this hardware"""
+        return self.capabilities.traffic_capable
+
+    def traffic_block_reason(self) -> str:
+        """Why Traffic Analysis is unavailable ('' when it is available)"""
+        return self.capabilities.traffic_block_reason
+
     def is_kiosk_capable(self) -> bool:
         """Check if the on-screen kiosk may run on this hardware"""
         return self.capabilities.kiosk_capable
@@ -323,6 +398,7 @@ class ServerCapabilities:
         return {
             'server_mode': caps.is_server_capable,
             'traffic_analysis': caps.traffic_analysis_enabled,
+            'traffic_sidecars': caps.traffic_sidecars_enabled,
             'advanced_vuln_assessment': caps.advanced_vuln_enabled,
             'parallel_scanning': caps.parallel_scanning_enabled,
             'local_ai': caps.local_ai_enabled,
@@ -352,9 +428,12 @@ class ServerCapabilities:
     
     def install_missing_tools(self, feature: str) -> Tuple[bool, str]:
         """Attempt to install missing tools for a feature"""
-        if not self.capabilities.is_server_capable:
+        # Traffic Analysis runs on any board, so its tools install on any board
+        # too - and this is the path that installs the missing tcpdump the gate
+        # is complaining about. Only server-class features need server mode.
+        if feature != 'traffic_analysis' and not self.capabilities.is_server_capable:
             return False, "Server mode not available on this system"
-        
+
         missing = self.get_missing_tools(feature)
         if not missing:
             return True, "All required tools are already installed"
@@ -416,6 +495,20 @@ def get_server_capabilities(shared_data=None) -> ServerCapabilities:
 def is_server_mode() -> bool:
     """Quick check if running in server mode"""
     return get_server_capabilities().is_server_mode()
+
+
+def traffic_capability(shared_data=None) -> Tuple[bool, str]:
+    """(capable, reason) for Traffic Analysis on this hardware.
+
+    Never raises: a detection failure must not take the traffic API down, and a
+    box we cannot measure is treated as capable=False with a stated reason.
+    """
+    try:
+        caps = get_server_capabilities(shared_data)
+        return caps.is_traffic_capable(), caps.traffic_block_reason()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error(f"Traffic capability check failed: {exc}")
+        return False, f"Could not determine hardware capability for Traffic Analysis: {exc}"
 
 
 def kiosk_capability(shared_data=None) -> Tuple[bool, str]:

--- a/tests/test_traffic_capability.py
+++ b/tests/test_traffic_capability.py
@@ -1,0 +1,199 @@
+"""Tests for the Traffic Analysis hardware gate.
+
+Traffic Analysis used to ride on full server mode (7.5GB RAM), which was the
+wrong bar: the engine is a `tcpdump` pipe read line by line in Python. Measured
+on a Pi 5 against a live LAN at ~90 packets/sec it costs 0.4% of one core and
+18MB RSS, plus 8MB for tcpdump — a Pi Zero workload. It now has its own gate.
+
+What matters here is that the two gates stay separate, that the real
+requirement (tcpdump installed) is what the gate actually reports, and that the
+genuinely heavy part — the tshark sidecars, ~290MB RSS each — does *not* follow
+the core onto small boards.
+"""
+
+import threading
+from collections import deque
+from datetime import datetime, timedelta
+
+import pytest
+
+from server_capabilities import ServerCapabilities, SystemCapabilities
+from traffic_analyzer import ConnectionStats, HostTrafficStats, TrafficAnalyzer
+
+
+def caps_for(ram_gb, cores=4, arch='aarch64', tcpdump=True, tshark=True,
+             is_pi_zero=False, is_server_capable=False):
+    """A ServerCapabilities describing a made-up board, no hardware detection."""
+    sc = ServerCapabilities.__new__(ServerCapabilities)
+    sc.shared_data = None
+    sc.capabilities = SystemCapabilities(
+        architecture=arch,
+        total_ram_gb=ram_gb,
+        cpu_cores=cores,
+        is_pi_zero=is_pi_zero,
+        is_server_capable=is_server_capable,
+        available_tools={'tcpdump': tcpdump, 'tshark': tshark},
+    )
+    return sc
+
+
+@pytest.mark.parametrize("ram_gb,is_pi_zero", [
+    (0.42, True),    # Pi Zero 2 W: 512MB board, ~415MB usable
+    (0.9, False),    # Pi 4 1GB
+    (3.9, False),    # Pi 5 4GB — below server mode's 7.5GB bar
+    (7.87, False),   # Pi 5 8GB
+])
+def test_traffic_analysis_runs_on_any_board_with_tcpdump(ram_gb, is_pi_zero):
+    capable, reason = caps_for(ram_gb, is_pi_zero=is_pi_zero)._evaluate_traffic_support()
+    assert capable is True
+    assert reason == ""
+
+
+def test_missing_tcpdump_is_the_real_blocker_and_says_so():
+    """tcpdump is the one hard requirement, and the reason is shown verbatim in
+    the UI — so it has to name the package, not just say 'unavailable'."""
+    capable, reason = caps_for(7.87, tcpdump=False)._evaluate_traffic_support()
+    assert capable is False
+    assert 'tcpdump' in reason
+
+
+@pytest.mark.parametrize("kwargs", [
+    {'ram_gb': 0.0},                      # RAM unreadable — fail closed
+    {'ram_gb': 4.0, 'cores': 0},          # no usable core count
+    {'ram_gb': 4.0, 'arch': 'mips'},      # unsupported architecture
+])
+def test_unmeasurable_or_unsupported_boards_are_refused(kwargs):
+    capable, reason = caps_for(**kwargs)._evaluate_traffic_support()
+    assert capable is False
+    assert reason.strip()
+
+
+def test_gate_is_independent_of_full_server_mode():
+    """The whole point of the change: a 4GB Pi 5 is not 'server capable' (that
+    bar is 7.5GB for OpenVAS-class work) but it captures traffic fine."""
+    sc = caps_for(3.9, is_server_capable=False)
+    sc._determine_feature_flags()
+    assert sc.capabilities.is_server_capable is False
+    assert sc.capabilities.traffic_analysis_enabled is True
+    assert sc.get_feature_status()['traffic_analysis'] is True
+    # Server-class features must not have leaked through with it.
+    assert sc.capabilities.advanced_vuln_enabled is False
+
+
+def test_flags_land_on_the_capabilities_object():
+    """_determine_feature_flags must publish the gate: that is what
+    /api/server/capabilities and /api/traffic/status report."""
+    sc = caps_for(0.42, tcpdump=False, is_pi_zero=True)
+    sc._determine_feature_flags()
+    assert sc.capabilities.traffic_capable is False
+    assert sc.capabilities.traffic_block_reason
+    assert sc.get_feature_status()['traffic_analysis'] is False
+
+
+@pytest.mark.parametrize("ram_gb,tshark,expected", [
+    (0.42, True, False),    # Pi Zero: two tsharks outweigh the whole board
+    (1.9, True, False),     # 2GB Pi 4: kiosk-class, still not tshark-class
+    (3.9, True, True),      # 4GB Pi 5
+    (7.87, False, False),   # big board, but tshark is not installed
+])
+def test_tshark_sidecars_keep_their_own_higher_bar(ram_gb, tshark, expected):
+    sc = caps_for(ram_gb, tshark=tshark)
+    sc._determine_feature_flags()
+    assert sc.capabilities.traffic_sidecars_enabled is expected
+    # The core capture is unaffected either way.
+    assert sc.capabilities.traffic_analysis_enabled is True
+
+
+@pytest.mark.parametrize("feature", ['traffic_analysis'])
+def test_tool_install_is_allowed_without_server_mode(feature, monkeypatch):
+    """Installing tcpdump is how a small board *gets* Traffic Analysis, so the
+    install path must not be the thing that requires server mode."""
+    sc = caps_for(0.42, tcpdump=False, is_pi_zero=True, is_server_capable=False)
+    monkeypatch.setattr(sc, 'get_missing_tools', lambda f: [])
+    ok, message = sc.install_missing_tools(feature)
+    assert ok is True
+    assert 'Server mode' not in message
+
+
+def test_advanced_vuln_install_still_requires_server_mode():
+    sc = caps_for(3.9, is_server_capable=False)
+    ok, message = sc.install_missing_tools('advanced_vuln')
+    assert ok is False
+    assert 'Server mode' in message
+
+
+@pytest.mark.parametrize("ram_gb,expect_low", [
+    (0.42, True),    # Pi Zero 2 W
+    (0.0, True),     # RAM unreadable — take the conservative caps
+    (3.9, False),
+    (15.8, False),
+])
+def test_state_caps_shrink_on_small_boards(ram_gb, expect_low):
+    """Tracked hosts/connections/flows are the only unbounded state, so on a
+    512MB board they get the divided caps."""
+    hosts, conns, flows = TrafficAnalyzer._state_caps(ram_gb)
+    d = TrafficAnalyzer.LOW_MEMORY_DIVISOR if expect_low else 1
+    assert hosts == TrafficAnalyzer.MAX_TRACKED_HOSTS // d
+    assert conns == TrafficAnalyzer.MAX_TRACKED_CONNECTIONS // d
+    assert flows == TrafficAnalyzer.MAX_TRACKED_FLOWS // d
+    assert hosts > 0 and conns > 0 and flows > 0
+
+
+def analyzer_with_state(hosts=6, cap=2):
+    """A TrafficAnalyzer holding `hosts` peers, capped at `cap`, no capture."""
+    a = TrafficAnalyzer.__new__(TrafficAnalyzer)   # no hardware detection
+    a._lock = threading.Lock()
+    a._max_hosts = a._max_connections = a._max_flows = cap
+    now = datetime.now()
+
+    a.host_stats, a.connections, a._flow_history, a._beacon_scored = {}, {}, {}, {}
+    a._mac_by_ip, a._listening_ports, a._hostname_by_ip, a._dns_query_times = {}, {}, {}, {}
+    for i in range(hosts):
+        ip = f'10.0.0.{i}'
+        # Higher i == seen more recently, so 0 is always the first evicted.
+        seen = now - timedelta(seconds=hosts - i)
+        a.host_stats[ip] = HostTrafficStats(ip=ip, last_seen=seen)
+        a.connections[f'{ip}:1->10.1.1.1:443'] = ConnectionStats(
+            src_ip=ip, dst_ip='10.1.1.1', src_port=1, dst_port=443,
+            protocol='tcp', last_seen=seen)
+        key = (ip, '10.1.1.1', 443)
+        a._flow_history[key] = deque([(seen.timestamp(), 100)])
+        a._beacon_scored[key] = {'score': 0.9}
+        a._mac_by_ip[ip] = 'aa:bb:cc:dd:ee:ff'
+        a._listening_ports[ip] = {443}
+        a._hostname_by_ip[ip] = f'host{i}'
+        a._dns_query_times[ip] = deque([seen.timestamp()])
+    return a
+
+
+def test_prune_state_evicts_the_least_recently_seen():
+    """Without this the analyzer grows an entry per peer forever, which is the
+    one thing that would make a long capture unsafe on a 512MB board."""
+    a = analyzer_with_state(hosts=6, cap=2)
+    a._prune_state()
+
+    assert len(a.host_stats) == 2
+    assert len(a.connections) == 2
+    assert len(a._flow_history) == 2
+    # Survivors are the most recently seen, not an arbitrary two.
+    assert set(a.host_stats) == {'10.0.0.4', '10.0.0.5'}
+    # Beacon scores follow their flow out, or they leak on their own.
+    assert set(a._beacon_scored) == set(a._flow_history)
+
+
+def test_prune_state_drops_side_tables_for_evicted_hosts():
+    a = analyzer_with_state(hosts=6, cap=2)
+    a._prune_state()
+
+    live = set(a.host_stats)
+    for table in (a._mac_by_ip, a._listening_ports, a._hostname_by_ip, a._dns_query_times):
+        assert set(table) == live
+
+
+def test_prune_state_is_a_no_op_under_the_caps():
+    a = analyzer_with_state(hosts=2, cap=10)
+    a._prune_state()
+    assert len(a.host_stats) == 2
+    assert len(a.connections) == 2
+    assert len(a._flow_history) == 2
+    assert set(a._mac_by_ip) == {'10.0.0.0', '10.0.0.1'}

--- a/traffic_analyzer.py
+++ b/traffic_analyzer.py
@@ -1,9 +1,15 @@
 # traffic_analyzer.py
 """
-Traffic Analysis Module for Ragnar Server Mode
+Traffic Analysis Module
 
-This module provides real-time network traffic analysis capabilities
-that are only available when running on a capable server (8GB+ RAM).
+Real-time network traffic analysis. The engine is a `tcpdump` pipe read line by
+line in Python — measured on a Pi 5 at ~90 packets/sec it costs 0.4% of one core
+and 18MB RSS (plus 8MB for tcpdump), so it runs on any board Ragnar runs on,
+down to a Pi Zero 2 W. Tracked state is capped and evicted (see _prune_state) so
+a long capture cannot grow into a small board's RAM.
+
+The one server-class part is the optional JA3/IRC sidecars, which each spawn a
+full tshark dissector; those stay gated (traffic_sidecars_enabled).
 
 Features:
 - Real-time packet capture with tcpdump
@@ -33,7 +39,11 @@ from collections import defaultdict, deque
 from enum import Enum
 
 from logger import Logger
-from server_capabilities import get_server_capabilities, is_server_mode
+from server_capabilities import (
+    ServerCapabilities,
+    get_server_capabilities,
+    is_server_mode,
+)
 
 logger = Logger(name="traffic_analyzer", level=logging.INFO)
 
@@ -154,8 +164,8 @@ class HostTrafficStats:
 
 class TrafficAnalyzer:
     """
-    Real-time traffic analyzer for Ragnar server mode.
-    
+    Real-time traffic analyzer.
+
     Uses tcpdump for packet capture and provides:
     - Live connection tracking
     - Per-host bandwidth statistics
@@ -272,10 +282,26 @@ class TrafficAnalyzer:
     PASSIVE_MAX_LISTEN_PORTS = 100       # cap per host
     PASSIVE_LAN_PREFIX = 24              # /24 around each known local/gateway IP
 
+    # Bounded state. Alerts and DNS queries are ring buffers already, but
+    # host_stats, connections and the beacon flow history gain an entry per new
+    # peer/flow seen and have no natural ceiling — on a box left capturing for a
+    # week they are the only thing that grows without limit. Cap them and evict
+    # the least-recently-seen entries.
+    #
+    # The caps are what makes this feature honest on a 512MB Pi Zero 2 W: at the
+    # low-memory numbers below the tracked state tops out around 3MB, on top of
+    # ~18MB for the analyzer itself and ~8MB for tcpdump.
+    STATE_PRUNE_INTERVAL = 60.0          # seconds between eviction sweeps
+    MAX_TRACKED_HOSTS = 4000
+    MAX_TRACKED_CONNECTIONS = 8000
+    MAX_TRACKED_FLOWS = 2000             # each holds a 64-sample ring buffer
+    LOW_MEMORY_RAM_GB = 1.0              # below this, use the divided caps
+    LOW_MEMORY_DIVISOR = 8
+
     # Rate limiting
     MAX_ALERTS_PER_MINUTE = 10
     STATS_RETENTION_HOURS = 24
-    
+
     def __init__(self, shared_data=None, interface: str = None):
         self.shared_data = shared_data
         self.interface = interface or self._detect_interface()
@@ -344,6 +370,13 @@ class TrafficAnalyzer:
         self._beacon_scored: Dict[Tuple[str, str, int], Dict[str, Any]] = {}
         self._last_beacon_sweep = time.time()
 
+        # State caps, sized for the board this is actually running on
+        caps_obj = get_server_capabilities(shared_data).capabilities
+        self._max_hosts, self._max_connections, self._max_flows = self._state_caps(
+            caps_obj.total_ram_gb
+        )
+        self._last_state_prune = time.time()
+
         # Optional sidecar subsystems (lazy, only spawned if tshark exists)
         self._ja3_collector = None
         self._irc_parser = None
@@ -352,10 +385,61 @@ class TrafficAnalyzer:
         self._on_alert_callbacks: List[Callable] = []
         
         # Check if feature is available
-        caps = get_server_capabilities(shared_data)
-        if not caps.capabilities.traffic_analysis_enabled:
-            logger.warning("Traffic analysis not available - missing requirements")
-    
+        if not caps_obj.traffic_analysis_enabled:
+            logger.warning("Traffic analysis not available: "
+                           f"{caps_obj.traffic_block_reason or 'missing requirements'}")
+
+    @classmethod
+    def _state_caps(cls, total_ram_gb: float) -> Tuple[int, int, int]:
+        """(hosts, connections, flows) caps for a board with this much RAM.
+
+        A RAM read of 0 means detection failed, which is exactly when the
+        conservative numbers are wanted — so it lands in the low-memory branch.
+        """
+        if total_ram_gb < cls.LOW_MEMORY_RAM_GB:
+            d = cls.LOW_MEMORY_DIVISOR
+            return (cls.MAX_TRACKED_HOSTS // d,
+                    cls.MAX_TRACKED_CONNECTIONS // d,
+                    cls.MAX_TRACKED_FLOWS // d)
+        return (cls.MAX_TRACKED_HOSTS, cls.MAX_TRACKED_CONNECTIONS, cls.MAX_TRACKED_FLOWS)
+
+    def _prune_state(self):
+        """Evict least-recently-seen tracked state back down to the caps.
+
+        Called from the analysis loop, not per packet: eviction is a sort over
+        the whole map, so doing it every STATE_PRUNE_INTERVAL keeps the cost off
+        the packet path entirely.
+        """
+        with self._lock:
+            if len(self.connections) > self._max_connections:
+                for key in sorted(self.connections,
+                                  key=lambda k: self.connections[k].last_seen
+                                  )[:len(self.connections) - self._max_connections]:
+                    del self.connections[key]
+
+            if len(self._flow_history) > self._max_flows:
+                def flow_last_seen(key):
+                    samples = self._flow_history[key]
+                    return samples[-1][0] if samples else 0.0
+                for key in sorted(self._flow_history, key=flow_last_seen
+                                  )[:len(self._flow_history) - self._max_flows]:
+                    del self._flow_history[key]
+                    self._beacon_scored.pop(key, None)
+
+            if len(self.host_stats) > self._max_hosts:
+                for ip in sorted(self.host_stats,
+                                 key=lambda k: self.host_stats[k].last_seen
+                                 )[:len(self.host_stats) - self._max_hosts]:
+                    del self.host_stats[ip]
+
+            # Per-IP side tables only make sense for hosts still tracked. They
+            # are rebuilt from the next packet, so dropping them is free.
+            live = self.host_stats.keys()
+            for table in (self._mac_by_ip, self._listening_ports,
+                          self._hostname_by_ip, self._dns_query_times):
+                for ip in [k for k in table if k not in live]:
+                    del table[ip]
+
     def _detect_interface(self) -> str:
         """Detect the primary network interface"""
         try:
@@ -510,11 +594,20 @@ class TrafficAnalyzer:
     def is_available(self) -> bool:
         """Check if traffic analysis is available"""
         return get_server_capabilities().capabilities.traffic_analysis_enabled
-    
+
+    def unavailable_reason(self) -> str:
+        """Why traffic analysis cannot run here ('' when it can).
+
+        Shown verbatim in the web UI, so it names what is actually missing —
+        almost always an uninstalled tcpdump rather than the hardware.
+        """
+        return get_server_capabilities().capabilities.traffic_block_reason
+
     def start(self) -> bool:
         """Start traffic capture and analysis"""
         if not self.is_available():
-            logger.error("Traffic analysis not available on this system")
+            logger.error("Traffic analysis not available: "
+                         f"{self.unavailable_reason() or 'requirements not met'}")
             return False
         
         if self._running:
@@ -544,7 +637,7 @@ class TrafficAnalyzer:
         try:
             self._start_sidecars()
         except Exception as exc:
-            logger.debug("Sidecar startup failed: %s", exc)
+            logger.debug(f"Sidecar startup failed: {exc}")
 
         logger.info(f"Traffic analyzer started on interface {self.interface}")
         return True
@@ -556,7 +649,7 @@ class TrafficAnalyzer:
         try:
             self._stop_sidecars()
         except Exception as exc:
-            logger.debug("Sidecar shutdown failed: %s", exc)
+            logger.debug(f"Sidecar shutdown failed: {exc}")
 
         if self._capture_process:
             try:
@@ -683,6 +776,14 @@ class TrafficAnalyzer:
                     except Exception as exc:
                         logger.debug(f"Passive host sync error: {exc}")
                     self._last_passive_sync = time.time()
+
+                # Periodically evict stale tracked state back under the caps
+                if time.time() - self._last_state_prune >= self.STATE_PRUNE_INTERVAL:
+                    try:
+                        self._prune_state()
+                    except Exception as exc:
+                        logger.debug(f"State prune error: {exc}")
+                    self._last_state_prune = time.time()
 
             except Exception as e:
                 logger.error(f"Analysis error: {e}")
@@ -1356,11 +1457,25 @@ class TrafficAnalyzer:
         """Best-effort start of tshark-based JA3 and IRC sidecars.
 
         Both modules degrade gracefully if tshark is missing.
+
+        These are the one genuinely heavy part of Traffic Analysis: each spawns
+        a full tshark dissector (~290MB RSS plus a ~155MB dumpcap child), so the
+        pair alone outweighs everything a Pi Zero has. The tcpdump core runs on
+        any board; the sidecars need a big one, hence the separate capability.
         """
+        caps = get_server_capabilities(self.shared_data).capabilities
+        if not caps.traffic_sidecars_enabled:
+            logger.info(
+                f"JA3/IRC sidecars skipped: they need tshark and a board with at "
+                f"least {ServerCapabilities.TRAFFIC_SIDECAR_MIN_RAM_GB:.1f}GB RAM "
+                f"(this one reports {caps.total_ram_gb:.2f}GB). Packet capture, "
+                f"beacon and port-scan detection are unaffected.")
+            return
+
         try:
             from tls_fingerprint import JA3Collector
         except Exception as exc:
-            logger.debug("JA3 collector unavailable: %s", exc)
+            logger.debug(f"JA3 collector unavailable: {exc}")
             JA3Collector = None  # type: ignore
 
         if JA3Collector is not None and self._ja3_collector is None:
@@ -1374,7 +1489,7 @@ class TrafficAnalyzer:
         try:
             from irc_dpi import IRCDPIParser
         except Exception as exc:
-            logger.debug("IRC DPI unavailable: %s", exc)
+            logger.debug(f"IRC DPI unavailable: {exc}")
             IRCDPIParser = None  # type: ignore
 
         if IRCDPIParser is not None and self._irc_parser is None:
@@ -1624,6 +1739,12 @@ class TrafficAnalyzer:
                 # Configuration
                 'excluded_local_ips': list(self._local_ips),
                 'alert_dedup_window_seconds': self._alert_dedup_window,
+                'sidecars_active': bool(self._ja3_collector or self._irc_parser),
+                'tracked_state_caps': {
+                    'hosts': self._max_hosts,
+                    'connections': self._max_connections,
+                    'flows': self._max_flows,
+                },
             }
     
     def get_top_hosts(self, limit: int = 10, sort_by: str = 'bytes') -> List[Dict]:

--- a/update_ragnar.sh
+++ b/update_ragnar.sh
@@ -269,6 +269,31 @@ if [ ${#_recon_missing[@]} -gt 0 ]; then
     echo -e "  ${YELLOW}⚠${NC} Recon features unavailable: ${_recon_missing[*]}"
 fi
 
+echo -e "${BLUE}Step 5.4: Ensuring Traffic Analysis capture tools...${NC}"
+# Traffic Analysis is no longer gated behind server mode — it is a tcpdump pipe
+# and runs on any board, Pi Zero included. tcpdump is its one hard requirement
+# and the sudoers rule is what lets Ragnar spawn it, so both are ensured here
+# for boxes that only ever update. Both are idempotent.
+if ! command -v tcpdump >/dev/null 2>&1; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tcpdump >/dev/null 2>&1 || true
+fi
+if command -v tcpdump >/dev/null 2>&1; then
+    if [ ! -f /etc/sudoers.d/ragnar-traffic ]; then
+        cat > /etc/sudoers.d/ragnar-traffic << 'EOF'
+# Allow ragnar user to run traffic analysis tools without password
+ragnar ALL=(ALL) NOPASSWD: /usr/bin/tcpdump
+ragnar ALL=(ALL) NOPASSWD: /usr/bin/tshark
+ragnar ALL=(ALL) NOPASSWD: /usr/sbin/iftop
+ragnar ALL=(ALL) NOPASSWD: /usr/sbin/nethogs
+EOF
+        chmod 440 /etc/sudoers.d/ragnar-traffic
+        echo -e "  ${GREEN}✓${NC} Added sudoers rule for packet capture"
+    fi
+    echo -e "  ${GREEN}✓${NC} tcpdump present — Traffic Analysis available"
+else
+    echo -e "  ${YELLOW}⚠${NC} tcpdump missing — Traffic Analysis tab stays hidden (apt install tcpdump)"
+fi
+
 echo -e "${BLUE}Step 5.5: Restoring local runtime data...${NC}"
 for file in "${PRESERVE_FILES[@]}"; do
     backup_file="$BACKUP_DIR/$(basename $file)"

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -671,7 +671,7 @@
                     <button onclick="showTab('threat-intel')" class="nav-btn px-3 py-1.5 rounded-lg hover:bg-slate-700 transition-colors text-[15px] whitespace-nowrap" data-tab="threat-intel">
                         Threat Intel
                     </button>
-                    <button onclick="showTab('traffic')" class="nav-btn px-3 py-1.5 rounded-lg hover:bg-slate-700 transition-colors text-[15px] whitespace-nowrap server-mode-feature hidden" data-tab="traffic">
+                    <button onclick="showTab('traffic')" class="nav-btn px-3 py-1.5 rounded-lg hover:bg-slate-700 transition-colors text-[15px] whitespace-nowrap traffic-feature hidden" data-tab="traffic">
                         <span class="flex items-center space-x-1">
                             <svg class="w-4 h-4 text-cyan-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
@@ -743,7 +743,7 @@
                     Pentest
                 </button>
                 <button onclick="showTab('threat-intel')" class="block w-full text-left px-3 py-2 rounded-lg hover:bg-slate-700">Threat Intel</button>
-                <button onclick="showTab('traffic')" data-tab="traffic" class="block w-full text-left px-3 py-2 rounded-lg hover:bg-slate-700 server-mode-feature hidden">Traffic Analysis</button>
+                <button onclick="showTab('traffic')" data-tab="traffic" class="block w-full text-left px-3 py-2 rounded-lg hover:bg-slate-700 traffic-feature hidden">Traffic Analysis</button>
                 <button onclick="showTab('adv-vuln')" data-tab="adv-vuln" class="block w-full text-left px-3 py-2 rounded-lg hover:bg-slate-700 server-mode-feature hidden">Adv Scan</button>
                 <button onclick="showTab('wardriving')" data-tab="wardriving" class="block w-full text-left px-3 py-2 rounded-lg hover:bg-slate-700 wardriving-feature hidden">Wardriving</button>
                 <button onclick="showTab('epaper')" class="block w-full text-left px-3 py-2 rounded-lg hover:bg-slate-700 requires-display">Display</button>
@@ -4453,7 +4453,7 @@
                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
                     <div class="flex items-center space-x-3">
                         <h2 class="text-xl sm:text-2xl font-bold">Traffic Analysis</h2>
-                        <span class="px-2 py-1 bg-cyan-600 bg-opacity-30 text-cyan-400 text-xs rounded-full">Server Mode</span>
+                        <span class="px-2 py-1 bg-cyan-600 bg-opacity-30 text-cyan-400 text-xs rounded-full">Live capture</span>
                     </div>
                     <div class="flex flex-wrap gap-2">
                         <button onclick="toggleTrafficCapture()" id="traffic-toggle-btn" class="flex-1 sm:flex-none bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg transition-colors text-sm sm:text-base">
@@ -4827,17 +4827,16 @@
                     </div>
                 </div>
 
-                <!-- Server Mode Notice -->
+                <!-- Unavailable notice — the reason comes from the API -->
                 <div id="traffic-not-available" class="hidden mt-6 p-4 bg-yellow-900 bg-opacity-30 border border-yellow-600 rounded-lg">
                     <div class="flex items-start">
                         <svg class="w-6 h-6 text-yellow-500 mr-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                         </svg>
                         <div>
-                            <h4 class="font-semibold text-yellow-400">Server Mode Required</h4>
-                            <p class="text-gray-300 text-sm mt-1">
-                                Traffic analysis requires Server Mode (AMD64/ARM64 with 8GB+ RAM).
-                                This feature provides real-time packet capture and network traffic monitoring.
+                            <h4 class="font-semibold text-yellow-400">Traffic Analysis unavailable</h4>
+                            <p class="text-gray-300 text-sm mt-1" id="traffic-not-available-reason">
+                                Traffic analysis could not start on this system.
                             </p>
                         </div>
                     </div>
@@ -7061,7 +7060,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260726-kiosk-server-only"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260726-traffic-any-board"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -22124,6 +22124,18 @@ async function checkServerCapabilities() {
                 }
             });
 
+            // Traffic Analysis has its own gate: it is a tcpdump pipe, not
+            // OpenVAS-class work, so it shows up on any board that can run it
+            // (a Pi Zero included) rather than only in server mode.
+            const trafficEnabled = data.features?.traffic_analysis || false;
+            document.querySelectorAll('.traffic-feature').forEach(el => {
+                el.classList.toggle('hidden', !trafficEnabled);
+            });
+            if (!trafficEnabled) {
+                console.log('[ServerMode] Traffic Analysis unavailable:',
+                            data.capabilities?.traffic_block_reason || 'unknown reason');
+            }
+
             // Show/hide wardriving feature based on config
             const wdEnabled = data.features?.wardriving_enabled || false;
             applyWardrivingEnabledState(wdEnabled);
@@ -22140,6 +22152,9 @@ async function checkServerCapabilities() {
                 console.log('[ServerMode]   - Full capabilities:', data.capabilities);
             }
             
+            // Re-measure the nav: we just changed which buttons are visible,
+            // and that decides desktop bar vs hamburger.
+            if (window._updateNavMode) window._updateNavMode();
             return data;
         } else if (!data.success) {
             console.error('[ServerMode] API error:', data.error);
@@ -22178,7 +22193,7 @@ async function loadTrafficAnalysisData() {
         const data = await statusResponse.json();
 
         if (!data.success || !data.available) {
-            showTrafficNotAvailable();
+            showTrafficNotAvailable(data.reason || data.error);
             return;
         }
 
@@ -22197,9 +22212,16 @@ async function loadTrafficAnalysisData() {
     }
 }
 
-function showTrafficNotAvailable() {
+function showTrafficNotAvailable(reason) {
     const notice = document.getElementById('traffic-not-available');
     if (notice) notice.classList.remove('hidden');
+    const reasonEl = document.getElementById('traffic-not-available-reason');
+    // The backend names what is actually missing (usually tcpdump); only fall
+    // back to generic wording when it did not say.
+    if (reasonEl) {
+        reasonEl.textContent = reason ||
+            'Traffic analysis could not start on this system.';
+    }
 }
 
 function hideTrafficNotAvailable() {

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -17830,6 +17830,7 @@ def get_server_capabilities_api():
             'features': {
                 'server_mode': False,
                 'traffic_analysis': False,
+                'traffic_sidecars': False,
                 'advanced_vuln_assessment': False,
                 'parallel_scanning': False,
                 'local_ai': False,
@@ -17899,15 +17900,17 @@ def install_server_tools():
         from server_capabilities import get_server_capabilities
         caps = get_server_capabilities(shared_data)
         
-        if not caps.is_server_mode():
+        data = request.get_json(silent=True) or {}
+        feature = data.get('feature', '')
+
+        # Traffic Analysis runs on any board, so installing its tools (tcpdump)
+        # must work on any board too. Server-class features still need one.
+        if feature != 'traffic_analysis' and not caps.is_server_mode():
             return jsonify({
                 'success': False,
                 'error': 'Server mode not available on this system'
             }), 400
-        
-        data = request.get_json(silent=True) or {}
-        feature = data.get('feature', '')
-        
+
         if feature not in ['traffic_analysis', 'advanced_vuln']:
             return jsonify({
                 'success': False,
@@ -17954,15 +17957,25 @@ def get_traffic_status():
     try:
         analyzer = get_traffic_analyzer()
         if not analyzer:
+            # The module itself failed to import. Ask the capability layer
+            # directly so the UI still gets a real reason (usually: no tcpdump).
+            from server_capabilities import traffic_capability
+            _, reason = traffic_capability(shared_data)
             return jsonify({
                 'success': False,
                 'available': False,
+                'reason': reason or 'Traffic analysis module not available',
                 'error': 'Traffic analysis module not available'
             })
-        
+
+
+        available = analyzer.is_available()
         return jsonify({
             'success': True,
-            'available': analyzer.is_available(),
+            'available': available,
+            # Named reason so the UI can say what is actually missing (almost
+            # always an uninstalled tcpdump) instead of "server mode required".
+            'reason': '' if available else analyzer.unavailable_reason(),
             'summary': analyzer.get_summary()
         })
     except Exception as e:
@@ -18045,7 +18058,8 @@ def start_traffic_capture():
         if not analyzer.is_available():
             return jsonify({
                 'success': False,
-                'error': 'Traffic analysis not available - check system requirements'
+                'error': (analyzer.unavailable_reason()
+                          or 'Traffic analysis not available - check system requirements')
             }), 400
         
         data = request.get_json(silent=True) or {}


### PR DESCRIPTION
Traffic Analysis was gated behind full server mode (7.5GB RAM), sitting next to OpenVAS-class vulnerability scanning. That was the wrong bar. The engine is a tcpdump pipe read line by line in Python. Measured on a Pi 5 against a live LAN at ~90 packets/sec: 0.4% of one core and 18MB RSS for the analyzer, 8MB for tcpdump. That is a Pi Zero workload.

So it gets its own gate, like the kiosk did, with one hard requirement - tcpdump installed - plus a supported arch and a readable RAM figure (a RAM read of 0 fails closed). traffic_capable/traffic_block_reason is published on the capabilities object, and the reason names what is actually missing, so a board without tcpdump is told to install tcpdump rather than "server mode required".

Two things had to be true before this was honest:

- The tshark sidecars stay behind a high bar. JA3 and IRC DPI each spawn a full tshark dissector - measured ~290MB RSS each plus a ~155MB dumpcap child - so the pair outweighs everything a Zero has. traffic_sidecars_enabled needs tshark and 3.5GB; below it the capture core is unaffected and the skip is logged with the board's real numbers.
- Tracked state is now bounded. Alerts and DNS queries were already ring buffers, but host_stats, connections and the beacon flow history gained an entry per new peer and had no ceiling - on a week-long capture that is the one thing that would grow into a small board's RAM. _prune_state() evicts the least-recently-seen every 60s, off the packet path, at caps divided by 8 under 1GB (500 hosts / 1000 connections / 250 flows, ~3MB).

Also here:
- API: /api/traffic/status returns capable + reason; start reports the reason on refusal; install-tools no longer requires server mode for the traffic tools, since that is the path that installs the missing tcpdump.
- Web UI: the Traffic tab is gated on features.traffic_analysis via its own traffic-feature class, the "Server Mode" badge is gone, and the unavailable notice shows the backend's reason. Nav re-measures after the visibility change - it was returning before _updateNavMode(), so the bar never recalculated whether it fits.
- update_ragnar.sh ensures tcpdump and the capture sudoers rule, since most boxes only ever update.
- Four logger calls used %-style args, which this Logger does not take; the one in start()'s sidecar handler turned any sidecar failure into a TypeError out of the API.
- docs/traffic-analysis.md, README, docs/grade.md, tests/test_traffic_capability.py