### PR TITLE
PCAP AI: instruct model to use only valid Wireshark filter syntax

### DIFF
--- a/ai_service.py
+++ b/ai_service.py
@@ -408,7 +408,11 @@ Tone: Direct, tactical Viking strategist. Use bullet points and clear sections.
             "high RTT), DNS and DHCP failures/latency, TLS/handshake errors, and — for "
             "802.11 captures — deauth/disassoc reason codes and retry rates that drive "
             "client drops. Be specific and quote the counts/codes. Do not invent data not "
-            "present in the summary. Use short markdown sections and bullet points."
+            "present in the summary. When you cite a Wireshark/tshark display filter or CLI "
+            "command, use only valid, real syntax (e.g. tcp.analysis.retransmission, "
+            "tcp.flags.reset==1, tcp.analysis.duplicate_ack); if you are unsure of the exact "
+            "filter, describe what to match in words rather than inventing a field name. "
+            "Use short markdown sections and bullet points."
         )
         focus = (
             "This is a Wi-Fi / access-point capture: pay special attention to WHY CLIENTS "


### PR DESCRIPTION
The pcap AI triage sometimes emitted non-existent display filters in its Fix-it steps (e.g. tcp.analysis.debug_regex, 'CAB/PMTUD') that a tech would paste into Wireshark and get an error. The existing 'do not invent data' rule only covered the capture summary, not remediation syntax, so add an explicit instruction to use only real filter/CLI syntax and to describe matches in words when unsure.