### PR TITLE
Investigate/airtime starvation detection

### DIFF
--- a/docs/wifi-defense.md
+++ b/docs/wifi-defense.md
@@ -163,6 +163,32 @@ re-associating/authing repeatedly). Findings flag high retry (≥30%), airtime
 hogs (≥50%) and unstable roaming. Route `GET /api/wifidef/airtime`; analysis is
 a pure function covered by selftest.
 
+### Airtime starvation / the "legacy client tax"
+
+On 2.4 GHz the medium is half-duplex CSMA/CA: airtime — not bandwidth — is the
+finite shared resource, and a single slow station consumes it out of all
+proportion to the bytes it moves. A client stuck at 1–11 Mbps DSSS (802.11b)
+needs enormously more time-on-air per frame than a Wi-Fi 6 client at hundreds of
+Mbps, and its mere presence makes the AP announce **ERP protection** (RTS /
+CTS-to-self) that every station in the BSS then pays on every frame. The cell
+looks "downgraded" but the mechanism is airtime starvation, not a rate drop.
+
+Ragnar pinpoints this two ways from the same passive capture:
+
+- **ERP protection detection** — the ERP Information element (ID 42) in beacons
+  carries a *Use_Protection* bit. When set, the AP is telling everyone a legacy
+  DSSS client is present; the AP row shows an **ERP** badge and an
+  `erp_protection` finding names the BSS.
+- **Per-client airtime attribution** — airtime is also bucketed by the
+  transmitting station (addr2), not just the AP. A station transmitting at DSSS
+  rates while eating real airtime is classified `802.11b (DSSS/CCK)` and raised
+  as a `slow_client` finding naming its MAC — the device to move to its own
+  SSID / 5 GHz, or to lock out by disabling the low basic rates on the AP.
+
+The per-client table (`clients[]` in the response) lists each station's PHY
+generation, frame count, airtime % and rate spread, with legacy rows
+highlighted.
+
 ## Client isolation observer
 
 A passive audit of whether an AP — or a whole mesh/ESS — actually enforces

--- a/docs/wifi-defense.md
+++ b/docs/wifi-defense.md
@@ -189,6 +189,21 @@ The per-client table (`clients[]` in the response) lists each station's PHY
 generation, frame count, airtime % and rate spread, with legacy rows
 highlighted.
 
+### Per-AP security & PHY generation
+
+Each AP row also reports two metrics read straight from its beacons (no active
+probing):
+
+- **Security** — `Open` / `WEP` / `WPA` / `WPA2` / `WPA2-Ent` / `WPA3` /
+  `WPA2/3` (transition) / `OWE`, decoded from the Privacy capability bit, the
+  RSN element (ID 48) and its AKM suites, and the legacy WPA v1 vendor element.
+  `Open` and `WEP` also raise a `weak_security` finding.
+- **PHY** — the 802.11 generation from the capability IEs: `802.11n (Wi-Fi 4)`,
+  `802.11ac (Wi-Fi 5)`, `802.11ax (Wi-Fi 6)`, `802.11be (Wi-Fi 7)`, or — when no
+  HT/VHT/HE/EHT IE is present — the legacy PHY split by band and rate set:
+  `802.11a`, `802.11g` (OFDM rates advertised) or `802.11b` (DSSS-only). The
+  b/g split is what the Spectrum Analyzer's coarser "legacy" label can't do.
+
 ## Client isolation observer
 
 A passive audit of whether an AP — or a whole mesh/ESS — actually enforces

--- a/docs/wifi-defense.md
+++ b/docs/wifi-defense.md
@@ -189,6 +189,34 @@ The per-client table (`clients[]` in the response) lists each station's PHY
 generation, frame count, airtime % and rate spread, with legacy rows
 highlighted.
 
+#### Naming the device (radio + network fusion)
+
+The monitor radio only sees a client by **MAC** — it can say *"this MAC is
+802.11b"* but not *what the device is*. Device identity (hostname, vendor,
+printer/phone/TV) is a **network-layer** fact that needs an association to the
+AP, which a monitor interface never has. So the two layers are fused by MAC:
+
+- **radio layer** (monitor mode) → MAC → PHY / airtime (the `clients[]` rows);
+- **network layer** (the connected radio's host inventory: DHCP/mDNS/ARP + the
+  device classifier) → MAC → ip / hostname / vendor / device type.
+
+The `/api/wifidef/airtime` route joins the two on MAC (`enrich_identity()` +
+`_enrich_airtime_identity()`), so each client row also carries `hostname`, `ip`,
+`vendor`, `device_type` and `device_label`, and the `slow_client` finding names
+the device (e.g. *"HP-LaserJet (192.168.1.42) [aa:bb:…] is 802.11b …"*). MACs
+not in the inventory fall back to an OUI vendor and show as *unidentified* until
+a network scan records them; randomized MACs are left unnamed.
+
+**Recommended deployment (Pi Zero 2 W + one Alfa AWUS036AXM).** Legacy 802.11b
+is a 2.4 GHz-only phenomenon, so a 2.4-only onboard radio loses nothing here.
+Let the **Pi onboard radio stay connected** (managed mode) to the target 2.4 GHz
+SSID — it populates the host inventory (hostnames / device types) — and put the
+**Alfa in dedicated monitor mode on that same channel** for the PHY/airtime
+capture. One Alfa is enough; the onboard radio can't do monitor mode but does
+managed fine, and each radio does the one job it's suited to. (A single
+mt7921u Alfa can alternatively do both at once via a concurrent monitor vif
+pinned to the connected channel.)
+
 ### Per-AP security & PHY generation
 
 Each AP row also reports two metrics read straight from its beacons (no active

--- a/docs/wifi-defense.md
+++ b/docs/wifi-defense.md
@@ -207,6 +207,12 @@ the device (e.g. *"HP-LaserJet (192.168.1.42) [aa:bb:…] is 802.11b …"*). MAC
 not in the inventory fall back to an OUI vendor and show as *unidentified* until
 a network scan records them; randomized MACs are left unnamed.
 
+Each client row also carries the **SSID** of the AP it is transmitting to
+(joined from the AP's `bssid`→`ssid` map; a client whose AP never beaconed in
+the capture falls back to showing the BSSID). The per-client table has an
+**SSID filter** dropdown so a multi-network capture can be narrowed to one
+network — you see exactly which clients belong to which SSID.
+
 **Recommended deployment (Pi Zero 2 W + one Alfa AWUS036AXM).** Legacy 802.11b
 is a 2.4 GHz-only phenomenon, so a 2.4-only onboard radio loses nothing here.
 Let the **Pi onboard radio stay connected** (managed mode) to the target 2.4 GHz

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -14215,6 +14215,76 @@ def do_install_tool(tool):
     return {'success': True, 'tool': tool, 'message': f'Installed {pkg}.'}
 
 
+def _ports_to_list(ports):
+    """Best-effort port list from a hosts.ports cell (JSON array, or a
+    comma/space-separated string like '22/tcp,80')."""
+    if not ports:
+        return []
+    if isinstance(ports, (list, tuple)):
+        raw = ports
+    else:
+        try:
+            raw = json.loads(ports)
+            if not isinstance(raw, list):
+                raise ValueError
+        except (ValueError, TypeError):
+            raw = re.split(r'[,\s]+', str(ports))
+    out = []
+    for p in raw:
+        m = re.match(r'\s*(\d+)', str(p))
+        if m:
+            out.append(m.group(1))
+    return out
+
+
+def _enrich_airtime_identity(result):
+    """Join the hosts inventory (from the connected radio) onto the monitor-mode
+    per-client rows by MAC, so a legacy station reads as a named device. Fully
+    best-effort: any missing piece (no DB, no classifier) just leaves the row
+    with whatever OUI vendor we can derive. Also rewrites slow_client findings
+    to name the device instead of a bare MAC."""
+    clients = result.get('clients') or []
+    host_map = {}
+    try:
+        from init_shared import shared_data
+        db = getattr(shared_data, 'db', None)
+        hosts = db.get_all_hosts() if db is not None else []
+    except Exception:
+        hosts = []
+    try:
+        import device_classifier
+    except Exception:
+        device_classifier = None
+    for h in hosts or []:
+        mac = (h.get('mac') or '').strip().lower()
+        if not mac:
+            continue
+        vendor = h.get('vendor') or None
+        dtype = dlabel = None
+        if device_classifier is not None:
+            try:
+                cls = device_classifier.classify_device(
+                    vendor, _ports_to_list(h.get('ports')), device_ip=h.get('ip'))
+                dtype = cls.get('device_type')
+                dlabel = cls.get('label')
+            except Exception:
+                pass
+        host_map[mac] = {'ip': h.get('ip'), 'hostname': h.get('hostname'),
+                         'vendor': vendor, 'device_type': dtype,
+                         'device_label': dlabel}
+    wifi_defense.enrich_identity(clients, host_map, wifi_analyzer._oui_lookup)
+    # Give the slow_client findings a human name where we resolved one.
+    names = {}
+    for c in clients:
+        label = c.get('hostname') or c.get('device_label') or c.get('vendor')
+        if label:
+            names[c['client']] = label + (f" ({c['ip']})" if c.get('ip') else '')
+    for f in result.get('findings') or []:
+        if f.get('type') == 'slow_client' and f.get('client') in names:
+            f['detail'] = f"{names[f['client']]} [{f['client']}]" + \
+                f['detail'][len(f['client']):]
+
+
 # --------------------------------------------------------------------------
 # Route registration
 # --------------------------------------------------------------------------
@@ -15147,7 +15217,15 @@ def register_network_diagnostics(app, logger=None):
         ch = request.args.get('channel')
         channel = int(ch) if (ch and ch.isdigit()) else None
         _log(f"wifidef/airtime {iface} ch={channel}")
-        return jsonify(wifi_defense.do_airtime(iface, seconds=secs, channel=channel))
+        result = wifi_defense.do_airtime(iface, seconds=secs, channel=channel)
+        # Fuse radio-layer PHY (who is 802.11b, by MAC) with network-layer
+        # identity from the connected radio's host inventory (what each MAC is).
+        if isinstance(result, dict) and result.get('clients'):
+            try:
+                _enrich_airtime_identity(result)
+            except Exception as exc:                      # never fail the scan
+                _log(f"wifidef/airtime identity enrich skipped: {exc}")
+        return jsonify(result)
 
     @app.route('/api/wifidef/isolation', methods=['GET'])
     def wifidef_isolation():

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -2667,11 +2667,14 @@
                     </table>
                 </div>
                 <div id="wifidef-at-clients-wrap" class="mt-4 hidden">
-                    <h4 class="text-xs font-semibold text-gray-300 mb-1">Per-client airtime <span class="text-[10px] text-gray-500 font-normal">— who actually holds the medium; a legacy 802.11b station eats airtime out of all proportion to its traffic and forces protection overhead on the whole cell</span></h4>
+                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-1">
+                        <h4 class="text-xs font-semibold text-gray-300">Per-client airtime <span class="text-[10px] text-gray-500 font-normal">— who actually holds the medium; a legacy 802.11b station eats airtime out of all proportion to its traffic and forces protection overhead on the whole cell</span></h4>
+                        <label class="text-[11px] text-gray-400 whitespace-nowrap">SSID <select id="wifidef-at-client-filter" onchange="wifidefFilterClients()" class="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-xs"><option value="">All</option></select></label>
+                    </div>
                     <div class="overflow-x-auto">
                         <table class="w-full text-sm">
                             <thead><tr class="text-left text-gray-400 border-b border-slate-800">
-                                <th class="py-1 pr-2">Client</th><th class="py-1 pr-2">Device</th><th class="py-1 pr-2">PHY</th><th class="py-1 pr-2">Frames</th><th class="py-1 pr-2">Airtime %</th><th class="py-1 pr-2">Rate min/med/max</th><th class="py-1 pr-2">RSSI</th>
+                                <th class="py-1 pr-2">Client</th><th class="py-1 pr-2">Device</th><th class="py-1 pr-2">SSID</th><th class="py-1 pr-2">PHY</th><th class="py-1 pr-2">Frames</th><th class="py-1 pr-2">Airtime %</th><th class="py-1 pr-2">Rate min/med/max</th><th class="py-1 pr-2">RSSI</th>
                             </tr></thead>
                             <tbody id="wifidef-at-clients-tbody"></tbody>
                         </table>

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -2671,7 +2671,7 @@
                     <div class="overflow-x-auto">
                         <table class="w-full text-sm">
                             <thead><tr class="text-left text-gray-400 border-b border-slate-800">
-                                <th class="py-1 pr-2">Client</th><th class="py-1 pr-2">PHY</th><th class="py-1 pr-2">Frames</th><th class="py-1 pr-2">Airtime %</th><th class="py-1 pr-2">Rate min/med/max</th><th class="py-1 pr-2">RSSI</th>
+                                <th class="py-1 pr-2">Client</th><th class="py-1 pr-2">Device</th><th class="py-1 pr-2">PHY</th><th class="py-1 pr-2">Frames</th><th class="py-1 pr-2">Airtime %</th><th class="py-1 pr-2">Rate min/med/max</th><th class="py-1 pr-2">RSSI</th>
                             </tr></thead>
                             <tbody id="wifidef-at-clients-tbody"></tbody>
                         </table>

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -2648,7 +2648,7 @@
                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-3">
                     <div>
                         <h3 class="font-semibold text-sm">Airtime &amp; link quality <span class="text-[11px] text-gray-500 font-normal">— click a row to inspect it in the Spectrum Analyzer</span></h3>
-                        <p class="text-[11px] text-gray-500 mt-0.5 max-w-2xl">Passive per-AP <strong>airtime %</strong>, <strong>retry rate</strong> and <strong>PHY-rate</strong> spread, plus roaming churn — the "why is it slow" view. Best on a <strong>fixed channel</strong> (airtime % is only meaningful when not hopping).</p>
+                        <p class="text-[11px] text-gray-500 mt-0.5 max-w-2xl">Passive per-AP <strong>airtime %</strong>, <strong>retry rate</strong> and <strong>PHY-rate</strong> spread, plus <strong>per-client airtime</strong> and <strong>ERP-protection</strong> detection — pinpoints a legacy <strong>802.11b</strong> device that's taxing the whole cell. Best on a <strong>fixed channel</strong> (airtime % is only meaningful when not hopping).</p>
                     </div>
                     <div class="flex flex-wrap items-end gap-2">
                         <label class="text-[11px] text-gray-400">Channel <input id="wifidef-at-channel" type="text" value="" placeholder="e.g. 6" class="w-16 bg-slate-800 border border-slate-700 rounded px-2 py-1 text-xs" title="Fix a channel for meaningful airtime %; blank = hop (approximate)"></label>
@@ -2665,6 +2665,17 @@
                         </tr></thead>
                         <tbody id="wifidef-at-tbody"><tr><td colspan="7" class="py-4 text-center text-gray-500">Press <span class="text-gray-300">Analyze airtime</span> (needs monitor mode).</td></tr></tbody>
                     </table>
+                </div>
+                <div id="wifidef-at-clients-wrap" class="mt-4 hidden">
+                    <h4 class="text-xs font-semibold text-gray-300 mb-1">Per-client airtime <span class="text-[10px] text-gray-500 font-normal">— who actually holds the medium; a legacy 802.11b station eats airtime out of all proportion to its traffic and forces protection overhead on the whole cell</span></h4>
+                    <div class="overflow-x-auto">
+                        <table class="w-full text-sm">
+                            <thead><tr class="text-left text-gray-400 border-b border-slate-800">
+                                <th class="py-1 pr-2">Client</th><th class="py-1 pr-2">PHY</th><th class="py-1 pr-2">Frames</th><th class="py-1 pr-2">Airtime %</th><th class="py-1 pr-2">Rate min/med/max</th><th class="py-1 pr-2">RSSI</th>
+                            </tr></thead>
+                            <tbody id="wifidef-at-clients-tbody"></tbody>
+                        </table>
+                    </div>
                 </div>
                 <div id="wifidef-at-roam" class="mt-2 text-xs text-gray-400"></div>
             </div>

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -2661,9 +2661,9 @@
                 <div class="overflow-x-auto">
                     <table class="w-full text-sm">
                         <thead><tr class="text-left text-gray-400 border-b border-slate-800">
-                            <th class="py-1 pr-2">SSID</th><th class="py-1 pr-2">BSSID</th><th class="py-1 pr-2">Frames</th><th class="py-1 pr-2">Retry %</th><th class="py-1 pr-2">Airtime %</th><th class="py-1 pr-2">Rate min/med/max</th><th class="py-1 pr-2">RSSI</th>
+                            <th class="py-1 pr-2">SSID</th><th class="py-1 pr-2">BSSID</th><th class="py-1 pr-2">Security</th><th class="py-1 pr-2">PHY</th><th class="py-1 pr-2">Frames</th><th class="py-1 pr-2">Retry %</th><th class="py-1 pr-2">Airtime %</th><th class="py-1 pr-2">Rate min/med/max</th><th class="py-1 pr-2">RSSI</th>
                         </tr></thead>
-                        <tbody id="wifidef-at-tbody"><tr><td colspan="7" class="py-4 text-center text-gray-500">Press <span class="text-gray-300">Analyze airtime</span> (needs monitor mode).</td></tr></tbody>
+                        <tbody id="wifidef-at-tbody"><tr><td colspan="9" class="py-4 text-center text-gray-500">Press <span class="text-gray-300">Analyze airtime</span> (needs monitor mode).</td></tr></tbody>
                     </table>
                 </div>
                 <div id="wifidef-at-clients-wrap" class="mt-4 hidden">

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -4148,7 +4148,7 @@ function _wifidefUpdateRunUI() {
 // Must match wifi_defense.py `_BUILD`. If the running service reports something
 // else, the webapp is executing an OLD wifi_defense module (service not restarted
 // after a git pull) — the #1 cause of "the fix didn't work in the web UI".
-const WIFIDEF_BUILD = '20260729-airtime-client-erp';
+const WIFIDEF_BUILD = '20260729-airtime-sec-phy';
 
 function _wifidefFillIfaces() {
     fetch('/api/wifidef/interfaces').then(r => r.json()).then(d => {
@@ -4373,19 +4373,27 @@ function wifidefRenderAirtime(d) {
             : f.type === 'airtime_hog' ? 'bg-orange-600/20 text-orange-300 border-orange-700/50'
             : f.type === 'slow_client' ? 'bg-red-600/20 text-red-300 border-red-700/50'
             : f.type === 'erp_protection' ? 'bg-fuchsia-600/20 text-fuchsia-300 border-fuchsia-700/50'
+            : f.type === 'weak_security' ? 'bg-rose-600/20 text-rose-300 border-rose-700/50'
             : 'bg-red-600/20 text-red-300 border-red-700/50';
         return `<span class="px-2 py-1 rounded border ${cls}">${f.detail}</span>`;
     }).join('') || '<span class="text-green-400 text-xs">✓ No link-quality issues in this capture.</span>';
     const tb = document.getElementById('wifidef-at-tbody');
     const aps = d.aps || [];
-    if (!aps.length) { tb.innerHTML = '<tr><td colspan="7" class="py-4 text-center text-gray-500">No frames captured (wrong channel? adapter idle?).</td></tr>'; }
+    if (!aps.length) { tb.innerHTML = '<tr><td colspan="9" class="py-4 text-center text-gray-500">No frames captured (wrong channel? adapter idle?).</td></tr>'; }
     else tb.innerHTML = aps.map(a => {
         const retryCol = a.retry_pct >= 30 ? 'text-red-400' : a.retry_pct >= 15 ? 'text-amber-400' : 'text-gray-300';
         const airCol = a.airtime_pct >= 50 ? 'text-orange-400' : 'text-gray-300';
         const rate = a.rate_med != null ? `${a.rate_min}/${a.rate_med}/${a.rate_max}` : '—';
+        const secCol = (a.security === 'Open' || a.security === 'WEP') ? 'text-red-400'
+            : (a.security === 'WPA') ? 'text-amber-400'
+            : a.security ? 'text-gray-300' : 'text-gray-600';
+        const legacyPhy = a.ap_phy && /802\.11[bg]|802\.11a /.test(a.ap_phy);
+        const phyCol = legacyPhy ? 'text-red-300' : a.ap_phy ? 'text-gray-300' : 'text-gray-600';
         return `<tr class="border-b border-slate-800/50 cursor-pointer hover:bg-slate-800/40" title="Open in Spectrum Analyzer" onclick="wifiPivotFromDefense('${a.bssid}','${encodeURIComponent(a.ssid || '').replace(/'/g, '%27')}')">
             <td class="py-1 pr-2">${a.ssid ? _esc(a.ssid) : '<span class="text-gray-600">—</span>'}${a.erp_protection ? ' <span class="text-[9px] px-1 rounded bg-fuchsia-600/20 text-fuchsia-300 border border-fuchsia-700/50" title="ERP protection ON — a legacy 802.11b client is taxing this BSS">ERP</span>' : ''}</td>
             <td class="py-1 pr-2 font-mono text-[11px]">${a.bssid}</td>
+            <td class="py-1 pr-2 text-xs ${secCol}">${a.security || '—'}</td>
+            <td class="py-1 pr-2 text-xs ${phyCol}">${a.ap_phy || '—'}</td>
             <td class="py-1 pr-2">${a.frames} <span class="text-gray-600 text-[10px]">(${a.data_frames} data)</span></td>
             <td class="py-1 pr-2 ${retryCol}">${a.retry_pct}%</td>
             <td class="py-1 pr-2 ${airCol}">${a.airtime_pct}%</td>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -4148,7 +4148,7 @@ function _wifidefUpdateRunUI() {
 // Must match wifi_defense.py `_BUILD`. If the running service reports something
 // else, the webapp is executing an OLD wifi_defense module (service not restarted
 // after a git pull) — the #1 cause of "the fix didn't work in the web UI".
-const WIFIDEF_BUILD = '20260729-airtime-identity';
+const WIFIDEF_BUILD = '20260729-airtime-ssid-filter';
 
 function _wifidefFillIfaces() {
     fetch('/api/wifidef/interfaces').then(r => r.json()).then(d => {
@@ -4402,40 +4402,70 @@ function wifidefRenderAirtime(d) {
     }).join('');
     // Per-client airtime attribution — pinpoints the offending device.
     const cwrap = document.getElementById('wifidef-at-clients-wrap');
-    const ctb = document.getElementById('wifidef-at-clients-tbody');
-    const clients = d.clients || [];
-    if (clients.length) {
+    _wifidefClients = d.clients || [];
+    if (_wifidefClients.length) {
         cwrap.classList.remove('hidden');
-        ctb.innerHTML = clients.map(c => {
-            const airCol = c.airtime_pct >= 20 ? 'text-orange-400' : 'text-gray-300';
-            const rate = c.rate_med != null ? `${c.rate_min}/${c.rate_med}/${c.rate_max}` : '—';
-            const phy = c.legacy
-                ? `<span class="text-red-300" title="Legacy DSSS — forces protection overhead">${c.phy}</span>`
-                : `<span class="text-gray-400">${c.phy || '—'}</span>`;
-            const name = c.hostname || c.device_label || c.vendor;
-            const sub = [c.hostname ? (c.device_label || c.vendor) : c.vendor, c.ip]
-                .filter(Boolean).join(' · ');
-            const device = name
-                ? `<span class="text-gray-200">${_esc(name)}</span>${sub ? ` <span class="text-gray-500 text-[10px]">${_esc(sub)}</span>` : ''}`
-                : '<span class="text-gray-600" title="Not in the host inventory — run a network scan on the connected radio to name it">unidentified</span>';
-            return `<tr class="border-b border-slate-800/50 ${c.legacy ? 'bg-red-900/10' : ''}">
-                <td class="py-1 pr-2 font-mono text-[11px]">${c.client}</td>
-                <td class="py-1 pr-2 text-xs">${device}</td>
-                <td class="py-1 pr-2 text-xs">${phy}</td>
-                <td class="py-1 pr-2">${c.frames}</td>
-                <td class="py-1 pr-2 ${airCol}">${c.airtime_pct}%</td>
-                <td class="py-1 pr-2 text-xs">${rate} <span class="text-gray-600">Mbps</span></td>
-                <td class="py-1 pr-2">${c.rssi == null ? '—' : c.rssi + ' dBm'}</td></tr>`;
-        }).join('');
+        // Populate the SSID filter with the networks actually seen this capture.
+        const sel = document.getElementById('wifidef-at-client-filter');
+        const groups = new Map();               // key -> label (ssid, else BSSID)
+        _wifidefClients.forEach(c => {
+            const key = c.ssid || c.bssid || '';
+            if (key && !groups.has(key)) groups.set(key, c.ssid || c.bssid);
+        });
+        const prev = sel.value;
+        sel.innerHTML = '<option value="">All SSIDs</option>' +
+            [...groups.entries()].map(([k, label]) =>
+                `<option value="${_esc(k)}">${_esc(label)}</option>`).join('');
+        sel.value = [...groups.keys()].includes(prev) ? prev : '';
+        wifidefFilterClients();
     } else {
         cwrap.classList.add('hidden');
-        ctb.innerHTML = '';
+        document.getElementById('wifidef-at-clients-tbody').innerHTML = '';
     }
     const roam = document.getElementById('wifidef-at-roam');
     roam.innerHTML = (d.roaming && d.roaming.length)
         ? '<b class="text-gray-300">Roaming clients:</b> ' + d.roaming.map(r =>
             `<span class="font-mono">${r.client}</span> (${r.reassoc + r.auth}×)`).join(', ')
         : '';
+}
+
+// Clients from the last airtime scan, kept so the SSID filter can re-render.
+let _wifidefClients = [];
+
+function _wifidefClientRow(c) {
+    const airCol = c.airtime_pct >= 20 ? 'text-orange-400' : 'text-gray-300';
+    const rate = c.rate_med != null ? `${c.rate_min}/${c.rate_med}/${c.rate_max}` : '—';
+    const phy = c.legacy
+        ? `<span class="text-red-300" title="Legacy DSSS — forces protection overhead">${c.phy}</span>`
+        : `<span class="text-gray-400">${c.phy || '—'}</span>`;
+    const name = c.hostname || c.device_label || c.vendor;
+    const sub = [c.hostname ? (c.device_label || c.vendor) : c.vendor, c.ip]
+        .filter(Boolean).join(' · ');
+    const device = name
+        ? `<span class="text-gray-200">${_esc(name)}</span>${sub ? ` <span class="text-gray-500 text-[10px]">${_esc(sub)}</span>` : ''}`
+        : '<span class="text-gray-600" title="Not in the host inventory — run a network scan on the connected radio to name it">unidentified</span>';
+    const ssid = c.ssid ? _esc(c.ssid)
+        : (c.bssid ? `<span class="text-gray-600 font-mono text-[10px]" title="AP SSID not seen in this capture">${c.bssid}</span>` : '<span class="text-gray-600">—</span>');
+    return `<tr class="border-b border-slate-800/50 ${c.legacy ? 'bg-red-900/10' : ''}">
+        <td class="py-1 pr-2 font-mono text-[11px]">${c.client}</td>
+        <td class="py-1 pr-2 text-xs">${device}</td>
+        <td class="py-1 pr-2 text-xs">${ssid}</td>
+        <td class="py-1 pr-2 text-xs">${phy}</td>
+        <td class="py-1 pr-2">${c.frames}</td>
+        <td class="py-1 pr-2 ${airCol}">${c.airtime_pct}%</td>
+        <td class="py-1 pr-2 text-xs">${rate} <span class="text-gray-600">Mbps</span></td>
+        <td class="py-1 pr-2">${c.rssi == null ? '—' : c.rssi + ' dBm'}</td></tr>`;
+}
+
+// Re-render the per-client table filtered to the SSID chosen in the dropdown.
+function wifidefFilterClients() {
+    const sel = document.getElementById('wifidef-at-client-filter');
+    const key = sel ? sel.value : '';
+    const rows = _wifidefClients.filter(c => !key || (c.ssid || c.bssid) === key);
+    const ctb = document.getElementById('wifidef-at-clients-tbody');
+    ctb.innerHTML = rows.length
+        ? rows.map(_wifidefClientRow).join('')
+        : '<tr><td colspan="8" class="py-3 text-center text-gray-500">No clients on this SSID in the capture.</td></tr>';
 }
 
 // ---- Client-isolation observer (passive AP/mesh peer-traffic audit) --------

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -4148,7 +4148,7 @@ function _wifidefUpdateRunUI() {
 // Must match wifi_defense.py `_BUILD`. If the running service reports something
 // else, the webapp is executing an OLD wifi_defense module (service not restarted
 // after a git pull) — the #1 cause of "the fix didn't work in the web UI".
-const WIFIDEF_BUILD = '20260729-airtime-sec-phy';
+const WIFIDEF_BUILD = '20260729-airtime-identity';
 
 function _wifidefFillIfaces() {
     fetch('/api/wifidef/interfaces').then(r => r.json()).then(d => {
@@ -4412,8 +4412,15 @@ function wifidefRenderAirtime(d) {
             const phy = c.legacy
                 ? `<span class="text-red-300" title="Legacy DSSS — forces protection overhead">${c.phy}</span>`
                 : `<span class="text-gray-400">${c.phy || '—'}</span>`;
+            const name = c.hostname || c.device_label || c.vendor;
+            const sub = [c.hostname ? (c.device_label || c.vendor) : c.vendor, c.ip]
+                .filter(Boolean).join(' · ');
+            const device = name
+                ? `<span class="text-gray-200">${_esc(name)}</span>${sub ? ` <span class="text-gray-500 text-[10px]">${_esc(sub)}</span>` : ''}`
+                : '<span class="text-gray-600" title="Not in the host inventory — run a network scan on the connected radio to name it">unidentified</span>';
             return `<tr class="border-b border-slate-800/50 ${c.legacy ? 'bg-red-900/10' : ''}">
                 <td class="py-1 pr-2 font-mono text-[11px]">${c.client}</td>
+                <td class="py-1 pr-2 text-xs">${device}</td>
                 <td class="py-1 pr-2 text-xs">${phy}</td>
                 <td class="py-1 pr-2">${c.frames}</td>
                 <td class="py-1 pr-2 ${airCol}">${c.airtime_pct}%</td>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -4148,7 +4148,7 @@ function _wifidefUpdateRunUI() {
 // Must match wifi_defense.py `_BUILD`. If the running service reports something
 // else, the webapp is executing an OLD wifi_defense module (service not restarted
 // after a git pull) — the #1 cause of "the fix didn't work in the web UI".
-const WIFIDEF_BUILD = '20260718-airtime-ssid';
+const WIFIDEF_BUILD = '20260729-airtime-client-erp';
 
 function _wifidefFillIfaces() {
     fetch('/api/wifidef/interfaces').then(r => r.json()).then(d => {
@@ -4371,6 +4371,8 @@ function wifidefRenderAirtime(d) {
     fnd.innerHTML = (d.findings || []).map(f => {
         const cls = f.type === 'roaming_churn' ? 'bg-amber-600/20 text-amber-300 border-amber-700/50'
             : f.type === 'airtime_hog' ? 'bg-orange-600/20 text-orange-300 border-orange-700/50'
+            : f.type === 'slow_client' ? 'bg-red-600/20 text-red-300 border-red-700/50'
+            : f.type === 'erp_protection' ? 'bg-fuchsia-600/20 text-fuchsia-300 border-fuchsia-700/50'
             : 'bg-red-600/20 text-red-300 border-red-700/50';
         return `<span class="px-2 py-1 rounded border ${cls}">${f.detail}</span>`;
     }).join('') || '<span class="text-green-400 text-xs">✓ No link-quality issues in this capture.</span>';
@@ -4382,7 +4384,7 @@ function wifidefRenderAirtime(d) {
         const airCol = a.airtime_pct >= 50 ? 'text-orange-400' : 'text-gray-300';
         const rate = a.rate_med != null ? `${a.rate_min}/${a.rate_med}/${a.rate_max}` : '—';
         return `<tr class="border-b border-slate-800/50 cursor-pointer hover:bg-slate-800/40" title="Open in Spectrum Analyzer" onclick="wifiPivotFromDefense('${a.bssid}','${encodeURIComponent(a.ssid || '').replace(/'/g, '%27')}')">
-            <td class="py-1 pr-2">${a.ssid ? _esc(a.ssid) : '<span class="text-gray-600">—</span>'}</td>
+            <td class="py-1 pr-2">${a.ssid ? _esc(a.ssid) : '<span class="text-gray-600">—</span>'}${a.erp_protection ? ' <span class="text-[9px] px-1 rounded bg-fuchsia-600/20 text-fuchsia-300 border border-fuchsia-700/50" title="ERP protection ON — a legacy 802.11b client is taxing this BSS">ERP</span>' : ''}</td>
             <td class="py-1 pr-2 font-mono text-[11px]">${a.bssid}</td>
             <td class="py-1 pr-2">${a.frames} <span class="text-gray-600 text-[10px]">(${a.data_frames} data)</span></td>
             <td class="py-1 pr-2 ${retryCol}">${a.retry_pct}%</td>
@@ -4390,6 +4392,30 @@ function wifidefRenderAirtime(d) {
             <td class="py-1 pr-2 text-xs">${rate} <span class="text-gray-600">Mbps</span></td>
             <td class="py-1 pr-2">${a.rssi == null ? '—' : a.rssi + ' dBm'}</td></tr>`;
     }).join('');
+    // Per-client airtime attribution — pinpoints the offending device.
+    const cwrap = document.getElementById('wifidef-at-clients-wrap');
+    const ctb = document.getElementById('wifidef-at-clients-tbody');
+    const clients = d.clients || [];
+    if (clients.length) {
+        cwrap.classList.remove('hidden');
+        ctb.innerHTML = clients.map(c => {
+            const airCol = c.airtime_pct >= 20 ? 'text-orange-400' : 'text-gray-300';
+            const rate = c.rate_med != null ? `${c.rate_min}/${c.rate_med}/${c.rate_max}` : '—';
+            const phy = c.legacy
+                ? `<span class="text-red-300" title="Legacy DSSS — forces protection overhead">${c.phy}</span>`
+                : `<span class="text-gray-400">${c.phy || '—'}</span>`;
+            return `<tr class="border-b border-slate-800/50 ${c.legacy ? 'bg-red-900/10' : ''}">
+                <td class="py-1 pr-2 font-mono text-[11px]">${c.client}</td>
+                <td class="py-1 pr-2 text-xs">${phy}</td>
+                <td class="py-1 pr-2">${c.frames}</td>
+                <td class="py-1 pr-2 ${airCol}">${c.airtime_pct}%</td>
+                <td class="py-1 pr-2 text-xs">${rate} <span class="text-gray-600">Mbps</span></td>
+                <td class="py-1 pr-2">${c.rssi == null ? '—' : c.rssi + ' dBm'}</td></tr>`;
+        }).join('');
+    } else {
+        cwrap.classList.add('hidden');
+        ctb.innerHTML = '';
+    }
     const roam = document.getElementById('wifidef-at-roam');
     roam.innerHTML = (d.roaming && d.roaming.length)
         ? '<b class="text-gray-300">Roaming clients:</b> ' + d.roaming.map(r =>

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -664,17 +664,22 @@ def _airtime_event(pkt):
         "bytes": len(bytes(d)),
         "rate_mbps": None, "rssi": None,
     }
-    # Beacons / probe responses name the BSS — lets the report show an SSID
-    # column instead of bare BSSIDs.
+    # Beacons / probe responses name the BSS and carry the ERP element — lets
+    # the report show an SSID column and, crucially, whether the AP has turned
+    # on protection because a legacy DSSS (802.11b) station is present.
     if d.type == 0 and d.subtype in (5, 8):
         el = pkt.getlayer(Dot11Elt)
         while el is not None and isinstance(el, Dot11Elt):
-            if el.ID == 0:
+            if el.ID == 0 and "ssid" not in ev:
                 try:
                     ev["ssid"] = el.info.decode(errors="replace") or None
                 except Exception:
                     pass
-                break
+            elif el.ID == 42 and el.info:
+                # ERP Information (1 byte): bit0 NonERP_Present, bit1 Use_Protection.
+                erp = el.info[0]
+                ev["erp_nonerp"] = bool(erp & 0x01)
+                ev["erp_protection"] = bool(erp & 0x02)
             el = el.payload.getlayer(Dot11Elt)
     try:
         from scapy.all import RadioTap
@@ -694,6 +699,23 @@ def _frame_airtime_us(ev):
     return (ev.get("bytes", 0) * 8) / rate + 50   # +~50us preamble+IFS
 
 
+# The DSSS/CCK rate set — a station transmitting only these is 802.11b, the
+# legacy client that forces ERP protection on the whole BSS.
+_DSSS_RATES = {1.0, 2.0, 5.5, 11.0}
+
+
+def _classify_phy(rate_min, rate_max):
+    """Best-effort PHY generation from a client's observed PHY-rate spread.
+    Returns a short label; None when we saw no rates."""
+    if rate_min is None:
+        return None
+    if rate_max <= 11.0 and rate_min in _DSSS_RATES:
+        return "802.11b (DSSS/CCK)"       # the airtime tax
+    if rate_max <= 54.0:
+        return "802.11a/g (OFDM)"
+    return "802.11n+ (HT/VHT/HE)"
+
+
 # Management subtypes that indicate a client (re)joining / roaming.
 _ROAM_SUBTYPES = {0: "assoc", 2: "reassoc", 11: "auth"}
 
@@ -704,13 +726,15 @@ def analyze_airtime(events, seconds=None):
     seconds = seconds or 1
     aps = {}
     roam = {}
+    clients = {}                             # per-transmitter (addr2) airtime
     for e in events:
         b = e.get("bssid")
         # Airtime/retry keyed on the AP (BSSID) for data + mgmt frames.
         if b:
             ap = aps.setdefault(b, {"bssid": b, "ssid": None, "frames": 0,
                                     "retries": 0, "airtime_us": 0.0, "rates": [],
-                                    "rssi": None, "data_frames": 0})
+                                    "rssi": None, "data_frames": 0,
+                                    "erp_protection": False, "erp_nonerp": False})
             ap["frames"] += 1
             if e.get("ssid"):
                 ap["ssid"] = e["ssid"]
@@ -723,6 +747,27 @@ def analyze_airtime(events, seconds=None):
                 ap["rates"].append(e["rate_mbps"])
             if e.get("rssi") is not None:
                 ap["rssi"] = e["rssi"]
+            # ERP is latched: once the AP announces protection in the window,
+            # a legacy client was present even if later beacons clear the bit.
+            if e.get("erp_protection"):
+                ap["erp_protection"] = True
+            if e.get("erp_nonerp"):
+                ap["erp_nonerp"] = True
+        # Per-client airtime attribution — the transmitting station (addr2) is
+        # who actually holds the medium. Only count frames a real STA sends
+        # (data + mgmt from a non-AP src); skip beacons the AP sends about itself.
+        src = e.get("src")
+        if src and not _is_group_mac(src) and e["type"] in (0, 2) and not (
+                e["type"] == 0 and e["subtype"] in (5, 8)):
+            c = clients.setdefault(src, {"client": src, "bssid": b, "frames": 0,
+                                         "airtime_us": 0.0, "rates": [], "rssi": None})
+            c["frames"] += 1
+            c["bssid"] = c["bssid"] or b
+            c["airtime_us"] += _frame_airtime_us(e)
+            if e.get("rate_mbps"):
+                c["rates"].append(e["rate_mbps"])
+            if e.get("rssi") is not None:
+                c["rssi"] = e["rssi"]
         # Roaming: a client (src) sending assoc/reassoc/auth frames.
         if e["type"] == 0 and e["subtype"] in _ROAM_SUBTYPES and e.get("src"):
             r = roam.setdefault(e["src"], {"client": e["src"], "assoc": 0,
@@ -741,11 +786,43 @@ def analyze_airtime(events, seconds=None):
         ap_list.append(ap)
     ap_list.sort(key=lambda a: -a["airtime_pct"])
 
+    client_list = []
+    for c in clients.values():
+        rates = c.pop("rates")
+        c["airtime_pct"] = round(c["airtime_us"] / (seconds * 1e6) * 100, 1)
+        c["rate_min"] = min(rates) if rates else None
+        c["rate_med"] = round(statistics.median(rates), 1) if rates else None
+        c["rate_max"] = max(rates) if rates else None
+        c["phy"] = _classify_phy(c["rate_min"], c["rate_max"])
+        c["legacy"] = c["phy"] == "802.11b (DSSS/CCK)"
+        c["airtime_us"] = round(c["airtime_us"])
+        client_list.append(c)
+    client_list.sort(key=lambda c: -c["airtime_pct"])
+
     # Roaming churn = a client re-associating/authing repeatedly.
     roam_list = [r for r in roam.values() if (r["reassoc"] + r["auth"]) >= 3]
     roam_list.sort(key=lambda r: -(r["reassoc"] + r["auth"]))
 
     findings = []
+    # BSS-wide "why is it slow": ERP protection turned on = a legacy DSSS client
+    # is imposing RTS/CTS overhead on every station in the cell.
+    for ap in ap_list:
+        if ap.get("erp_protection"):
+            name = ap["ssid"] or ap["bssid"]
+            findings.append({"type": "erp_protection", "bssid": ap["bssid"],
+                             "detail": f"{name} has ERP protection ON — a legacy "
+                                       "802.11b client is taxing the whole BSS "
+                                       "(RTS/CTS overhead on every frame)"})
+    # Pinpoint the culprit: a station transmitting at DSSS rates while eating
+    # real airtime is the device to move off the band / evict.
+    for c in client_list:
+        if c["legacy"] and (c["airtime_pct"] >= 5 or c["frames"] >= 20):
+            findings.append({"type": "slow_client", "client": c["client"],
+                             "detail": f"{c['client']} is 802.11b @ "
+                                       f"{c['rate_min']}–{c['rate_max']} Mbps, "
+                                       f"~{c['airtime_pct']}% airtime "
+                                       f"({c['frames']} frames) — the airtime tax; "
+                                       "move it to its own SSID or 5 GHz"})
     for ap in ap_list:
         if ap["retry_pct"] >= 30 and ap["frames"] >= 20:
             findings.append({"type": "high_retry", "bssid": ap["bssid"],
@@ -759,8 +836,8 @@ def analyze_airtime(events, seconds=None):
                          "detail": f"{r['client']} re-joined {r['reassoc'] + r['auth']}× "
                                    "(reassoc/auth) — roaming instability"})
 
-    return {"aps": ap_list, "roaming": roam_list, "findings": findings,
-            "frames": len(events), "seconds": seconds}
+    return {"aps": ap_list, "clients": client_list, "roaming": roam_list,
+            "findings": findings, "frames": len(events), "seconds": seconds}
 
 
 # --------------------------------------------------------------------------
@@ -1772,6 +1849,53 @@ def selftest():
           any(f["type"] == "roaming_churn" for f in at["findings"]))
     check("airtime: rate parse legacy (radiotap Rate=12 => 6 Mbps)",
           _frame_rate_mbps(type("R", (), {"Rate": 12, "MCS_index": None})()) == 6.0)
+
+    # --- Airtime starvation: per-client attribution + ERP protection ---
+    star = []
+    STAR_AP = "aa:bb:cc:00:00:0a"
+    FAST = "10:20:30:00:00:01"                    # unicast, Wi-Fi 6
+    PLUG = "20:30:40:00:00:02"                    # unicast, legacy 802.11b
+    # AP beacons announcing ERP protection ON (a legacy DSSS client is present).
+    for _ in range(10):
+        star.append({"type": 0, "subtype": 8, "retry": False, "src": STAR_AP,
+                     "dst": "ff:ff:ff:ff:ff:ff", "bssid": STAR_AP, "bytes": 120,
+                     "rate_mbps": 6.0, "rssi": -40, "ssid": "HomeNet",
+                     "erp_protection": True, "erp_nonerp": True})
+    # Fast client: many big frames at 130 Mbps (little airtime each).
+    for _ in range(300):
+        star.append({"type": 2, "subtype": 0, "retry": False, "src": FAST,
+                     "dst": STAR_AP, "bssid": STAR_AP, "bytes": 1500,
+                     "rate_mbps": 130.0, "rssi": -45})
+    # Legacy plug: few small frames at 1 Mbps (huge airtime per byte).
+    for _ in range(80):
+        star.append({"type": 2, "subtype": 0, "retry": False, "src": PLUG,
+                     "dst": STAR_AP, "bssid": STAR_AP, "bytes": 400,
+                     "rate_mbps": 1.0, "rssi": -60})
+    st = analyze_airtime(star, seconds=10)
+    plug = next((c for c in st["clients"] if c["client"] == PLUG), None)
+    fast = next((c for c in st["clients"] if c["client"] == FAST), None)
+    check("starvation: legacy client classified 802.11b",
+          plug is not None and plug["legacy"]
+          and plug["phy"] == "802.11b (DSSS/CCK)", json.dumps(plug))
+    check("starvation: fast client not flagged legacy",
+          fast is not None and not fast["legacy"])
+    check("starvation: legacy plug eats more airtime than fast client despite fewer frames",
+          plug["airtime_pct"] > fast["airtime_pct"] and plug["frames"] < fast["frames"])
+    check("starvation: ERP protection latched on AP",
+          any(a["bssid"] == STAR_AP and a["erp_protection"] for a in st["aps"]))
+    check("starvation: erp_protection finding raised",
+          any(f["type"] == "erp_protection" for f in st["findings"]),
+          json.dumps(st["findings"]))
+    check("starvation: slow_client finding names the culprit",
+          any(f["type"] == "slow_client" and f.get("client") == PLUG
+              for f in st["findings"]))
+    check("starvation: AP beacons excluded from per-client attribution",
+          all(c["client"] != STAR_AP for c in st["clients"]))
+    check("starvation: PHY classifier boundaries",
+          _classify_phy(1.0, 11.0) == "802.11b (DSSS/CCK)"
+          and _classify_phy(6.0, 54.0) == "802.11a/g (OFDM)"
+          and _classify_phy(6.5, 130.0) == "802.11n+ (HT/VHT/HE)"
+          and _classify_phy(None, None) is None)
 
     # --- Client-isolation observer (passive AP/mesh peer-traffic audit) ---
     from scapy.all import wrpcap

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -944,6 +944,38 @@ def analyze_airtime(events, seconds=None):
             "findings": findings, "frames": len(events), "seconds": seconds}
 
 
+def enrich_identity(clients, host_map=None, vendor_lookup=None):
+    """Join network-layer identity onto the radio-layer per-client rows by MAC.
+
+    The monitor radio sees WHO is 802.11b (by MAC); the connected radio's host
+    inventory knows WHAT each MAC is (ip / hostname / vendor / device type).
+    This fuses the two so a legacy client reads as e.g. "HP printer
+    (HP-LaserJet, 192.168.1.42)" instead of a bare MAC.
+
+    Pure: the caller supplies ``host_map`` (mac→record from the hosts DB) and an
+    optional ``vendor_lookup(mac)->str`` OUI fallback for MACs not yet in the
+    inventory. Mutates and returns ``clients``."""
+    host_map = host_map or {}
+    for c in clients:
+        mac = (c.get("client") or "").lower()
+        rec = host_map.get(mac) or {}
+        c["ip"] = rec.get("ip") or None
+        c["hostname"] = rec.get("hostname") or None
+        vendor = rec.get("vendor")
+        if not vendor and vendor_lookup:
+            try:
+                v = vendor_lookup(mac)
+                vendor = v if v and v != "Randomized" else None
+            except Exception:
+                vendor = None
+        c["vendor"] = vendor or None
+        c["device_type"] = rec.get("device_type") or None
+        c["device_label"] = rec.get("device_label") or None
+        # A device we could actually name from the network side.
+        c["identified"] = bool(c["hostname"] or c["ip"])
+    return clients
+
+
 # --------------------------------------------------------------------------
 # Client-isolation observer  (passive AP/mesh peer-traffic audit)
 # --------------------------------------------------------------------------
@@ -2025,6 +2057,24 @@ def selftest():
           _classify_ap_phy(False, False, False, False, [1.0, 2.0, 5.5, 11.0], True) == "802.11b (DSSS)"
           and _classify_ap_phy(False, False, False, False, [1.0, 11.0, 24.0], True) == "802.11g (OFDM)"
           and _classify_ap_phy(False, False, False, False, [], False) == "802.11a (OFDM)")
+    # --- Identity fusion (MAC-join of radio PHY + network host inventory) ---
+    _cl = [{"client": "20:30:40:00:00:02", "legacy": True},
+           {"client": "aa:bb:cc:dd:ee:ff", "legacy": False}]
+    _hosts = {"20:30:40:00:00:02": {"ip": "192.168.1.42", "hostname": "HP-LaserJet",
+                                    "vendor": "Hewlett Packard",
+                                    "device_type": "printer", "device_label": "Printer"}}
+    enrich_identity(_cl, _hosts, lambda m: "AcmeVendor")
+    check("identity: known MAC gets hostname/ip/type from host map",
+          _cl[0]["hostname"] == "HP-LaserJet" and _cl[0]["ip"] == "192.168.1.42"
+          and _cl[0]["device_type"] == "printer" and _cl[0]["identified"] is True)
+    check("identity: unknown MAC falls back to OUI vendor, stays unidentified",
+          _cl[1]["vendor"] == "AcmeVendor" and _cl[1]["hostname"] is None
+          and _cl[1]["identified"] is False)
+    _cl2 = [{"client": "de:ad:be:ef:00:01", "legacy": True}]
+    enrich_identity(_cl2, {}, lambda m: "Randomized")
+    check("identity: randomized OUI is not used as a vendor name",
+          _cl2[0]["vendor"] is None)
+
     check("security: weak_security finding raised for Open BSS",
           any(f["type"] == "weak_security"
               for f in analyze_airtime(

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -648,6 +648,65 @@ def _frame_rate_mbps(rt):
     return None
 
 
+# RSN AKM suite selectors (last byte of the 00-0F-AC OUI suite) worth naming.
+_AKM_SAE = {8, 9, 24}                    # WPA3-Personal (SAE / FT-SAE)
+_AKM_1X = {1, 3, 5, 11, 12, 13}          # 802.1X / enterprise
+_AKM_OWE = {18}                          # Opportunistic Wireless Encryption
+
+
+def _parse_rsn_akm(info):
+    """Return the set of AKM suite selector bytes from an RSN element body."""
+    akms = set()
+    try:
+        i = 2                            # skip version
+        i += 4                           # group cipher suite
+        n_pw = info[i] | (info[i + 1] << 8); i += 2
+        i += 4 * n_pw                    # pairwise cipher suites
+        n_akm = info[i] | (info[i + 1] << 8); i += 2
+        for _ in range(n_akm):
+            akms.add(info[i + 3])        # 4th byte = suite type
+            i += 4
+    except (IndexError, TypeError):
+        pass
+    return akms
+
+
+def _classify_security(privacy, rsn_info, has_wpa1):
+    """Map beacon capability + RSN/WPA elements to a security label."""
+    if rsn_info is not None:
+        akms = _parse_rsn_akm(rsn_info)
+        if akms & _AKM_OWE:
+            return "OWE"
+        if akms & _AKM_SAE:
+            # SAE + PSK together = WPA2/WPA3 transition mode.
+            return "WPA2/3" if 2 in akms or 6 in akms else "WPA3"
+        if akms & _AKM_1X:
+            return "WPA2-Ent"
+        return "WPA2"
+    if has_wpa1:
+        return "WPA"
+    if privacy:
+        return "WEP"
+    return "Open"
+
+
+def _classify_ap_phy(ht, vht, he, eht, rates, is_2ghz):
+    """802.11 generation from a beacon's capability IEs (+ rate set for a/b/g)."""
+    if eht:
+        return "802.11be (Wi-Fi 7)"
+    if he:
+        return "802.11ax (Wi-Fi 6)"
+    if vht:
+        return "802.11ac (Wi-Fi 5)"
+    if ht:
+        return "802.11n (Wi-Fi 4)"
+    # No HT/VHT/HE => legacy. Split by band + rate set.
+    if not is_2ghz:
+        return "802.11a (OFDM)"
+    has_ofdm = any(r > 11.0 for r in rates)     # 6/9/12/.. Mbps => ERP-OFDM
+    return "802.11g (OFDM)" if has_ofdm else "802.11b (DSSS)"
+
+
 def _airtime_event(pkt):
     """Normalize ANY 802.11 frame for airtime/retry/roaming stats (or None)."""
     from scapy.all import Dot11, Dot11Elt
@@ -664,23 +723,57 @@ def _airtime_event(pkt):
         "bytes": len(bytes(d)),
         "rate_mbps": None, "rssi": None,
     }
-    # Beacons / probe responses name the BSS and carry the ERP element — lets
-    # the report show an SSID column and, crucially, whether the AP has turned
-    # on protection because a legacy DSSS (802.11b) station is present.
+    # Beacons / probe responses describe the BSS: SSID, ERP protection, the
+    # security suite (Open/WEP/WPA/WPA2/WPA3) and the 802.11 generation — all
+    # read straight from the management IEs, no active probing.
     if d.type == 0 and d.subtype in (5, 8):
+        rsn_info = None
+        has_wpa1 = False
+        ht = vht = he = eht = False
+        rates = []
+        ds_channel = None
         el = pkt.getlayer(Dot11Elt)
         while el is not None and isinstance(el, Dot11Elt):
-            if el.ID == 0 and "ssid" not in ev:
+            eid, info = el.ID, (el.info or b"")
+            if eid == 0 and "ssid" not in ev:
                 try:
-                    ev["ssid"] = el.info.decode(errors="replace") or None
+                    ev["ssid"] = info.decode(errors="replace") or None
                 except Exception:
                     pass
-            elif el.ID == 42 and el.info:
+            elif eid == 42 and info:
                 # ERP Information (1 byte): bit0 NonERP_Present, bit1 Use_Protection.
-                erp = el.info[0]
-                ev["erp_nonerp"] = bool(erp & 0x01)
-                ev["erp_protection"] = bool(erp & 0x02)
+                ev["erp_nonerp"] = bool(info[0] & 0x01)
+                ev["erp_protection"] = bool(info[0] & 0x02)
+            elif eid in (1, 50):                 # (Extended) Supported Rates
+                rates += [(b & 0x7f) * 0.5 for b in info]
+            elif eid == 3 and info:              # DS Parameter Set = primary channel
+                ds_channel = info[0]
+            elif eid == 48:                      # RSN => WPA2/WPA3
+                rsn_info = info
+            elif eid == 221 and info[:4] == b"\x00\x50\xf2\x01":
+                has_wpa1 = True                  # Microsoft WPA v1 vendor element
+            elif eid == 45:
+                ht = True
+            elif eid == 191:
+                vht = True
+            elif eid == 255 and info:            # Element ID Extension
+                ext = info[0]
+                if ext in (35, 36):              # HE Capabilities / Operation
+                    he = True
+                elif ext in (106, 108):          # EHT Operation / Capabilities
+                    eht = True
             el = el.payload.getlayer(Dot11Elt)
+        privacy = False
+        try:
+            from scapy.all import Dot11Beacon, Dot11ProbeResp
+            mgmt = pkt.getlayer(Dot11Beacon) or pkt.getlayer(Dot11ProbeResp)
+            if mgmt is not None:
+                privacy = bool(int(mgmt.cap) & 0x0010)
+        except Exception:
+            pass
+        is_2ghz = ds_channel is None or ds_channel <= 14
+        ev["security"] = _classify_security(privacy, rsn_info, has_wpa1)
+        ev["ap_phy"] = _classify_ap_phy(ht, vht, he, eht, rates, is_2ghz)
     try:
         from scapy.all import RadioTap
         if pkt.haslayer(RadioTap):
@@ -734,10 +827,15 @@ def analyze_airtime(events, seconds=None):
             ap = aps.setdefault(b, {"bssid": b, "ssid": None, "frames": 0,
                                     "retries": 0, "airtime_us": 0.0, "rates": [],
                                     "rssi": None, "data_frames": 0,
-                                    "erp_protection": False, "erp_nonerp": False})
+                                    "erp_protection": False, "erp_nonerp": False,
+                                    "security": None, "ap_phy": None})
             ap["frames"] += 1
             if e.get("ssid"):
                 ap["ssid"] = e["ssid"]
+            if e.get("security"):
+                ap["security"] = e["security"]
+            if e.get("ap_phy"):
+                ap["ap_phy"] = e["ap_phy"]
             if e.get("retry"):
                 ap["retries"] += 1
             if e["type"] == 2:               # data
@@ -807,6 +905,12 @@ def analyze_airtime(events, seconds=None):
     # BSS-wide "why is it slow": ERP protection turned on = a legacy DSSS client
     # is imposing RTS/CTS overhead on every station in the cell.
     for ap in ap_list:
+        if ap.get("security") in ("Open", "WEP"):
+            name = ap["ssid"] or ap["bssid"]
+            findings.append({"type": "weak_security", "bssid": ap["bssid"],
+                             "detail": f"{name} is {ap['security']} — "
+                                       + ("no encryption" if ap["security"] == "Open"
+                                          else "WEP is broken, treat as open")})
         if ap.get("erp_protection"):
             name = ap["ssid"] or ap["bssid"]
             findings.append({"type": "erp_protection", "bssid": ap["bssid"],
@@ -1896,6 +2000,38 @@ def selftest():
           and _classify_phy(6.0, 54.0) == "802.11a/g (OFDM)"
           and _classify_phy(6.5, 130.0) == "802.11n+ (HT/VHT/HE)"
           and _classify_phy(None, None) is None)
+
+    # --- Encryption + AP PHY generation parsed from beacon IEs ---
+    rsn_psk = (bytes([1, 0]) + b"\x00\x0f\xac\x04" + bytes([1, 0])
+               + b"\x00\x0f\xac\x04" + bytes([1, 0]) + b"\x00\x0f\xac\x02" + bytes([0, 0]))
+    rsn_sae = (bytes([1, 0]) + b"\x00\x0f\xac\x04" + bytes([1, 0])
+               + b"\x00\x0f\xac\x04" + bytes([1, 0]) + b"\x00\x0f\xac\x08" + bytes([0, 0]))
+    check("security: RSN PSK => WPA2",
+          _classify_security(True, rsn_psk, False) == "WPA2")
+    check("security: RSN SAE => WPA3",
+          _classify_security(True, rsn_sae, False) == "WPA3")
+    check("security: privacy bit only => WEP",
+          _classify_security(True, None, False) == "WEP")
+    check("security: no privacy => Open",
+          _classify_security(False, None, False) == "Open")
+    check("security: WPA1 vendor element => WPA",
+          _classify_security(True, None, True) == "WPA")
+    check("ap_phy: HT => 802.11n, VHT => ac, HE => ax, EHT => be",
+          _classify_ap_phy(True, False, False, False, [], True).startswith("802.11n")
+          and _classify_ap_phy(False, True, False, False, [], True).startswith("802.11ac")
+          and _classify_ap_phy(False, False, True, False, [], True).startswith("802.11ax")
+          and _classify_ap_phy(False, False, False, True, [], True).startswith("802.11be"))
+    check("ap_phy: legacy 2.4 split b vs g by rate set",
+          _classify_ap_phy(False, False, False, False, [1.0, 2.0, 5.5, 11.0], True) == "802.11b (DSSS)"
+          and _classify_ap_phy(False, False, False, False, [1.0, 11.0, 24.0], True) == "802.11g (OFDM)"
+          and _classify_ap_phy(False, False, False, False, [], False) == "802.11a (OFDM)")
+    check("security: weak_security finding raised for Open BSS",
+          any(f["type"] == "weak_security"
+              for f in analyze_airtime(
+                  [{"type": 0, "subtype": 8, "retry": False, "src": "aa:00:00:00:00:01",
+                    "dst": "ff:ff:ff:ff:ff:ff", "bssid": "aa:00:00:00:00:01",
+                    "bytes": 100, "ssid": "OpenNet", "security": "Open",
+                    "ap_phy": "802.11g (OFDM)"}], seconds=1)["findings"]))
 
     # --- Client-isolation observer (passive AP/mesh peer-traffic audit) ---
     from scapy.all import wrpcap

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -884,6 +884,9 @@ def analyze_airtime(events, seconds=None):
         ap_list.append(ap)
     ap_list.sort(key=lambda a: -a["airtime_pct"])
 
+    # Map each BSSID to its SSID so clients can show the network they're on.
+    ssid_by_bssid = {a["bssid"]: a["ssid"] for a in ap_list if a.get("ssid")}
+
     client_list = []
     for c in clients.values():
         rates = c.pop("rates")
@@ -893,6 +896,7 @@ def analyze_airtime(events, seconds=None):
         c["rate_max"] = max(rates) if rates else None
         c["phy"] = _classify_phy(c["rate_min"], c["rate_max"])
         c["legacy"] = c["phy"] == "802.11b (DSSS/CCK)"
+        c["ssid"] = ssid_by_bssid.get(c.get("bssid"))
         c["airtime_us"] = round(c["airtime_us"])
         client_list.append(c)
     client_list.sort(key=lambda c: -c["airtime_pct"])
@@ -2027,6 +2031,8 @@ def selftest():
               for f in st["findings"]))
     check("starvation: AP beacons excluded from per-client attribution",
           all(c["client"] != STAR_AP for c in st["clients"]))
+    check("starvation: client tagged with its AP's SSID",
+          plug is not None and plug.get("ssid") == "HomeNet")
     check("starvation: PHY classifier boundaries",
           _classify_phy(1.0, 11.0) == "802.11b (DSSS/CCK)"
           and _classify_phy(6.0, 54.0) == "802.11a/g (OFDM)"

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -49,7 +49,7 @@ _STATE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 # the web UI (WIFIDEF_BUILD in ragnar_modern.js). The UI compares them and warns
 # if the running (long-lived) webapp still has an OLD wifi_defense module loaded,
 # i.e. the service wasn't restarted after a git pull. Kills stale-service guesswork.
-_BUILD = "20260718-airtime-ssid"
+_BUILD = "20260729-airtime-ssid-filter"
 
 # Detection thresholds (per capture window)
 _DEAUTH_FLOOD_MIN = 15      # deauth+disassoc frames => flood


### PR DESCRIPTION
This pull request introduces major improvements to the Wi-Fi "airtime" analysis and web UI, with a focus on pinpointing legacy 802.11b clients that degrade network performance for everyone. The backend now attributes airtime usage per client and fuses radio-layer (MAC/PHY) data with network-layer device identity, so slow clients are named in findings. The web UI displays per-client airtime tables, allows filtering by SSID, and highlights security and PHY generation for each AP. Several new detection and classification features are added, and the UI is updated for clarity and troubleshooting.

**Airtime analysis and device identification enhancements:**
- Added per-client airtime attribution in `network_diagnostics.py` and `/api/wifidef/airtime`, joining monitor-mode MAC/PHY data with host inventory to name slow legacy clients in findings and tables. (`_enrich_airtime_identity`, `_ports_to_list`, route update) [[1]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaR14218-R14287) [[2]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL15150-R15228)
- Updated documentation to explain the "legacy client tax", ERP protection, per-client airtime, and device identity fusion, with deployment recommendations. (`docs/wifi-defense.md`)

**Web UI improvements:**
- Added per-client airtime table with SSID filter, device naming, and legacy client highlighting in the UI. (`web/index_modern.html`, `ragnar_modern.js`) [[1]](diffhunk://#diff-7a539845f7a3dbcb375c4f1fd20d0e033f28fd246928b5167f61ffef837e62f8L2664-R2682) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R4374-R4470)
- Enhanced AP table to include security and PHY columns, ERP-protection badges, and improved findings highlighting for slow clients, ERP, and weak security. (`web/index_modern.html`, `ragnar_modern.js`) [[1]](diffhunk://#diff-7a539845f7a3dbcb375c4f1fd20d0e033f28fd246928b5167f61ffef837e62f8L2664-R2682) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R4374-R4470)

**Security and PHY classification:**
- Added robust parsing and labeling of AP security (WPA3, WPA2/3, WPA2-Ent, OWE, etc.) and PHY generation (Wi-Fi 4/5/6/7, 802.11b/g/a) based on beacon elements. (`wifi_defense.py`)

**Versioning and UI synchronization:**
- Updated build/version strings to ensure the web UI and backend are in sync after deployment. (`wifi_defense.py`, `ragnar_modern.js`) [[1]](diffhunk://#diff-1f11567fa3a994b3d7afde74a00c58b9f688934eaa1e8cec696e0e1210e90023L52-R52) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L4151-R4151)

These changes provide much deeper visibility into which clients are causing airtime starvation, make findings more actionable by naming devices, and improve troubleshooting for both technical and non-technical users.