### PR TITLE
pwnagotchi: harden clean reinstall (keep config, ignore-installed pyd…

### DIFF
--- a/docs/PWNAGOTCHI.md
+++ b/docs/PWNAGOTCHI.md
@@ -89,11 +89,16 @@ the idempotent installer to restore the missing pieces without touching your
 captures or config.
 
 A **Reinstall (clean)** button is **always** shown, even when Healthy. It runs the
-installer with `--clean`, which stops the services, wipes `/opt/pwnagotchi`, backs
-up and removes `config.toml`, then rebuilds everything from scratch — the
-guaranteed-fresh path for when Repair isn't enough. Handshakes/captures are left
-untouched, and the previous config is kept as `config.toml.bak.<timestamp>`.
+installer with `--clean`, which stops the services, wipes `/opt/pwnagotchi`, and
+regenerates `config.toml` fresh (the old one is copied to
+`config.toml.bak.<timestamp>` first — it is **never** left deleted, so an
+interrupted reinstall can't strand the box without a config), then rebuilds
+everything from scratch. Handshakes/captures are left untouched.
 (Manual equivalent: `sudo ./scripts/install_pwnagotchi.sh --clean`.)
+
+> During a clean reinstall the clone is briefly absent while it re-downloads, so
+> the Installation Check badge shows **Installing…** (not a red *Needs Repair*)
+> until it finishes.
 
 ### Does Pwnagotchi's own updater conflict with Ragnar's?
 

--- a/scripts/install_pwnagotchi.sh
+++ b/scripts/install_pwnagotchi.sh
@@ -214,9 +214,11 @@ fi
 write_status "installing" "Starting Pwnagotchi installation" "preflight"
 echo "[INFO] Beginning Pwnagotchi installation..."
 
-# Clean reinstall: stop services and wipe the managed clone + config so the rest
-# of the installer regenerates them from scratch. Config is backed up first so a
-# customised name/whitelist can be recovered from the .bak file if needed.
+# Clean reinstall: stop services and wipe the managed clone so the rest of the
+# installer re-clones and rebuilds from scratch. The config is BACKED UP but left
+# in place — the config step below force-regenerates it when CLEAN_INSTALL=1. We
+# never delete it here: if the installer were interrupted between the delete and
+# the regenerate, the box would be left with no config at all (worse than before).
 if [[ "$CLEAN_INSTALL" == "1" ]]; then
     echo "[INFO] Clean reinstall requested — wiping existing Pwnagotchi state..."
     write_status "installing" "Clean reinstall: removing existing Pwnagotchi" "clean_wipe"
@@ -225,8 +227,7 @@ if [[ "$CLEAN_INSTALL" == "1" ]]; then
     rm -rf "$PWN_DIR"
     if [[ -f "$CONFIG_FILE" ]]; then
         cp -f "$CONFIG_FILE" "${CONFIG_FILE}.bak.$(date +%s)" 2>/dev/null || true
-        rm -f "$CONFIG_FILE"
-        echo "[INFO] Backed up and removed existing config.toml"
+        echo "[INFO] Backed up existing config.toml (regenerated fresh below)"
     fi
 fi
 
@@ -323,9 +324,13 @@ python3 -m pip install \
 # pydrive2 is a hard dependency (pwnagotchi crashes without it).
 # Force PyPI only - piwheels drops connections on large packages like google-api-python-client.
 # PIP_CONFIG_FILE=/dev/null ignores /etc/pip.conf which adds piwheels.
+# --ignore-installed: some pydrive2 deps (PyYAML, oauthlib, ...) may be apt-managed,
+# and pip cannot uninstall a Debian-owned package to upgrade it ("The package was
+# installed by debian..."). Ignoring installed copies lets pip put its own alongside.
 echo "[INFO] Installing pydrive2 from PyPI (required - may take a few minutes)..."
 PIP_CONFIG_FILE=/dev/null python3 -m pip install \
     --break-system-packages \
+    --ignore-installed \
     --index-url https://pypi.org/simple \
     --timeout 300 \
     --retries 5 \
@@ -333,11 +338,12 @@ PIP_CONFIG_FILE=/dev/null python3 -m pip install \
     echo "[WARN] pydrive2 first attempt failed. Retrying with no cache..."
     PIP_CONFIG_FILE=/dev/null python3 -m pip install \
         --break-system-packages \
+        --ignore-installed \
         --index-url https://pypi.org/simple \
         --timeout 600 \
         --retries 5 \
         --no-cache-dir \
-        pydrive2 2>&1 || echo "[ERROR] pydrive2 install failed. Run manually: sudo PIP_CONFIG_FILE=/dev/null pip3 install --break-system-packages --index-url https://pypi.org/simple pydrive2"
+        pydrive2 2>&1 || echo "[ERROR] pydrive2 install failed. Run manually: sudo PIP_CONFIG_FILE=/dev/null pip3 install --break-system-packages --ignore-installed --index-url https://pypi.org/simple pydrive2"
 }
 
 # -------------------------------------------------------------------
@@ -404,7 +410,10 @@ chmod 644 "$CONFIG_DIR/id_rsa.pub"
 # -------------------------------------------------------------------
 echo "[INFO] Configuring Pwnagotchi config file..."
 write_status "installing" "Creating configuration files" "config_files"
-if [[ ! -f "$CONFIG_FILE" ]]; then
+# Write a fresh config when it's missing, or always on a clean reinstall (the
+# old one was backed up above). Otherwise keep the user's file and just correct
+# the Ragnar-managed values.
+if [[ ! -f "$CONFIG_FILE" || "$CLEAN_INSTALL" == "1" ]]; then
     cat >"$CONFIG_FILE" <<EOF
 # Ragnar-managed Pwnagotchi config (pwnagotchiworking)
 

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -7417,7 +7417,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260731-pwn-reinstall"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260731-pwn-reinstall2"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -12856,7 +12856,12 @@ function updatePwnHealthCard(status = {}) {
     const badge = document.getElementById('pwn-health-badge');
     if (badge) {
         badge.className = 'text-xs font-semibold uppercase tracking-wide px-3 py-1 rounded-full self-start whitespace-nowrap';
-        if (!anyMissing) {
+        if (status.installing) {
+            // Mid-install the clone/config are transiently absent (especially on a
+            // clean reinstall) — don't alarm the user with a red "Needs Repair".
+            badge.textContent = 'Installing…';
+            badge.classList.add('bg-sky-900/60', 'text-sky-300');
+        } else if (!anyMissing) {
             badge.textContent = 'Healthy';
             badge.classList.add('bg-green-900/60', 'text-green-300');
         } else if (missingCritical.length) {


### PR DESCRIPTION
…rive2)

Three fixes from a reinstall report where the Installation Check showed config.toml missing mid-run and pydrive2 failed:

- Clean reinstall no longer deletes config.toml up front. It's backed up and left in place; the config step force-regenerates it when --clean is set. Previously the file was gone for the whole (20-40 min) install, so opening the check mid-run showed a scary config.toml ✗, and an interrupted reinstall could strand the box with no config at all.
- pydrive2 pip install gains --ignore-installed so it stops failing with 'The package was installed by debian... cannot uninstall' when a dep (PyYAML, oauthlib, ...) is apt-managed.
- Installation Check badge shows 'Installing…' while an install runs instead of flashing red 'Needs Repair' while the clone is transiently absent.