### PR TITLE
Remove Ragnar mobile app section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,7 @@ The portal supports network scanning with signal strength, manual entry for hidd
 
 web will be down during wardrive without ap or wifi connection.
 
-**Mobile app over the mesh** — the [Ragnar mobile app](https://github.com/PierreGode/Ragnarmobile)
-(iOS/Android) drives the box over the [Ragnar Mesh](docs/mesh.md). You bring
-Tailscale up on the phone, connect to one unit by its Tailscale address, and log
-in — the app then reads `/api/mesh/status` off that unit to list and switch
-between every other unit on the mesh. No Tailscale token, no local-IP or
-Bluetooth setup. See [The Ragnar Mobile app](docs/mesh.md#the-ragnar-mobile-app).
 
----
 
 ## 🌟 Features
 


### PR DESCRIPTION
Removed details about the Ragnar mobile app and its functionality with Tailscale.