### PR TITLE
Only record a listening port a host actually served from

### DIFF
--- a/docs/traffic-analysis.md
+++ b/docs/traffic-analysis.md
@@ -74,10 +74,41 @@ the next packet.
 
 Alerts are rate-limited (10/min) and deduplicated in a 300s window.
 
+## Passive host discovery
+
 Capture also feeds **passive host discovery**: LAN hosts seen only in traffic —
 firewalled boxes that never answer a scan — are flushed into the hosts DB every
-30s, with MACs learned from ARP replies and services inferred from the ports
-they answer on.
+30s, with MACs learned from ARP replies.
+
+A port is recorded as **listening** only on real evidence: the host must have
+sent a packet **from** that port **carrying payload**. Both halves matter.
+
+- *Source only.* Crediting the destination of a packet treats "someone sent
+  something to this port" as proof the host listens there. Any port scan then
+  becomes a lie — and Ragnar's own scanner sweeps the configured portlist
+  against every LAN host, so a capture running during a scan wrote ~50 phantom
+  ports onto every host and pushed the dashboard's Open Ports count into the
+  hundreds.
+- *Payload only.* `tcpdump -q` prints a SYN-ACK and an RST identically as
+  `tcp 0`, so a reply on its own cannot tell an open port from a closed one.
+
+The consequence is that most hosts contribute no ports at all, which is
+correct: this is inference from traffic, not a scan result. The host is still
+recorded — that is the point — and its port list is left untouched rather than
+overwritten with an empty one. An active scan replaces the field with the truth.
+
+### Repairing a database written before the fix
+
+```bash
+python3 scripts/repair_passive_ports.py           # report only
+python3 scripts/repair_passive_ports.py --apply   # clear the phantom rows
+```
+
+It finds rows carrying the sweep signature — dozens of ports dominated by the
+scanner's portlist, three or more services nobody runs together (ftp-data,
+tftp, nntp, bgp…), and no 22 or 8000, which the capture filter hid — then backs
+up the DB and clears their `ports`/`services`. The next active scan repopulates
+real results, so a false positive costs one scan cycle.
 
 ## API
 

--- a/scripts/repair_passive_ports.py
+++ b/scripts/repair_passive_ports.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Repair phantom open ports written by passive host discovery.
+
+Until this was fixed, Traffic Analysis credited a host with a "listening port"
+whenever it saw a packet sent *to* that port. Ragnar's own scanner sweeps the
+configured portlist against every LAN host, so a capture running during a scan
+wrote that entire portlist into the hosts DB for every host — turning the
+dashboard's Open Ports count into a four-digit number of ports nothing was
+listening on.
+
+The signature is unmistakable, because the capture filter (`not port 22 and not
+port 8000`) hid two of the scanned ports: an affected host carries dozens of
+ports dominated by the scanner's portlist, with 22 and 8000 conspicuously
+absent. Real hosts do not answer on 20, 69, 111, 119, 179, 515 and 520 at once,
+and certainly not while refusing SSH.
+
+This clears the ports/services columns of matching hosts. The next active scan
+repopulates them with real results — nmap replaces that field wholesale — so a
+false positive costs one scan cycle, not data.
+
+    python3 scripts/repair_passive_ports.py            # report only (default)
+    python3 scripts/repair_passive_ports.py --apply    # write the fix
+    python3 scripts/repair_passive_ports.py --min-ports 15 --apply
+
+Runs against every network DB under data/networks/*/db/*.db unless --db is given.
+"""
+
+import argparse
+import glob
+import json
+import os
+import shutil
+import sqlite3
+import sys
+from datetime import datetime
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Ports the capture filter hides, so passive discovery can never have seen them.
+# Their absence from an otherwise-complete portlist is the tell.
+FILTERED_PORTS = {22, 8000}
+DEFAULT_MIN_PORTS = 15
+
+# Ports the passive recorder was allowed to write: anything privileged, plus
+# the high-value ports it tracks by name. Nothing outside this set can have
+# come from passive discovery.
+RECORDABLE_CEILING = 1024
+HIGH_VALUE_PORTS = {
+    1433, 1521, 2375, 2376, 2379, 2380, 3306, 3389, 5432, 5601, 5672, 15672,
+    5900, 5901, 5984, 5985, 5986, 6379, 7474, 7687, 8000, 8008, 8086, 8080,
+    8443, 8888, 9000, 9090, 9091, 9042, 9092, 9200, 9300, 11211, 27017, 27018,
+}
+
+# Services essentially nobody runs, and never together: a host "listening" on
+# three or more of these is reporting a scan, not a service. This is what keeps
+# the repair off a genuinely busy server (a Windows DC answers on 88/135/389/445,
+# but not on ftp-data, tftp, nntp, bgp and rip at once).
+IMPLAUSIBLE_TOGETHER = {20, 69, 111, 119, 179, 515, 520, 554, 631, 1024, 1025}
+MIN_IMPLAUSIBLE = 3
+
+# How much of a row must look swept before it counts as swept.
+DOMINANCE = 0.8
+
+
+def load_portlist():
+    """The scanner's port list — the exact set the sweep wrote."""
+    for path in (os.path.join(ROOT, 'config', 'shared_config.json'),
+                 os.path.join(ROOT, 'data', 'shared_config.json')):
+        try:
+            with open(path) as fh:
+                ports = json.load(fh).get('portlist')
+            if ports:
+                return {int(p) for p in ports}
+        except (OSError, ValueError, TypeError):
+            continue
+    return set()
+
+
+def parse_ports(field):
+    out = set()
+    for chunk in (field or '').split(','):
+        chunk = chunk.strip()
+        if chunk.isdigit():
+            out.add(int(chunk))
+    return out
+
+
+def is_poisoned(ports, portlist, min_ports):
+    """Does this host's port list look like a recorded scan sweep?
+
+    Four things have to hold at once, because clearing a real scan result is
+    the one outcome worth avoiding:
+
+    1. a big set — a swept host carries dozens of ports;
+    2. three or more ports nobody runs together (ftp-data, tftp, nntp, bgp…);
+    3. 22 and 8000 absent — the capture filter hid them, so the sweep could
+       never have recorded them, while a real host that busy would answer SSH;
+    4. the set is dominated by ports passive discovery could write (privileged
+       or high-value) and by ports the scanner sweeps.
+
+    Dominance rather than purity, because passive discovery *merged* its
+    phantom ports into whatever an earlier real scan had found: a swept row can
+    still carry a few genuine ports from outside both sets. Those come back on
+    the next scan, which is why clearing the whole row is safe.
+    """
+    if len(ports) < min_ports:
+        return False
+    if ports & FILTERED_PORTS:
+        return False
+    if len(ports & IMPLAUSIBLE_TOGETHER) < MIN_IMPLAUSIBLE:
+        return False
+    recordable = {p for p in ports if p < RECORDABLE_CEILING or p in HIGH_VALUE_PORTS}
+    if len(recordable) < DOMINANCE * len(ports):
+        return False
+    if portlist and len(ports & portlist) < DOMINANCE * len(ports):
+        return False
+    return True
+
+
+def repair_db(db_path, portlist, min_ports, apply_changes):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT mac, ip, ports FROM hosts WHERE ports IS NOT NULL AND ports != ''"
+        ).fetchall()
+    except sqlite3.Error as exc:
+        print(f"  ! cannot read {db_path}: {exc}")
+        conn.close()
+        return 0, 0
+
+    hits = [(r['mac'], r['ip'], parse_ports(r['ports'])) for r in rows]
+    hits = [h for h in hits if is_poisoned(h[2], portlist, min_ports)]
+    cleared_ports = sum(len(p) for _, _, p in hits)
+
+    if hits and apply_changes:
+        backup = f"{db_path}.bak-{datetime.now():%Y%m%d%H%M%S}"
+        shutil.copy2(db_path, backup)
+        print(f"  backup: {backup}")
+        conn.executemany(
+            "UPDATE hosts SET ports = '', services = '' WHERE mac = ?",
+            [(mac,) for mac, _, _ in hits],
+        )
+        conn.commit()
+
+    for mac, ip, ports in hits:
+        print(f"  {'cleared' if apply_changes else 'would clear'} "
+              f"{len(ports):3d} ports  {ip or '?':<15} {mac}")
+
+    conn.close()
+    return len(hits), cleared_ports
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--apply', action='store_true',
+                    help='write the changes (default: report only)')
+    ap.add_argument('--db', action='append',
+                    help='specific hosts DB to repair (repeatable)')
+    ap.add_argument('--min-ports', type=int, default=DEFAULT_MIN_PORTS,
+                    help=f'ports a host needs before it looks swept '
+                         f'(default: {DEFAULT_MIN_PORTS})')
+    args = ap.parse_args()
+
+    portlist = load_portlist()
+    if not portlist:
+        print("Could not read the scanner portlist from config — aborting, "
+              "since without it every host would look clean.")
+        return 2
+    print(f"Scanner portlist: {len(portlist)} ports; "
+          f"treating >= {args.min_ports} of them (without "
+          f"{'/'.join(str(p) for p in sorted(FILTERED_PORTS))}) as a recorded sweep.")
+
+    dbs = args.db or sorted(glob.glob(os.path.join(ROOT, 'data', 'networks', '*', 'db', '*.db')))
+    if not dbs:
+        print("No hosts databases found.")
+        return 1
+
+    total_hosts = total_ports = 0
+    for db_path in dbs:
+        print(f"\n{db_path}")
+        hosts, ports = repair_db(db_path, portlist, args.min_ports, args.apply)
+        if not hosts:
+            print("  clean")
+        total_hosts += hosts
+        total_ports += ports
+
+    verb = 'Cleared' if args.apply else 'Would clear'
+    print(f"\n{verb} {total_ports} phantom ports across {total_hosts} hosts.")
+    if total_hosts and not args.apply:
+        print("Re-run with --apply to write the fix.")
+    elif total_hosts:
+        print("The next active scan will repopulate real open ports.")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_passive_host_discovery.py
+++ b/tests/test_passive_host_discovery.py
@@ -90,36 +90,71 @@ def test_arp_request_does_not_record_mac(analyzer):
 # Listening-port detection
 # ---------------------------------------------------------------------------
 
-def test_listening_port_recorded_when_well_known_dst(analyzer):
-    base_ts = '2026-05-28 01:00:00.000000'
-    line = f'{base_ts} IP 192.168.1.20.50000 > 192.168.1.50.443: tcp 0'
+BASE_TS = '2026-05-28 01:00:00.000000'
+
+
+def test_listening_port_recorded_when_host_serves_payload(analyzer):
+    """The evidence is the host answering *from* the port with data."""
+    line = f'{BASE_TS} IP 192.168.1.50.443 > 192.168.1.20.50000: tcp 1440'
     analyzer._parse_and_record_packet(line)
 
     assert 443 in analyzer._listening_ports['192.168.1.50']
 
 
 def test_listening_port_recorded_for_high_value_high_port(analyzer):
-    base_ts = '2026-05-28 01:00:00.000000'
-    line = f'{base_ts} IP 192.168.1.20.50000 > 192.168.1.50.6379: tcp 0'
+    line = f'{BASE_TS} IP 192.168.1.50.6379 > 192.168.1.20.50000: tcp 96'
     analyzer._parse_and_record_packet(line)
 
     assert 6379 in analyzer._listening_ports['192.168.1.50']
 
 
-def test_listening_port_not_recorded_for_ephemeral(analyzer):
-    base_ts = '2026-05-28 01:00:00.000000'
-    # Random ephemeral; should NOT be considered a listening port.
-    line = f'{base_ts} IP 192.168.1.20.50000 > 192.168.1.50.40000: tcp 0'
+def test_listening_port_not_recorded_from_being_contacted(analyzer):
+    """Regression: a packet *to* a port is not evidence anyone listens there.
+
+    Ragnar's own scanner sweeps the configured portlist against every LAN
+    host. Crediting the destination turned that sweep into ~50 phantom open
+    ports per host in the hosts DB, and a four-digit port count on the
+    dashboard.
+    """
+    line = f'{BASE_TS} IP 192.168.1.20.50000 > 192.168.1.50.443: tcp 0'
     analyzer._parse_and_record_packet(line)
 
-    assert 192_168_1_50 != 0  # sanity
+    assert 443 not in analyzer._listening_ports.get('192.168.1.50', set())
+
+
+def test_listening_port_not_recorded_from_empty_reply(analyzer):
+    """`tcpdump -q` prints SYN-ACK and RST identically as `tcp 0`, so a reply
+    with no payload cannot distinguish an open port from a closed one."""
+    line = f'{BASE_TS} IP 192.168.1.50.443 > 192.168.1.20.50000: tcp 0'
+    analyzer._parse_and_record_packet(line)
+
+    assert 443 not in analyzer._listening_ports.get('192.168.1.50', set())
+
+
+def test_full_port_sweep_leaves_no_listening_ports(analyzer):
+    """The exact shape of the reported bug: a scan of every service port,
+    each target replying RST (closed) — nothing may be recorded."""
+    sweep = [20, 21, 23, 25, 53, 80, 111, 139, 143, 389, 443, 445, 515, 631]
+    for port in sweep:
+        analyzer._parse_and_record_packet(
+            f'{BASE_TS} IP 192.168.1.10.50000 > 192.168.1.50.{port}: tcp 0')
+        analyzer._parse_and_record_packet(
+            f'{BASE_TS} IP 192.168.1.50.{port} > 192.168.1.10.50000: tcp 0')
+
+    assert analyzer._listening_ports.get('192.168.1.50', set()) == set()
+
+
+def test_listening_port_not_recorded_for_ephemeral(analyzer):
+    # Random ephemeral source; the host is a client, not a listener.
+    line = f'{BASE_TS} IP 192.168.1.50.40000 > 192.168.1.20.443: tcp 512'
+    analyzer._parse_and_record_packet(line)
+
     listening = analyzer._listening_ports.get('192.168.1.50', set())
     assert 40000 not in listening
 
 
 def test_listening_port_not_recorded_for_non_lan(analyzer):
-    base_ts = '2026-05-28 01:00:00.000000'
-    line = f'{base_ts} IP 192.168.1.20.50000 > 8.8.8.8.443: tcp 0'
+    line = f'{BASE_TS} IP 8.8.8.8.443 > 192.168.1.20.50000: tcp 512'
     analyzer._parse_and_record_packet(line)
 
     assert '8.8.8.8' not in analyzer._listening_ports
@@ -155,12 +190,12 @@ def test_passive_sync_creates_new_host_with_real_mac(analyzer):
     db = _build_db()
     analyzer.shared_data = MagicMock(db=db)
 
-    # Seed: ARP reply + a packet to a service port.
+    # Seed: ARP reply + the host serving payload from a service port.
     base_ts = '2026-05-28 01:00:00.000000'
     analyzer._parse_and_record_packet(
         f'{base_ts} ARP, Reply 192.168.1.50 is-at aa:bb:cc:dd:ee:ff, length 28')
     analyzer._parse_and_record_packet(
-        f'{base_ts} IP 192.168.1.20.50000 > 192.168.1.50.443: tcp 0')
+        f'{base_ts} IP 192.168.1.50.443 > 192.168.1.20.50000: tcp 1440')
 
     analyzer._passive_sync_to_db()
 
@@ -185,13 +220,13 @@ def test_passive_sync_merges_ports_with_existing_host(analyzer):
     analyzer.shared_data = MagicMock(db=db)
 
     base_ts = '2026-05-28 01:00:00.000000'
-    # Observed listening on 443 and 6379 (new ports).
+    # Observed serving on 443 and 6379 (new ports).
     analyzer._parse_and_record_packet(
         f'{base_ts} ARP, Reply 192.168.1.50 is-at aa:bb:cc:dd:ee:ff, length 28')
     analyzer._parse_and_record_packet(
-        f'{base_ts} IP 192.168.1.20.50000 > 192.168.1.50.443: tcp 0')
+        f'{base_ts} IP 192.168.1.50.443 > 192.168.1.20.50000: tcp 1440')
     analyzer._parse_and_record_packet(
-        f'{base_ts} IP 192.168.1.20.50001 > 192.168.1.50.6379: tcp 0')
+        f'{base_ts} IP 192.168.1.50.6379 > 192.168.1.20.50001: tcp 96')
 
     analyzer._passive_sync_to_db()
 
@@ -306,6 +341,55 @@ def test_passive_sync_skips_when_existing_host_and_no_new_ports(analyzer):
     analyzer._passive_sync_to_db()
 
     # upsert_host should be called but with ports=None to avoid clobbering.
+    call = db.upsert_host.call_args
+    assert call.kwargs.get('ports') is None
+    assert call.kwargs.get('services') is None
+
+
+def test_passive_sync_records_host_that_serves_nothing(analyzer):
+    """A host seen only as a client still belongs in the DB.
+
+    With listening ports now requiring real evidence, most hosts contribute
+    none — and hosts that never answer a scan are exactly what passive
+    discovery is for. It must record the host and leave the port columns alone.
+    """
+    db = _build_db()
+    analyzer.shared_data = MagicMock(db=db)
+
+    base_ts = '2026-05-28 01:00:00.000000'
+    analyzer._parse_and_record_packet(
+        f'{base_ts} ARP, Reply 192.168.1.50 is-at aa:bb:cc:dd:ee:ff, length 28')
+    analyzer._parse_and_record_packet(
+        f'{base_ts} IP 192.168.1.50.51000 > 8.8.8.8.443: tcp 517')
+
+    analyzer._passive_sync_to_db()
+
+    call = next((c for c in db.upsert_host.call_args_list
+                 if c.kwargs.get('ip') == '192.168.1.50'), None)
+    assert call is not None
+    assert call.kwargs['mac'] == 'aa:bb:cc:dd:ee:ff'
+    assert call.kwargs.get('ports') is None
+    assert call.kwargs.get('services') is None
+
+
+def test_passive_sync_never_overwrites_ports_with_empty(analyzer):
+    """An existing host's scanned port list must survive a quiet capture."""
+    existing = {
+        '192.168.1.50': {
+            'mac': 'aa:bb:cc:dd:ee:ff',
+            'ports': '22,443',
+            'services': '{"22": "ssh", "443": "https"}',
+        }
+    }
+    db = _build_db(existing)
+    analyzer.shared_data = MagicMock(db=db)
+
+    base_ts = '2026-05-28 01:00:00.000000'
+    analyzer._parse_and_record_packet(
+        f'{base_ts} ARP, Reply 192.168.1.50 is-at aa:bb:cc:dd:ee:ff, length 28')
+
+    analyzer._passive_sync_to_db()
+
     call = db.upsert_host.call_args
     assert call.kwargs.get('ports') is None
     assert call.kwargs.get('services') is None

--- a/tests/test_repair_passive_ports.py
+++ b/tests/test_repair_passive_ports.py
@@ -1,0 +1,93 @@
+"""Tests for the phantom-port repair heuristic.
+
+The repair clears a host's whole port list, so the cost of a false positive is
+one scan cycle — but it still must not fire on a genuinely busy server. These
+tests pin both directions: the recorded sweep is caught, a real multi-service
+box is left alone.
+"""
+
+import importlib.util
+import os
+
+import pytest
+
+SCRIPT = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                      'scripts', 'repair_passive_ports.py')
+_spec = importlib.util.spec_from_file_location('repair_passive_ports', SCRIPT)
+repair = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(repair)
+
+
+# The scanner's shipped portlist — what the sweep wrote into every host.
+PORTLIST = {
+    20, 21, 22, 23, 25, 53, 67, 68, 69, 80, 88, 110, 111, 119, 123, 135, 137,
+    138, 139, 143, 161, 162, 179, 389, 443, 445, 465, 514, 515, 520, 554, 587,
+    631, 636, 993, 995, 1024, 1025, 1080, 1194, 1433, 1434, 1521, 1723, 1812,
+    1813, 1883, 1900, 2049, 5000, 5432, 5900, 5985, 5986, 6379, 7000, 8080,
+    8086, 8443, 8888, 9000, 9090, 9200,
+}
+
+# A real row from the reported incident: 53 ports, no 22 (the capture filter
+# hid it), everything else straight out of the sweep.
+SWEPT = {
+    20, 21, 23, 25, 53, 67, 68, 69, 80, 88, 110, 111, 119, 123, 135, 137, 138,
+    139, 143, 161, 162, 179, 389, 443, 445, 465, 514, 515, 520, 554, 587, 631,
+    636, 993, 995, 1433, 1521, 3306, 3389, 5432, 5900, 5985, 5986, 6379, 8080,
+    8086, 8443, 8888, 9000, 9090, 9200,
+}
+
+
+def poisoned(ports, min_ports=repair.DEFAULT_MIN_PORTS):
+    return repair.is_poisoned(set(ports), PORTLIST, min_ports)
+
+
+def test_recorded_sweep_is_caught():
+    assert poisoned(SWEPT) is True
+
+
+def test_sweep_merged_over_an_earlier_real_scan_is_caught():
+    """Passive discovery merged into whatever a scan had already found, so a
+    swept row can carry a couple of genuine ports too."""
+    assert poisoned(SWEPT | {5000, 7000}) is True
+
+
+def test_real_windows_server_is_left_alone():
+    """Lots of privileged ports from the portlist, but none of the junk ones
+    and SSH-free is not enough on its own."""
+    dc = {53, 88, 135, 139, 389, 443, 445, 464, 636, 3268, 3269, 5985, 9389, 3389}
+    assert poisoned(dc) is False
+
+
+def test_busy_linux_server_answering_ssh_is_left_alone():
+    """22 present means the capture filter cannot explain the row."""
+    assert poisoned(SWEPT | {22}) is False
+
+
+def test_small_port_list_is_left_alone():
+    assert poisoned({22, 80, 443, 3306}) is False
+
+
+def test_row_needs_the_implausible_services():
+    """A large privileged-port set without ftp-data/tftp/nntp/bgp-style junk is
+    a real host, not a sweep."""
+    plausible = {25, 53, 80, 110, 143, 389, 443, 445, 465, 587, 636, 993, 995,
+                 3306, 5432, 8080, 8443}
+    assert len(plausible) >= repair.DEFAULT_MIN_PORTS
+    assert poisoned(plausible) is False
+
+
+def test_ports_outside_the_scanner_portlist_disqualify_when_dominant():
+    """A row mostly made of ports the sweep never touches is a scan result."""
+    exotic = {20, 69, 119, 179, 515} | set(range(30000, 30040))
+    assert poisoned(exotic) is False
+
+
+def test_parse_ports_ignores_junk():
+    assert repair.parse_ports('80, 443,,x,8080') == {80, 443, 8080}
+    assert repair.parse_ports('') == set()
+    assert repair.parse_ports(None) == set()
+
+
+@pytest.mark.parametrize("min_ports,expected", [(15, True), (60, False)])
+def test_min_ports_threshold_is_honoured(min_ports, expected):
+    assert poisoned(SWEPT, min_ports=min_ports) is expected

--- a/traffic_analyzer.py
+++ b/traffic_analyzer.py
@@ -890,9 +890,10 @@ class TrafficAnalyzer:
             conn.bytes_sent += packet_size
             conn.last_seen = datetime.now()
             
-            # Record listening ports (a host using a service port = listener).
-            self._record_listening_port(src_ip, src_port)
-            self._record_listening_port(dst_ip, dst_port)
+            # Record listening ports. Only the SOURCE side counts, and only
+            # when the packet carries payload — see _record_listening_port.
+            if packet_size > 0:
+                self._record_listening_port(src_ip, src_port)
 
             # Check for suspicious patterns
             self._check_suspicious_patterns(src_ip, dst_ip, src_port, dst_port, protocol)
@@ -1019,9 +1020,27 @@ class TrafficAnalyzer:
             self.host_stats[ip].mac = mac
 
     def _record_listening_port(self, ip: str, port: int):
+        """Record that `ip` appears to serve on `port`. Feeds the hosts DB.
+
+        The caller must only pass the packet's SOURCE ip/port, and only for a
+        packet carrying payload. Both halves of that rule are load-bearing:
+
+        - Source only. Crediting the *destination* of a packet takes "someone
+          sent something to this port" as proof the host listens there, which
+          any port scan turns into a lie — Ragnar's own scanner sweeps the
+          whole configured portlist against every LAN host, so every host ends
+          up claiming ~50 open ports it never had.
+        - Payload only. `tcpdump -q` prints a SYN-ACK and an RST identically as
+          `tcp 0`, so a reply alone cannot tell an open port from a closed one.
+          Requiring payload means only a host that actually served something
+          counts, and scan responses of either kind are ignored.
+
+        This is inference from traffic, not a scan result: no payload seen, no
+        claim made. An active scan overwrites this field with the truth.
+        """
         if not ip or not port or port <= 0:
             return
-        # A host using a service port (<1024 or high-value) = it's a listener.
+        # A host serving from a service port (<1024 or high-value) = a listener.
         if port >= self.PORTSCAN_EPHEMERAL_FLOOR and port not in self.HIGH_VALUE_HIGH_PORTS:
             return
         if not self._is_lan_ip(ip):
@@ -1124,8 +1143,6 @@ class TrafficAnalyzer:
 
         merged_ports = existing_ports | listening_ports
         new_ports = listening_ports - existing_ports
-        if not existing and not merged_ports:
-            return  # nothing useful to write yet
 
         services = dict(existing_services)
         for port in merged_ports:
@@ -1133,15 +1150,21 @@ class TrafficAnalyzer:
             if key not in services or not services[key]:
                 services[key] = self.PORT_SERVICE_NAMES.get(port, '')
 
-        ports_str = ','.join(str(p) for p in sorted(merged_ports))
-        # Only pass services if we have something to add — avoid clobbering
-        # richer service descriptions an active scan may have written.
-        services_arg = services if new_ports or not existing else None
+        # Touch the port columns only when we actually inferred something new.
+        # A host we never saw serve anything is still worth recording — hosts
+        # that never answer a scan are the whole point of passive discovery —
+        # but its port list must be left alone, not overwritten with an empty
+        # one. Passing None leaves both columns untouched.
+        write_ports = bool(new_ports) or (not existing and bool(merged_ports))
+        ports_arg = ','.join(str(p) for p in sorted(merged_ports)) if write_ports else None
+        # Only pass services alongside ports — avoid clobbering richer service
+        # descriptions an active scan may have written.
+        services_arg = services if write_ports else None
 
         db.upsert_host(
             mac=target_mac,
             ip=ip,
-            ports=ports_str if (new_ports or not existing) else None,
+            ports=ports_arg,
             services=services_arg,
         )
 


### PR DESCRIPTION
The dashboard reported 699 open ports after a Traffic Analysis capture. It was counting the scanner's own port list, written back into the hosts DB once per host: passive discovery credited a host with a "listening port" whenever it saw a packet sent *to* that port, and Ragnar's scanner sweeps the configured portlist against every LAN host. 14 hosts had picked up ~50 phantom ports each.

The fingerprint was that every poisoned row was missing 22 and 8000 — the two ports the capture filter (`not port 22 and not port 8000`) hides — while carrying the rest of the portlist verbatim.

A port is now recorded only when the host itself sent a packet FROM that port carrying payload:

- Source only, because being contacted is not evidence of listening.
- Payload only, because `tcpdump -q` prints SYN-ACK and RST identically as `tcp 0` — a reply alone cannot tell an open port from a closed one, so scan responses of either kind are ignored.

Most hosts now contribute no ports at all, which is correct for inference from traffic. That exposed a second bug: _upsert_passive_host refused to create a host with no ports ("nothing useful to write yet"), so with the strict rule the firewalled hosts passive discovery exists for would have stopped being recorded entirely. It now records the host and passes ports=None, leaving the port columns untouched rather than overwriting a real scan result with an empty one.

scripts/repair_passive_ports.py cleans up databases written before this. It matches the sweep signature — dozens of ports dominated by the scanner's portlist, three or more services nobody runs together (ftp-data, tftp, nntp, bgp...), and no 22/8000 — then backs up the DB and clears those rows, which the next active scan repopulates. Reports by default; --apply writes.

Ran on this box: 676 phantom ports across 14 hosts cleared, dashboard back to
23. Tests cover both directions of the heuristic, since clearing a real scan result is the outcome worth avoiding.