### PR TITLE
PCAP Analyzer: capture interface picker now matches the L2/L3 selectors

### DIFF
--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -1914,9 +1914,12 @@ There are **three ways to feed it a capture**, all landing on the same analysis
    newest first — pick one and analyze it in place. Selection is confined to
    those roots and magic-byte checked, so it can't be used to read arbitrary
    files off disk.
-3. **🎥 Capture live** — record fresh traffic yourself: pick an **interface**, a
-   **duration** (3–60 s), and an optional **BPF filter** (e.g. `tcp port 443 or
-   host 10.0.0.5`). Ragnar runs a passive `tcpdump -w` for the window, saves the
+3. **🎥 Capture live** — record fresh traffic yourself: pick an **interface**
+   (defaults to **Auto (wired first)** — the same link-up-wired-port preference
+   the L2/L3 Watch scanners use), a **duration** (3–60 s), and an optional **BPF
+   filter** (e.g. `tcp port 443 or host 10.0.0.5`). The interface list is
+   pre-populated on tab load, like every other picker in this section. Ragnar
+   runs a passive `tcpdump -w` for the window, saves the
    pcap under `data/pcaps/` (so it also shows up in *Open stored pcap*), and
    analyzes it immediately. Capturing needs root — the Ragnar service already
    runs as root.

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -14154,6 +14154,10 @@ def do_pcap_capture(interface=None, seconds=10, bpf=None, max_seconds=60):
     valid = set(_list_iface_names(include_virtual=True))
     if not valid:
         return {'success': False, 'error': 'no capturable interfaces found'}
+    # Empty selection means "Auto (wired first)" — resolve it the same way the
+    # L2/L3 Watch scanners do, so the PCAP capture picker behaves like the rest.
+    if not interface:
+        interface = _capture_iface()
     if not interface or interface not in valid:
         return {'success': False,
                 'error': 'unknown interface — pick one of: %s'

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -1902,6 +1902,15 @@
                         <button onclick="pcapShowStored()" class="w-full sm:w-auto bg-slate-700 hover:bg-slate-600 text-gray-200 px-4 py-2 rounded text-sm whitespace-nowrap">📁 Open stored pcap</button>
                         <button onclick="pcapShowCapture()" class="w-full sm:w-auto bg-slate-700 hover:bg-slate-600 text-gray-200 px-4 py-2 rounded text-sm whitespace-nowrap">🎥 Capture live</button>
                     </div>
+                    <div id="pcap-capture-form" class="hidden mt-3">
+                        <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-end gap-2">
+                            <label class="text-sm text-gray-400">Interface<br><select id="pcap-cap-iface" title="Interface to capture on — Auto prefers a link-up wired port; pick a WiFi/LAN NIC to force one" class="mt-1 w-full sm:w-auto bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-gray-300"><option value="">Auto (wired first)</option></select></label>
+                            <label class="text-sm text-gray-400">Seconds<br><input id="pcap-cap-secs" type="number" min="3" max="60" value="10" class="mt-1 w-20 bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-gray-300"></label>
+                            <label class="text-sm text-gray-400 sm:flex-1 sm:min-w-[12rem]">Filter <span class="text-gray-600">(optional BPF)</span><br><input id="pcap-cap-bpf" type="text" placeholder="e.g. tcp port 443 or host 10.0.0.5" class="mt-1 w-full bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-gray-300"></label>
+                            <button onclick="startPcapCapture()" class="w-full sm:w-auto bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Start capture</button>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-2">Records passively with tcpdump, then analyzes the result. The file is saved under Ragnar, so it also shows up in “Open stored pcap”.</p>
+                    </div>
                     <div id="pcap-panel" class="hidden mt-3 text-sm"></div>
                     <div id="pcap-results" class="hidden mt-3 text-sm"></div>
                 </div>
@@ -7430,7 +7439,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260802-pcap-iface"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260802-pcap-iface-static"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -1335,6 +1335,7 @@ function showNetworkSubtab(name) {
         _lldpFillIfaces();
         loadLldp();
         _arpScanFillIfaces();
+        _pcapCapFillIfaces();
         _locateFillIfaces();
         _l2FillIfaces();
         _dhcpFillIfaces();
@@ -5671,6 +5672,8 @@ async function analyzePcap() {
 async function pcapShowStored() {
     const panel = document.getElementById('pcap-panel');
     const btn = event && event.target ? event.target : null;
+    const capForm = document.getElementById('pcap-capture-form');
+    if (capForm) capForm.classList.add('hidden');   // don't show both at once
     panel.classList.remove('hidden');
     panel.innerHTML = '<p class="text-sm text-gray-400">Scanning for stored captures…</p>';
     _ndBusy(btn, true, 'Scanning…');
@@ -5722,26 +5725,30 @@ async function analyzeStoredPcap(el) {
     }
 }
 
-// PCAP source #3 — capture live traffic on an interface into a new pcap.
-function pcapShowCapture() {
-    const panel = document.getElementById('pcap-panel');
-    panel.classList.remove('hidden');
-    panel.innerHTML = `<div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-end gap-2">
-        <label class="text-sm text-gray-400">Interface<br><select id="pcap-cap-iface" title="Interface to capture on — pick your WiFi or LAN NIC (monitor-mode interfaces are listed too)" class="mt-1 w-full sm:w-auto bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-gray-300"></select></label>
-        <label class="text-sm text-gray-400">Seconds<br><input id="pcap-cap-secs" type="number" min="3" max="60" value="10" class="mt-1 w-20 bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-gray-300"></label>
-        <label class="text-sm text-gray-400 sm:flex-1 sm:min-w-[12rem]">Filter <span class="text-gray-600">(optional BPF)</span><br><input id="pcap-cap-bpf" type="text" placeholder="e.g. tcp port 443 or host 10.0.0.5" class="mt-1 w-full bg-slate-800 border border-slate-700 rounded px-2 py-1 text-sm text-gray-200"></label>
-        <button onclick="startPcapCapture()" class="bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Start capture</button>
-    </div><p class="text-xs text-gray-500 mt-2">Records passively with tcpdump, then analyzes the result. The file is saved under Ragnar, so it also shows up in “Open stored pcap”.</p>`;
+// PCAP source #3 — capture live traffic on an interface into a new pcap. The
+// interface <select> is static in the page (with "Auto (wired first)") and is
+// pre-filled on tab load like every other Switch & L2/L3 picker, so opening the
+// form just reveals it — no async populate.
+function _pcapCapFillIfaces() {
     const sel = document.getElementById('pcap-cap-iface');
-    fetchAPI('/api/net/interfaces?all=1').then(x => {
+    if (!sel || sel.dataset.filled === '1') return Promise.resolve();
+    return fetchAPI('/api/net/interfaces').then(x => {
         (x.interfaces || []).forEach(i => {
             const o = document.createElement('option');
             o.value = i.name;
             const tag = i.type === 'wifi' ? ' (WiFi)' : i.type === 'ethernet' ? ' (LAN)' : (i.type ? ' (' + i.type + ')' : '');
-            o.textContent = i.name + tag + (i.operstate && i.operstate !== 'up' ? ' — ' + i.operstate : '');
+            o.textContent = i.name + tag;
             sel.appendChild(o);
         });
+        sel.dataset.filled = '1';
     }).catch(() => {});
+}
+function pcapShowCapture() {
+    const form = document.getElementById('pcap-capture-form');
+    const panel = document.getElementById('pcap-panel');
+    if (panel) panel.classList.add('hidden');   // hide the stored-pcap list if it was open
+    _pcapCapFillIfaces();                        // no-op if already filled on tab load
+    if (form) form.classList.toggle('hidden');
 }
 async function startPcapCapture() {
     const iface = (document.getElementById('pcap-cap-iface') || {}).value || '';
@@ -5750,10 +5757,9 @@ async function startPcapCapture() {
     const bpf = ((document.getElementById('pcap-cap-bpf') || {}).value || '').trim();
     const out = document.getElementById('pcap-results');
     const btn = event && event.target ? event.target : null;
-    if (!iface) return;
     _ndBusy(btn, true, 'Capturing…');
     out.classList.remove('hidden');
-    out.innerHTML = '<p class="text-sm text-gray-400">Capturing on ' + escapeHtml(iface) + ' for ' + secs + 's… (this blocks for the capture window)</p>';
+    out.innerHTML = '<p class="text-sm text-gray-400">Capturing on ' + (iface ? escapeHtml(iface) : 'auto (wired first)') + ' for ' + secs + 's… (this blocks for the capture window)</p>';
     try {
         const d = await postAPI('/api/net/pcap/capture', { interface: iface, seconds: secs, bpf: bpf });
         if (!d.success) {


### PR DESCRIPTION
The live-capture interface dropdown was built dynamically only after clicking 'Capture live' and populated async ('it loads it'), unlike every other Switch & L2/L3 picker which is a static select pre-filled on tab load with an 'Auto (wired first)' default.

- Move the capture form into static HTML with a static <select> that has the 'Auto (wired first)' option, matching the shared styling.
- Add _pcapCapFillIfaces() (guarded, same shape as _stpFillIfaces/etc.) and call it from the tab-init block so the interface list is present immediately; 'Capture live' just reveals the form.
- Backend: do_pcap_capture() resolves an empty interface via _capture_iface() (the same wired-first logic the Watch scanners use), so 'Auto' works instead of erroring.
- Hide stored-list and capture-form from each other so only one shows.