### PR TITLE
PCAP AI: calibrate severity to volume; drop normal TCP teardown noise

### DIFF
--- a/ai_service.py
+++ b/ai_service.py
@@ -400,26 +400,37 @@ Tone: Direct, tactical Viking strategist. Use bullet points and clear sections.
 
         is_wifi = bool(wifi.get('is_wifi'))
         system = (
-            "You are a senior network engineer triaging a packet capture to find what is "
-            "WRONG with the network. Diagnose the ROOT CAUSE from the evidence and explain "
-            "it in plain language a field tech can act on. Reason across the whole stack: "
-            "L2 (ARP/broadcast/multicast storms, duplicate IPs, spanning-tree churn), "
+            "You are a senior network engineer triaging a packet capture. Decide whether the "
+            "network is HEALTHY or has a real problem, and if so diagnose the ROOT CAUSE from "
+            "the evidence in plain language a field tech can act on. Reason across the whole "
+            "stack: L2 (ARP/broadcast/multicast storms, duplicate IPs, spanning-tree churn), "
             "TCP health (retransmissions, resets, zero-windows, dup-ACKs, out-of-order, "
             "high RTT), DNS and DHCP failures/latency, TLS/handshake errors, and — for "
             "802.11 captures — deauth/disassoc reason codes and retry rates that drive "
-            "client drops. Be specific and quote the counts/codes. Do not invent data not "
-            "present in the summary. When you cite a Wireshark/tshark display filter or CLI "
-            "command, use only valid, real syntax (e.g. tcp.analysis.retransmission, "
-            "tcp.flags.reset==1, tcp.analysis.duplicate_ack); if you are unsure of the exact "
-            "filter, describe what to match in words rather than inventing a field name. "
-            "Use short markdown sections and bullet points."
+            "client drops. "
+            "CALIBRATE SEVERITY AGAINST VOLUME: a small number of RSTs, duplicate ACKs, "
+            "retransmissions, and normal FIN-based connection closes is EXPECTED, especially "
+            "for ordinary web/TLS browsing — judge by RATES relative to total packets/bytes "
+            "and to the number of conversations, not by raw counts. Normal connection teardown "
+            "(FIN / 'connection closing') is NOT a fault, and a few RSTs are how clients "
+            "routinely close sessions. Do not describe the network as 'unstable' or 'degraded' "
+            "unless the error rate is clearly disproportionate to the traffic. If the capture "
+            "looks healthy, SAY SO plainly (make that the Verdict) rather than manufacturing a "
+            "problem. "
+            "Be specific and quote the counts/codes. Do not invent data not present in the "
+            "summary. When you cite a Wireshark/tshark display filter or CLI command, use only "
+            "valid, real syntax (e.g. tcp.analysis.retransmission, tcp.flags.reset==1, "
+            "tcp.analysis.duplicate_ack) and parenthesize mixed AND/OR filters correctly; if "
+            "unsure of the exact filter, describe what to match in words rather than inventing "
+            "a field name. Use short markdown sections and bullet points."
         )
         focus = (
             "This is a Wi-Fi / access-point capture: pay special attention to WHY CLIENTS "
             "ARE DROPPING / DISCONNECTING (deauth/disassoc reason codes, retry %, AP "
             "behavior), but still flag any other network problems you see." if is_wifi else
             "Diagnose the most impactful problems in this capture across every layer — "
-            "not just one — and rank them by how much they hurt the network."
+            "not just one — and rank them by how much they hurt the network. If nothing "
+            "rises above normal background noise, say the capture looks healthy."
         )
         user = f"""{focus}
 
@@ -428,7 +439,7 @@ Packet-capture summary (JSON):
 
 Provide:
 
-**Verdict** - the single most likely root cause (1-2 sentences).
+**Verdict** - is the network healthy, or the single most likely root cause if not (1-2 sentences).
 
 **Evidence** - the specific counts / reason codes / status codes / expert
 findings that point to it, quoted from the summary.

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -13964,6 +13964,12 @@ def do_pcap_analyze(path):
     expert = {'errors': 0, 'warnings': 0, 'notes': 0, 'items': []}
     sev = None
     sev_key = {'Errors': 'errors', 'Warns': 'warnings', 'Notes': 'notes'}
+    # Normal TCP connection lifecycle (SYN establishment, FIN teardown) is
+    # surfaced by tshark as low-severity notes. It is NOT a fault — feeding it to
+    # the AI made routine teardown read as "instability" — so drop these items and
+    # discount them from the note total so the counts stay honest.
+    _normal_seq = ('the connection closing', 'connection establish request',
+                   'connection establish acknowledge')
     for line in _run(['tshark', '-r', path, '-q', '-z', 'expert'], timeout=90)['out'].splitlines():
         hm = re.match(r'^(Errors|Warns|Notes|Chats)\s*\((\d+)\)', line)
         if hm:
@@ -13973,9 +13979,14 @@ def do_pcap_analyze(path):
             continue
         rm = re.match(r'^\s+(\d+)\s+(\S+)\s+(\S+)\s+(.+?)\s*$', line)
         if rm and sev and sev != 'Chats':
+            summary = rm.group(4).strip()
+            if any(p in summary.lower() for p in _normal_seq):
+                if sev in sev_key:      # keep the badge total consistent with items
+                    expert[sev_key[sev]] = max(0, expert[sev_key[sev]] - int(rm.group(1)))
+                continue
             expert['items'].append({'severity': sev_key.get(sev, sev.lower()),
                                     'count': int(rm.group(1)), 'protocol': rm.group(3),
-                                    'summary': rm.group(4).strip()})
+                                    'summary': summary})
     expert['items'].sort(key=lambda i: i['count'], reverse=True)
     expert['items'] = expert['items'][:20]
 


### PR DESCRIPTION
On a healthy low-volume TLS capture (a few RSTs + dup-ACKs while browsing to GitHub), the AI declared 'active TCP instability'. Two causes:

- The prompt was framed 'find what is WRONG', biasing toward problems and never allowing a healthy verdict. Reframe to decide healthy-vs-problem, and add explicit severity calibration: judge RSTs/dup-ACKs/retransmits by RATE vs total packets/bytes/conversations, treat normal FIN teardown as not-a-fault, and say so plainly when the capture looks healthy. Also tell it to parenthesize mixed AND/OR display filters.

- do_pcap_analyze() fed tshark's normal connection-lifecycle notes (SYN establishment, FIN 'connection closing') to the model, which read routine teardown as evidence of instability. Drop those items and discount them from the note total so the expert badge stays consistent.