### PR TITLE
pwnagotchi: validate install components + Repair button; disable pwn …

### DIFF
--- a/docs/PWNAGOTCHI.md
+++ b/docs/PWNAGOTCHI.md
@@ -59,6 +59,48 @@ The script:
 
 Re-running is safe — already-installed packages are skipped.
 
+### Installation Check & Repair (dashboard)
+
+The **Pwnagotchi Bridge** settings section shows an **Installation Check** card that
+validates each piece of a working install independently rather than treating it as
+all-or-nothing:
+
+| Component | Path / check |
+| --- | --- |
+| `/opt/pwnagotchi clone` | `/opt/pwnagotchi` directory present |
+| git metadata | `/opt/pwnagotchi/.git` present (needed for in-app updates) |
+| `pwnagotchi.service` unit | `/etc/systemd/system/pwnagotchi.service` present |
+| service wired to launcher | unit's `ExecStart` points at `/usr/bin/pwnagotchi-launcher` (so MANU/AUTO flags work) |
+| `config.toml` | `/etc/pwnagotchi/config.toml` present |
+| launcher wrapper | `/usr/bin/pwnagotchi-launcher` present and executable |
+| pwnagotchi executable | real `pwnagotchi` binary resolvable |
+
+Each row shows ✓ / ✗. The badge reflects three states:
+
+- **Healthy** — everything present.
+- **Needs Repair** (red) — a *critical* piece is missing: the clone, service unit,
+  `config.toml`, launcher wrapper, or the executable.
+- **Degraded** (amber) — only recommended pieces are missing (git metadata, or the
+  service `ExecStart` no longer points at the launcher). Pwnagotchi still runs, but
+  updates or the MANU/AUTO flags may not work.
+
+Whenever anything is missing a **Repair Installation** button appears — it re-runs
+the idempotent installer to restore the missing pieces without touching your
+captures or config.
+
+### Does Pwnagotchi's own updater conflict with Ragnar's?
+
+It can. Pwnagotchi ships an `auto-update` plugin that pulls upstream releases on its
+own. Left enabled it would fight Ragnar's git updater over `/opt/pwnagotchi` (dirtying
+the clone) and can revert `pwnagotchi.service` `ExecStart` back to the raw binary —
+breaking the flag-aware launcher wiring (MANU/AUTO). The Ragnar installer therefore
+sets `main.plugins.auto-update.enabled = false`, making Ragnar the single update
+authority. If an older install drifted, the **Installation Check** card flags it and
+the `ragnar-pwn-migrate` boot unit + **Repair** both restore the launcher wiring.
+
+The check is exposed via `GET /api/pwnagotchi/status` under `components`,
+`missing_critical`, `missing_optional`, `healthy`, and `needs_repair`.
+
 ---
 
 ## 🔧 Configuration

--- a/scripts/install_pwnagotchi.sh
+++ b/scripts/install_pwnagotchi.sh
@@ -413,6 +413,14 @@ enabled = false
 [main.plugins.fix_services]
 enabled = false
 
+# Disable Pwnagotchi's built-in self-updater. Ragnar is the single update
+# authority for /opt/pwnagotchi (see the dashboard "Pwnagotchi Updates" card).
+# Leaving auto-update on lets Pwnagotchi pull upstream releases behind our back,
+# which can dirty the git clone and revert pwnagotchi.service ExecStart back to
+# the raw binary — breaking the flag-aware launcher (MANU/AUTO) wiring.
+[main.plugins.auto-update]
+enabled = false
+
 [personality]
 advertise = false
 EOF
@@ -440,6 +448,9 @@ else
     # Disable fix_services — it is hardcoded to wlan0mon but we use mon0/wlan1.
     # The brcmfmac recovery logic does not apply to our mt76x2u setup.
     set_or_update_config_value "main.plugins.fix_services.enabled" "false"
+    # Disable Pwnagotchi's self-updater so it can't fight Ragnar's git updater
+    # or revert pwnagotchi.service ExecStart away from the flag-aware launcher.
+    set_or_update_config_value "main.plugins.auto-update.enabled" "false"
     echo "[INFO] Config updated"
 fi
 

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -6623,6 +6623,27 @@
                         </div>
                     </div>
 
+                    <!-- Pwnagotchi Installation Check Card -->
+                    <div id="pwn-health-card" class="glass rounded-lg p-4 mt-4" style="display: none;">
+                        <div class="flex items-center justify-between mb-3">
+                            <div>
+                                <h4 class="font-medium text-lg">Installation Check</h4>
+                                <p class="text-xs text-gray-500 mt-1">Validates the files and services a working Pwnagotchi install needs.</p>
+                            </div>
+                            <span id="pwn-health-badge" class="text-xs font-semibold uppercase tracking-wide px-3 py-1 rounded-full bg-slate-700 text-slate-200 self-start whitespace-nowrap">—</span>
+                        </div>
+                        <ul id="pwn-health-list" class="space-y-1.5 text-sm"></ul>
+                        <div id="pwn-health-repair" class="hidden mt-4">
+                            <div class="p-3 rounded-lg bg-amber-900/40 border border-amber-700/60 text-amber-200 text-xs mb-3">
+                                <p id="pwn-health-repair-msg">Some components are missing or broken.</p>
+                            </div>
+                            <button id="pwn-repair-btn" class="w-full bg-amber-600 hover:bg-amber-700 text-white py-2 px-4 rounded-lg transition-colors">
+                                Repair Installation
+                            </button>
+                            <p class="text-xs text-gray-500 mt-2">Re-runs the installer to restore missing pieces. Your captures and config are left untouched.</p>
+                        </div>
+                    </div>
+
                     <!-- Pwnagotchi Updates Card -->
                     <div id="pwn-update-card" class="glass rounded-lg p-4 mt-4" style="display: none;">
                         <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
@@ -7390,7 +7411,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260730-ai-wifi"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260731-pwn-healthcheck"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -12679,6 +12679,11 @@ function initializePwnUI() {
         installBtn.addEventListener('click', handlePwnInstallClick);
     }
 
+    const repairBtn = document.getElementById('pwn-repair-btn');
+    if (repairBtn) {
+        repairBtn.addEventListener('click', handlePwnRepairClick);
+    }
+
     const swapToPwnBtn = document.getElementById('pwn-swap-to-pwn-btn');
     if (swapToPwnBtn) {
         swapToPwnBtn.addEventListener('click', () => handlePwnSwap('pwnagotchi'));
@@ -12798,11 +12803,92 @@ function updatePwnagotchiUI(status = {}) {
 
     updatePwnDiscoveredCard(pwnStatus, visuals);
     updatePwnButtons();
+    updatePwnHealthCard(pwnStatus);
     if (pwnStatus.installing && !wasInstalling) {
         resetPwnLogState('Installer output will stream here during installation.');
     }
     ensurePwnLogStreamingForStatus(pwnStatus);
     lastPwnState = pwnStatus.state;
+}
+
+function updatePwnHealthCard(status = {}) {
+    const card = document.getElementById('pwn-health-card');
+    if (!card) {
+        return;
+    }
+
+    const components = status.components || {};
+    const labels = status.component_labels || {};
+    const order = (status.component_order && status.component_order.length)
+        ? status.component_order
+        : Object.keys(labels);
+    const anyComponent = order.some(key => components[key]);
+
+    // Only meaningful once something is on disk; otherwise the Install card
+    // already tells the user Pwnagotchi isn't set up yet.
+    if (!(status.installed || anyComponent)) {
+        card.style.display = 'none';
+        return;
+    }
+    card.style.display = '';
+
+    const list = document.getElementById('pwn-health-list');
+    if (list) {
+        list.innerHTML = order.map(key => {
+            const ok = Boolean(components[key]);
+            const icon = ok
+                ? '<span class="text-green-400 font-bold">✓</span>'
+                : '<span class="text-red-400 font-bold">✗</span>';
+            const rowClass = ok ? 'text-gray-300' : 'text-red-300';
+            return `<li class="flex items-center gap-2 ${rowClass}">${icon}<span>${escapeHtml(labels[key] || key)}</span></li>`;
+        }).join('');
+    }
+
+    const missingCritical = status.missing_critical || [];
+    const missingOptional = status.missing_optional || [];
+    const anyMissing = missingCritical.length > 0 || missingOptional.length > 0;
+
+    const badge = document.getElementById('pwn-health-badge');
+    if (badge) {
+        badge.className = 'text-xs font-semibold uppercase tracking-wide px-3 py-1 rounded-full self-start whitespace-nowrap';
+        if (!anyMissing) {
+            badge.textContent = 'Healthy';
+            badge.classList.add('bg-green-900/60', 'text-green-300');
+        } else if (missingCritical.length) {
+            badge.textContent = 'Needs Repair';
+            badge.classList.add('bg-red-900/60', 'text-red-300');
+        } else {
+            // Only recommended (non-critical) pieces missing — runs, but degraded.
+            badge.textContent = 'Degraded';
+            badge.classList.add('bg-amber-900/60', 'text-amber-300');
+        }
+    }
+
+    // Offer Repair whenever anything is missing — including non-critical drift
+    // such as the service ExecStart being reverted away from the launcher
+    // (e.g. by Pwnagotchi's own updater). Re-running the installer is idempotent.
+    const repair = document.getElementById('pwn-health-repair');
+    const showRepair = anyMissing && !status.installing;
+    if (repair) {
+        repair.classList.toggle('hidden', !showRepair);
+    }
+
+    const repairMsg = document.getElementById('pwn-health-repair-msg');
+    if (showRepair && repairMsg) {
+        const missing = missingCritical.concat(missingOptional);
+        repairMsg.textContent = missing.length
+            ? `Missing or broken: ${missing.join(', ')}.`
+            : 'Some components need attention. Re-run the installer to repair.';
+    }
+
+    const repairBtn = document.getElementById('pwn-repair-btn');
+    if (repairBtn) {
+        const busy = Boolean(status.installing);
+        repairBtn.disabled = busy;
+        repairBtn.textContent = busy ? 'Repairing…' : 'Repair Installation';
+        repairBtn.classList.toggle('opacity-70', busy);
+        repairBtn.classList.toggle('cursor-not-allowed', busy);
+    }
 }
 
 function updatePwnButtons() {
@@ -13556,11 +13642,13 @@ function formatPwnPhaseLabel(phase) {
     return phase.replace(/_/g, ' ').replace(/\b\w/g, char => char.toUpperCase());
 }
 
-async function handlePwnInstallClick() {
+async function runPwnInstaller(isRepair) {
     if (pwnStatus.installing) {
         addConsoleMessage('Pwnagotchi installer already running', 'warning');
         return;
     }
+
+    const verb = isRepair ? 'Repair' : 'Install';
 
     const installBtn = document.getElementById('pwn-install-btn');
     if (installBtn) {
@@ -13568,26 +13656,42 @@ async function handlePwnInstallClick() {
         installBtn.textContent = 'Starting installer...';
         installBtn.classList.add('opacity-70', 'cursor-not-allowed');
     }
+    const repairBtn = document.getElementById('pwn-repair-btn');
+    if (repairBtn) {
+        repairBtn.disabled = true;
+        repairBtn.textContent = 'Starting repair…';
+        repairBtn.classList.add('opacity-70', 'cursor-not-allowed');
+    }
 
-    resetPwnLogState('Installer requested. Waiting for output...');
+    resetPwnLogState(isRepair
+        ? 'Repair requested. Waiting for output...'
+        : 'Installer requested. Waiting for output...');
     startPwnLogStreaming({ initial: true });
 
     try {
         const result = await postPwnAPI('/api/pwnagotchi/install', {});
-        addConsoleMessage('Pwnagotchi installer started', 'success');
+        addConsoleMessage(`Pwnagotchi ${verb.toLowerCase()} started`, 'success');
         if (result && result.status) {
             updatePwnagotchiUI(result.status);
         } else {
             refreshPwnagotchiStatus({ silent: true });
         }
     } catch (error) {
-        console.error('Failed to start Pwnagotchi installer:', error);
-        addConsoleMessage(`Install failed: ${error.message}`, 'error');
+        console.error(`Failed to start Pwnagotchi ${verb.toLowerCase()}:`, error);
+        addConsoleMessage(`${verb} failed: ${error.message}`, 'error');
         stopPwnLogStreaming();
         setPwnLogEmptyMessage('Installer failed to start. Check Ragnar logs for details.');
     } finally {
         updatePwnButtons();
     }
+}
+
+function handlePwnInstallClick() {
+    return runPwnInstaller(false);
+}
+
+function handlePwnRepairClick() {
+    return runPwnInstaller(true);
 }
 
 async function handlePwnSwap(targetMode) {

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -4390,6 +4390,69 @@ def _collect_pwnagotchi_discovery_summary() -> dict:
     return result
 
 
+def _pwn_service_execstart_ok() -> bool:
+    """True when pwnagotchi.service ExecStart points at the flag-aware launcher.
+
+    A unit that execs the pwnagotchi binary directly (older installs) still runs
+    but ignores the MANU/AUTO one-shot flags, so we flag it as needing repair.
+    """
+    try:
+        with open(PWN_SERVICE_FILE, 'r') as fh:
+            content = fh.read()
+    except OSError:
+        return False
+    return PWN_LAUNCHER_PATH in content
+
+
+# Components a working Ragnar-managed Pwnagotchi install needs. The bool marks
+# whether the piece is *critical* (a missing critical piece means the install is
+# broken); non-critical pieces are recommended but Pwnagotchi can still run.
+_PWN_COMPONENT_SPEC = (
+    ('repo_dir', '/opt/pwnagotchi clone', True),
+    ('repo_git', '/opt/pwnagotchi git metadata (needed for updates)', False),
+    ('service_file', 'pwnagotchi.service unit', True),
+    ('service_launcher', 'service wired to flag-aware launcher', False),
+    ('config_file', '/etc/pwnagotchi/config.toml', True),
+    ('launcher', 'pwnagotchi-launcher wrapper', True),
+    ('binary', 'pwnagotchi executable', True),
+)
+
+
+def _pwnagotchi_component_health() -> dict:
+    """Inspect the on-disk pieces of a Pwnagotchi install.
+
+    Returns per-component booleans plus derived health so the dashboard can tell
+    a clean install from a partial/broken one and offer a targeted Repair action
+    (re-running the idempotent installer) instead of assuming all-or-nothing.
+    """
+    repo_dir = os.path.isdir(PWN_REPO_PATH)
+    launcher_ok = os.path.isfile(PWN_LAUNCHER_PATH) and os.access(PWN_LAUNCHER_PATH, os.X_OK)
+    components = {
+        'repo_dir': repo_dir,
+        'repo_git': repo_dir and os.path.isdir(os.path.join(PWN_REPO_PATH, '.git')),
+        'service_file': os.path.exists(PWN_SERVICE_FILE),
+        'service_launcher': _pwn_service_execstart_ok(),
+        'config_file': os.path.exists(PWN_CONFIG_FILE),
+        'launcher': launcher_ok,
+        'binary': _resolve_pwnagotchi_binary() is not None,
+    }
+
+    labels = {key: label for key, label, _critical in _PWN_COMPONENT_SPEC}
+    missing_critical = [labels[k] for k, _l, crit in _PWN_COMPONENT_SPEC
+                        if crit and not components.get(k)]
+    missing_optional = [labels[k] for k, _l, crit in _PWN_COMPONENT_SPEC
+                        if not crit and not components.get(k)]
+
+    return {
+        'components': components,
+        'component_labels': labels,
+        'component_order': [k for k, _l, _c in _PWN_COMPONENT_SPEC],
+        'missing_critical': missing_critical,
+        'missing_optional': missing_optional,
+        'healthy': not missing_critical,
+    }
+
+
 def _build_pwnagotchi_status(persist: bool = True) -> dict:
     status = {
         'state': 'not_installed',
@@ -4535,6 +4598,19 @@ def _build_pwnagotchi_status(persist: bool = True) -> dict:
         or status['service_active']
         or status['service_enabled']
         or service_file_exists
+    )
+
+    # Component-level validation: distinguish "fully installed" from a partial or
+    # broken install so the dashboard can offer a Repair button.
+    health = _pwnagotchi_component_health()
+    status['components'] = health['components']
+    status['component_labels'] = health['component_labels']
+    status['component_order'] = health['component_order']
+    status['missing_critical'] = health['missing_critical']
+    status['missing_optional'] = health['missing_optional']
+    status['healthy'] = health['healthy']
+    status['needs_repair'] = bool(
+        status['installed'] and not health['healthy'] and not status['installing']
     )
 
     config_updates = {}


### PR DESCRIPTION
…self-updater

Settings now checks each piece of a Pwnagotchi install independently (/opt/pwnagotchi clone + .git, pwnagotchi.service unit + launcher wiring, config.toml, launcher wrapper, resolvable binary) instead of the old all-or-nothing 'installed' flag. The Installation Check card shows per- component pass/fail with a three-state badge (Healthy / Degraded / Needs Repair) and a Repair Installation button that re-runs the idempotent installer whenever anything is missing or has drifted.

Also disable Pwnagotchi's built-in auto-update plugin in config.toml so it can't fight Ragnar's git updater over /opt/pwnagotchi or revert pwnagotchi.service ExecStart away from the flag-aware launcher.