### PR TITLE
Pwn install healthcheck

### DIFF
--- a/docs/PWNAGOTCHI.md
+++ b/docs/PWNAGOTCHI.md
@@ -189,13 +189,27 @@ Adapt the exact commands to your nexmon version and kernel.
 
 ### Pwnagotchi → Ragnar
 
+**Via Web UI:** From the Pwnagotchi portal open `http://<ip>:8080/plugins/ragnar_return`
+→ **Return to Ragnar**. The page triggers the swap and then **redirects your
+browser to `http://<ip>:8000`** automatically once Ragnar is back — so the tab
+doesn't get stuck on the dead :8080 portal. It also follows Ragnar back if you
+trigger the swap with the hardware button while that page is open.
+
 **Via PiSugar button:** Double-tap or long-press
 
 **Via physical button:** Press KEY1 on the e-Paper HAT
 
+> **Why a plugin?** The :8080 portal is served by Pwnagotchi, not Ragnar, so only
+> a page served from :8080 can redirect that tab. The hardware button can move the
+> *service* to :8000 but has no way to move your *browser* — that's what the
+> `ragnar_return` web plugin adds. It's symlinked into
+> `/etc/pwnagotchi/custom_plugins/` and enabled (`main.plugins.ragnar_return.enabled = true`)
+> by the installer.
+
 **What happens internally:**
 
-1. `ragnar-swap-button.service` detects the button press (10-second cooldown)
+1. The button press (`ragnar-swap-button.service`, 10-second cooldown) **or** a POST
+   to `/plugins/ragnar_return/swap` from the web plugin triggers the swap
 2. A transient systemd unit (`pwnagotchi-to-ragnar-swap`) runs:
    ```
    systemctl stop pwnagotchi.service

--- a/scripts/install_pwnagotchi.sh
+++ b/scripts/install_pwnagotchi.sh
@@ -595,6 +595,23 @@ else
 fi
 
 # -------------------------------------------------------------------
+# WEB SWAP-BACK PLUGIN (Return to Ragnar button on the :8080 UI)
+# -------------------------------------------------------------------
+echo "[INFO] Installing ragnar_return web plugin..."
+RAGNAR_PLUGIN_SRC="$REPO_ROOT/scripts/pwnagotchi_plugins/ragnar_return.py"
+if [[ -f "$RAGNAR_PLUGIN_SRC" ]]; then
+    chmod 644 "$RAGNAR_PLUGIN_SRC"
+    # Symlink (not copy) so a git pull of /opt/pwnagotchi's Ragnar checkout
+    # keeps the plugin current, matching how the swap button is deployed.
+    ln -sf "$RAGNAR_PLUGIN_SRC" "$CONFIG_DIR/custom_plugins/ragnar_return.py"
+    set_or_update_config_value "main.plugins.ragnar_return.enabled" "true"
+    echo "[INFO] ragnar_return plugin linked into custom_plugins and enabled"
+    echo "[INFO] Reach it at http://<host>:8080/plugins/ragnar_return"
+else
+    echo "[WARN] ragnar_return.py not found - skipping web swap-back plugin"
+fi
+
+# -------------------------------------------------------------------
 # BOOT-TIME MIGRATION SERVICE
 # -------------------------------------------------------------------
 echo "[INFO] Setting up migration service..."

--- a/scripts/pwnagotchi_plugins/ragnar_return.py
+++ b/scripts/pwnagotchi_plugins/ragnar_return.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+ragnar_return — Pwnagotchi web plugin to swap back to Ragnar from the browser.
+
+Pwnagotchi's own web UI runs on :8080. When the user swaps back to Ragnar the
+Ragnar service comes up on :8000, but the browser tab stays on the now-dead
+:8080 portal with nothing to redirect it. The hardware button
+(scripts/ragnar_swap_button.py) has the same limitation: it can move the
+service but not the browser.
+
+This plugin closes that gap on the web side. It exposes a page at
+    http://<host>:8080/plugins/ragnar_return
+with a "Return to Ragnar" button. Clicking it:
+  1. POSTs to /plugins/ragnar_return/swap, which stops Pwnagotchi/bettercap and
+     starts Ragnar via systemd-run (survives pwnagotchi's cgroup teardown), then
+  2. the page polls http://<host>:8000 and redirects the browser there once
+     Ragnar answers consistently.
+
+The page also polls in the background from load, so if the swap is triggered by
+the hardware button while this page is open, the tab still follows to Ragnar.
+
+Enable with `main.plugins.ragnar_return.enabled = true` (the Ragnar installer
+does this and symlinks the file into /etc/pwnagotchi/custom_plugins).
+"""
+
+import logging
+import subprocess
+
+import pwnagotchi.plugins as plugins
+
+# Mirror the swap sequence used by scripts/ragnar_swap_button.py so both the
+# hardware button and this web button behave identically.
+_SWAP_CMD = (
+    'sleep 1'
+    ' && systemctl stop pwnagotchi.service'
+    ' && systemctl stop bettercap.service'
+    ' && systemctl stop ragnar-swap-button.service'
+    ' && sleep 2'
+    ' && systemctl start ragnar.service'
+)
+
+# Standalone HTML so it renders even as Pwnagotchi is torn down. No external
+# assets — the portal is often the only thing reachable at swap time.
+_PAGE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Return to Ragnar</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin:0; min-height:100vh; display:flex; align-items:center; justify-content:center;
+         background:#0f172a; color:#e2e8f0; font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+  .card { width:min(92vw,420px); background:rgba(30,41,59,.7); border:1px solid rgba(148,163,184,.25);
+          border-radius:16px; padding:28px; text-align:center; box-shadow:0 10px 40px rgba(0,0,0,.4); }
+  h1 { font-size:1.35rem; margin:0 0 6px; }
+  p  { color:#94a3b8; font-size:.9rem; margin:0 0 20px; line-height:1.5; }
+  button { width:100%; padding:14px 18px; font-size:1rem; font-weight:600; color:#fff; border:0;
+           border-radius:12px; background:#16a34a; cursor:pointer; transition:background .15s, opacity .15s; }
+  button:hover:not(:disabled) { background:#15803d; }
+  button:disabled { opacity:.7; cursor:not-allowed; }
+  .status { margin-top:16px; font-size:.85rem; color:#cbd5e1; min-height:1.2em; }
+  .spin { display:inline-block; width:14px; height:14px; margin-right:8px; vertical-align:-2px;
+          border:2px solid #4ade80; border-top-color:transparent; border-radius:50%; animation:s 1s linear infinite; }
+  @keyframes s { to { transform:rotate(360deg); } }
+</style>
+</head>
+<body>
+  <div class="card">
+    <h1>&#129445; Return to Ragnar</h1>
+    <p>Stops Pwnagotchi and starts Ragnar. This tab will move to Ragnar
+       (port&nbsp;8000) automatically once it&rsquo;s back up.</p>
+    <button id="btn">Return to Ragnar</button>
+    <div class="status" id="status"></div>
+  </div>
+<script>
+  var RAGNAR_URL = window.location.protocol + '//' + window.location.hostname + ':8000';
+  var btn = document.getElementById('btn');
+  var statusEl = document.getElementById('status');
+  var polling = false;
+
+  function setStatus(html) { statusEl.innerHTML = html; }
+
+  // Redirect only after Ragnar answers consistently — a single opaque success
+  // means the port is up before the app can actually render (see the forward
+  // swap fix on the Ragnar side).
+  function pollAndRedirect() {
+    if (polling) return;
+    polling = true;
+    var okStreak = 0, elapsed = 0;
+    var NEEDED_OK = 4, MAX_WAIT = 120;
+    setStatus('<span class="spin"></span>Waiting for Ragnar to come back...');
+    var timer = setInterval(function () {
+      elapsed++;
+      fetch(RAGNAR_URL, { mode: 'no-cors', cache: 'no-store' }).then(function () {
+        okStreak++;
+        if (okStreak >= NEEDED_OK) {
+          clearInterval(timer);
+          setStatus('Ragnar is up &mdash; redirecting...');
+          window.location.href = RAGNAR_URL;
+        } else {
+          setStatus('<span class="spin"></span>Ragnar starting... ' + elapsed + 's');
+        }
+      }).catch(function () {
+        okStreak = 0;
+        setStatus('<span class="spin"></span>Waiting for Ragnar to come back... ' + elapsed + 's');
+      });
+      if (elapsed >= MAX_WAIT) {
+        clearInterval(timer);
+        setStatus('Still waiting. <a style="color:#4ade80" href="' + RAGNAR_URL + '">Open Ragnar manually</a>.');
+      }
+    }, 1000);
+  }
+
+  btn.addEventListener('click', function () {
+    btn.disabled = true;
+    btn.textContent = 'Switching to Ragnar...';
+    fetch('/plugins/ragnar_return/swap', { method: 'POST' })
+      .then(function () { pollAndRedirect(); })
+      .catch(function () {
+        // The server may be torn down before the response returns — that's the
+        // swap working, so start polling anyway.
+        pollAndRedirect();
+      });
+  });
+
+  // If the hardware button triggers the swap while this page is open, follow
+  // Ragnar back without needing a click.
+  pollAndRedirect();
+</script>
+</body>
+</html>"""
+
+
+class RagnarReturn(plugins.Plugin):
+    __author__ = 'Ragnar'
+    __version__ = '1.0.0'
+    __license__ = 'GPL3'
+    __name__ = 'ragnar_return'
+    __description__ = 'Adds a web button to swap back from Pwnagotchi to Ragnar and redirect the browser to :8000.'
+
+    def on_loaded(self):
+        logging.info('[ragnar_return] plugin loaded — /plugins/ragnar_return is available')
+
+    def _trigger_swap(self):
+        """Stop Pwnagotchi/bettercap and start Ragnar via a transient unit.
+
+        systemd-run detaches the sequence into its own cgroup so it survives
+        pwnagotchi being killed a moment later.
+        """
+        subprocess.Popen(
+            ['systemd-run', '--no-block', '--collect',
+             '--unit=pwnagotchi-to-ragnar-swap',
+             'bash', '-c', _SWAP_CMD],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        logging.info('[ragnar_return] scheduled swap: stop pwnagotchi -> start ragnar')
+
+    def on_webhook(self, path, request):
+        # POST /plugins/ragnar_return/swap → kick off the swap, ack immediately.
+        if path == 'swap' and request.method == 'POST':
+            try:
+                self._trigger_swap()
+                return ('{"ok": true}', 200, {'Content-Type': 'application/json'})
+            except Exception as exc:  # noqa: BLE001 - report any failure to the UI
+                logging.error(f'[ragnar_return] swap failed: {exc}')
+                return ('{"ok": false}', 500, {'Content-Type': 'application/json'})
+
+        # GET /plugins/ragnar_return (path is None) → the button + redirect page.
+        return _PAGE

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -7411,7 +7411,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260731-pwn-healthcheck"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260731-pwn-portal-ready"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -12934,36 +12934,61 @@ function updatePwnButtons() {
 
             if (!swapToPwnBtn._countdownRunning && _pwnSwapRequestedThisSession) {
                 // Poll pwnagotchi portal directly - works even after Ragnar goes down.
-                // mode:'no-cors' gives an opaque response but won't throw, meaning server is up.
+                // mode:'no-cors' gives an opaque response but won't throw, meaning
+                // the server answered. But an opaque success only means the TCP
+                // listener + a minimal HTTP layer are up — bettercap/pwnagotchi
+                // often accept connections seconds before the web app can actually
+                // render the page and its assets. A single success therefore fires
+                // "ready" too early on slower boards, and the opened tab loads a
+                // blank/stalled page. Require several CONSECUTIVE successes (reset
+                // on any failure) so the app has had a stable window to finish
+                // coming up before we hand the user a link.
                 swapToPwnBtn._countdownRunning = true;
                 let elapsed = 0;
-                const MAX_WAIT = 60;
+                let consecutiveOk = 0;
+                const MAX_WAIT = 90;
+                const NEEDED_OK = 4; // ~4s of uninterrupted reachability
                 swapToPwnBtn.disabled = true;
                 swapToPwnBtn.textContent = `Waiting for Pwnagotchi... 0s`;
+
+                const markReady = (label) => {
+                    swapToPwnBtn.disabled = false;
+                    swapToPwnBtn.textContent = label;
+                    // Not a one-shot: leave it clickable so a blank/slow first
+                    // paint can just be re-opened without restarting the swap.
+                    swapToPwnBtn.onclick = function(e) {
+                        e.preventDefault();
+                        window.open(portalUrl, '_blank');
+                    };
+                    const hint = document.getElementById('pwn-swap-hint');
+                    if (hint) {
+                        hint.textContent = 'If the portal opens blank, give it a few more seconds and refresh — Pwnagotchi\'s web UI finishes loading shortly after the port opens.';
+                    }
+                };
+
                 const poll = setInterval(async () => {
                     elapsed++;
-                    swapToPwnBtn.textContent = `Waiting for Pwnagotchi... ${elapsed}s`;
                     try {
                         await fetch(portalUrl, { mode: 'no-cors', cache: 'no-store' });
-                        // Reached here = server responded (opaque ok)
-                        clearInterval(poll);
-                        swapToPwnBtn.disabled = false;
-                        swapToPwnBtn.textContent = 'Go to Pwnagotchi Portal';
-                        swapToPwnBtn.onclick = function(e) {
-                            e.preventDefault();
-                            window.open(portalUrl, '_blank');
-                        };
-                    } catch (_) {
-                        // Not up yet; fall through unless timeout
-                        if (elapsed >= MAX_WAIT) {
+                        // Opaque success — count it, but keep going until we've
+                        // seen the server answer consistently.
+                        consecutiveOk++;
+                        if (consecutiveOk >= NEEDED_OK) {
                             clearInterval(poll);
-                            swapToPwnBtn.disabled = false;
-                            swapToPwnBtn.textContent = 'Open Pwnagotchi Portal';
-                            swapToPwnBtn.onclick = function(e) {
-                                e.preventDefault();
-                                window.open(portalUrl, '_blank');
-                            };
+                            markReady('Go to Pwnagotchi Portal');
+                            return;
                         }
+                        swapToPwnBtn.textContent = `Pwnagotchi starting... ${elapsed}s`;
+                    } catch (_) {
+                        // Server flickered/not up — the streak must be unbroken.
+                        consecutiveOk = 0;
+                        swapToPwnBtn.textContent = `Waiting for Pwnagotchi... ${elapsed}s`;
+                    }
+                    if (elapsed >= MAX_WAIT) {
+                        clearInterval(poll);
+                        // Timed out waiting for a stable signal — still let the
+                        // user try the portal manually.
+                        markReady('Open Pwnagotchi Portal');
                     }
                 }, 1000);
             }


### PR DESCRIPTION
This pull request adds a new "Return to Ragnar" web plugin to the Pwnagotchi portal, improving the user experience when switching back to Ragnar from Pwnagotchi. It also enhances the reliability of the swap-back and swap-forward flows by ensuring the web UI only redirects after the target service is fully ready, preventing premature redirects to blank or stalled pages.

**New "Return to Ragnar" web plugin:**

* Added a new plugin (`scripts/pwnagotchi_plugins/ragnar_return.py`) that provides a web page (`/plugins/ragnar_return`) on the Pwnagotchi portal with a button to swap back to Ragnar and automatically redirect the browser to port 8000 once Ragnar is ready. This page also follows Ragnar if the hardware button triggers the swap while open.
* Updated the installer script (`scripts/install_pwnagotchi.sh`) to symlink and enable the `ragnar_return` plugin during installation.
* Documented the new plugin and its rationale in `docs/PWNAGOTCHI.md`, explaining how it solves the browser redirection gap when swapping services.

**Improved swap readiness detection:**

* Updated the Ragnar web UI (`web/scripts/ragnar_modern.js`) to require several consecutive successful polls before enabling the "Go to Pwnagotchi Portal" button, ensuring the portal is actually ready before redirecting the user. This prevents blank or stalled pages on slower boards.
* Updated the HTML reference for the new JS version in `web/index_modern.html`.