### PR TITLE
Feat/ragnarmobile tailscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ web will be down during wardrive without ap or wifi connection.
 
 **Mobile app over the mesh** — the [Ragnar mobile app](https://github.com/PierreGode/Ragnarmobile)
 (iOS/Android) drives the box over the [Ragnar Mesh](docs/mesh.md). You bring
-Tailscale up on the phone, paste a Tailscale API token into the app, and it
-lists every unit tagged `tag:ragnar-mesh` so you can pick one and switch between
-them. There is no local-IP or Bluetooth setup. See
-[The Ragnar Mobile app](docs/mesh.md#the-ragnar-mobile-app).
+Tailscale up on the phone, connect to one unit by its Tailscale address, and log
+in — the app then reads `/api/mesh/status` off that unit to list and switch
+between every other unit on the mesh. No Tailscale token, no local-IP or
+Bluetooth setup. See [The Ragnar Mobile app](docs/mesh.md#the-ragnar-mobile-app).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ The portal supports network scanning with signal strength, manual entry for hidd
 
 web will be down during wardrive without ap or wifi connection.
 
-**Mobile app + Bluetooth discovery** — the [Ragnar mobile app](https://github.com/PierreGode/Ragnarmobile)
-(iOS/Android) drives the box over your network. Optionally, a BlueZ GATT
-peripheral lets the phone *find* a box and read its IP over Bluetooth — it is
-provisioning only; all real traffic stays on Wi-Fi. Off by default (it shares
-the adapter with the BLE overlay scanner); enable it from the app's Box tab or
-`POST /api/ble/provisioning/toggle`. See [docs/ble_provisioning.md](docs/ble_provisioning.md).
+**Mobile app over the mesh** — the [Ragnar mobile app](https://github.com/PierreGode/Ragnarmobile)
+(iOS/Android) drives the box over the [Ragnar Mesh](docs/mesh.md). You bring
+Tailscale up on the phone, paste a Tailscale API token into the app, and it
+lists every unit tagged `tag:ragnar-mesh` so you can pick one and switch between
+them. There is no local-IP or Bluetooth setup. See
+[The Ragnar Mobile app](docs/mesh.md#the-ragnar-mobile-app).
 
 ---
 

--- a/docs/ble_provisioning.md
+++ b/docs/ble_provisioning.md
@@ -1,9 +1,13 @@
 # BLE Provisioning
 
-`ble_provisioning.py` is a BlueZ GATT peripheral that lets the **Ragnar mobile
-app** discover a box over Bluetooth and learn how to reach it over IP. It is
-the Pi side of the contract documented in the Ragnarmobile repo
-(`docs/PROTOCOL.md`).
+> **Note (deprecated client path).** The Ragnar mobile app no longer uses
+> Bluetooth to find a box — it connects over the [Ragnar Mesh](mesh.md)
+> (Tailscale) and selects units by their `tag:ragnar-mesh` tag. This BLE
+> peripheral still ships and works, but nothing currently consumes it; it is
+> kept for other provisioning clients and may be retired later.
+
+`ble_provisioning.py` is a BlueZ GATT peripheral that lets a client discover a
+box over Bluetooth and learn how to reach it over IP.
 
 ## What it is — and isn't
 

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -425,27 +425,28 @@ no Bluetooth path — it reaches units exclusively over the mesh, which is what
 makes one phone able to jump between a box on your desk and a box in a data
 centre without reconfiguration.
 
-**How it finds units.** The app asks the Tailscale API for every device in the
-tailnet and keeps the ones tagged `tag:ragnar-mesh` — i.e. every Ragnar unit.
-Each becomes a tappable entry; selecting one points the app at
-`http://<100.x>:8000`. Switching units is just picking a different entry.
+**How it finds units — and why it needs no Tailscale token.** The app never
+talks to the Tailscale API. It connects to one unit and reads that unit's
+[`/api/mesh/status`](#mesh-nodes-list-and-the-node-page), which already lists
+every peer (Viking name, `100.x` address, online state, tag) because the unit
+speaks to its own `tailscaled`. So a single login exposes the whole fleet, and
+switching units just repoints the app at another peer's `http://<100.x>:8000`.
 
 **What the operator needs, once:**
 
 1. **Tailscale connected on the phone**, signed into the same tailnet as the
    units. This is what makes the `100.x` addresses reachable.
-2. **A Tailscale API access token** pasted into the app (admin console →
-   **Settings → Keys → API access tokens**). Listing devices is an API
-   operation, so a token is required; tailnet membership alone cannot enumerate
-   the fleet. The token is stored on the device and never sent to a Ragnar unit.
+2. **One unit's Tailscale address** typed into the app — its MagicDNS name
+   (`bjorn.tailXXXX.ts.net`) or `100.x` — plus a normal Ragnar login. Every
+   other unit is then discovered from the mesh; nothing else is entered.
 
 **Why this is safe.** The app authenticates to each unit exactly as the web UI
 does — Ragnar's existing session login (`/api/auth/login`). The mesh reaching a
 unit is not the same as being authorized on it: an operator's phone is a real
 tailnet node and must still sign in, precisely as
 [the mesh security model](#unit-to-unit-authentication) requires of any
-non-unit caller. The Tailscale token only reads the device list; it grants no
-access to a unit's API.
+non-unit caller. Reading `/api/mesh/status` is a session-authenticated GET, the
+same as any other read the app makes.
 
 For units to answer the phone on port 8000, the tailnet ACL must permit it —
 the [suggested ACL shape](#suggested-acl-shape) already opens

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -31,6 +31,7 @@ be logged into renders the mesh; so would any other.
   - [Path 3 — later, from the web UI](#path-3--later-from-the-web-ui)
 - [Reaching the whole far-side LAN](#reaching-the-whole-far-side-lan)
 - [Backup access when Ragnar itself is wedged](#backup-access-when-ragnar-itself-is-wedged)
+- [The Ragnar Mobile app](#the-ragnar-mobile-app)
 - [Security model](#security-model)
 - [Cross-site incident correlation](#cross-site-incident-correlation)
 - [Configuration reference](#configuration-reference)
@@ -413,6 +414,43 @@ and both make the card *correct*, not wrong:
 > **Set this up before you ship the hardware.** Every one of these paths is
 > trivial to establish with the box on your desk and impossible to establish
 > once it is 1,500 km away and unreachable.
+
+---
+
+## The Ragnar Mobile app
+
+[Ragnar Mobile](https://github.com/PierreGode/Ragnarmobile) (iOS + Android) is a
+first-class mesh client. It does **not** connect to a unit by local IP and has
+no Bluetooth path — it reaches units exclusively over the mesh, which is what
+makes one phone able to jump between a box on your desk and a box in a data
+centre without reconfiguration.
+
+**How it finds units.** The app asks the Tailscale API for every device in the
+tailnet and keeps the ones tagged `tag:ragnar-mesh` — i.e. every Ragnar unit.
+Each becomes a tappable entry; selecting one points the app at
+`http://<100.x>:8000`. Switching units is just picking a different entry.
+
+**What the operator needs, once:**
+
+1. **Tailscale connected on the phone**, signed into the same tailnet as the
+   units. This is what makes the `100.x` addresses reachable.
+2. **A Tailscale API access token** pasted into the app (admin console →
+   **Settings → Keys → API access tokens**). Listing devices is an API
+   operation, so a token is required; tailnet membership alone cannot enumerate
+   the fleet. The token is stored on the device and never sent to a Ragnar unit.
+
+**Why this is safe.** The app authenticates to each unit exactly as the web UI
+does — Ragnar's existing session login (`/api/auth/login`). The mesh reaching a
+unit is not the same as being authorized on it: an operator's phone is a real
+tailnet node and must still sign in, precisely as
+[the mesh security model](#unit-to-unit-authentication) requires of any
+non-unit caller. The Tailscale token only reads the device list; it grants no
+access to a unit's API.
+
+For units to answer the phone on port 8000, the tailnet ACL must permit it —
+the [suggested ACL shape](#suggested-acl-shape) already opens
+`tag:ragnar-mesh:8000` between mesh members; add the operator's user or device
+as a source there too if the phone is not itself tagged.
 
 ---
 


### PR DESCRIPTION
This pull request updates the documentation to reflect that the Ragnar mobile app now exclusively uses the Ragnar Mesh (via Tailscale) for device discovery and management, deprecating the previous Bluetooth-based provisioning path. It also adds clear guidance for operators on how the mobile app interacts with the mesh and the security implications.

**Mobile app and mesh documentation updates:**

* Updated the `README.md` to describe that the Ragnar mobile app now connects over the Ragnar Mesh, removing references to Bluetooth-based discovery and provisioning.
* Added a new section in `docs/mesh.md` detailing how the mobile app discovers and connects to units over the mesh, including login flow, discovery mechanism, and security model.
* Updated the table of contents in `docs/mesh.md` to include the new mobile app section.

**Bluetooth provisioning deprecation:**

* Marked the Bluetooth provisioning path as deprecated in `docs/ble_provisioning.md`, clarifying that the mobile app no longer uses it and that it is retained only for potential other clients.