### PR TITLE
sdr: fix Waterfall not activating — probe HackRF once, handle probe t…

### DIFF
--- a/sdr_spectrum.py
+++ b/sdr_spectrum.py
@@ -117,15 +117,30 @@ def detect():
     installed *and* a board actually answers — the exact condition under which
     the web UI un-greys the Waterfall button.
     """
-    tools = os.path.exists(_HACKRF_SWEEP) or _HACKRF_SWEEP == "hackrf_sweep"
-    tools_installed = (_run([_HACKRF_SWEEP, "-h"])[0] not in (127,)) and \
-        (_run([_HACKRF_INFO])[0] != 127)
-    if not tools_installed:
+    # Probe the board exactly ONCE. hackrf_info opens the USB device; opening it
+    # twice back-to-back (as this used to) often makes the second open fail with
+    # "hackrf_open() failed" because libusb hasn't released the first claim yet —
+    # which then reads as "no HackRF" and greys the Waterfall out on a board that
+    # is actually fine. hackrf_sweep -h only prints usage (no device open), so we
+    # use it purely to tell "tools missing" apart from "device problem".
+    if _run([_HACKRF_SWEEP, "-h"])[0] == 127:
         return {"available": False, "tools_installed": False,
                 "device_present": False,
                 "error": "hackrf tools not installed (apt install hackrf)"}
-    rc, out, err = _run([_HACKRF_INFO])
+    # First enumeration after boot / on a busy USB bus can be slow, so give the
+    # single probe generous headroom and treat a timeout as its own case rather
+    # than silently reporting the board absent.
+    rc, out, err = _run([_HACKRF_INFO], timeout=12)
     blob = (out or "") + (err or "")
+    if rc == 127:
+        return {"available": False, "tools_installed": False,
+                "device_present": False,
+                "error": "hackrf tools not installed (apt install hackrf)"}
+    if rc == 124:
+        return {"available": False, "tools_installed": True,
+                "device_present": False,
+                "error": "HackRF probe timed out — retry, or use a powered USB "
+                         "hub (the Pi's port may be under-powering the board)"}
     if rc != 0 or "No HackRF boards found" in blob or "hackrf_open" in blob:
         return {"available": False, "tools_installed": True,
                 "device_present": False,


### PR DESCRIPTION
…imeout

detect() opened the HackRF via hackrf_info twice per call (tools check + real probe). Back-to-back opens frequently make the second fail with hackrf_open() failed before libusb releases the first claim, which read as 'no HackRF' and greyed out the Waterfall on a working board — matching the field report of multiple HackRFs/cables/reboots all failing to activate.

- probe the board exactly once; use hackrf_sweep -h (no device open) only to distinguish missing tools from a device problem
- give the single probe a 12s timeout for slow first enumeration after boot
- report a probe timeout as its own case instead of silently 'absent'