### PR TITLE
PCAP: fix 500 on capture — expert loop clobbered the summary dict

### DIFF
--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -13979,14 +13979,14 @@ def do_pcap_analyze(path):
             continue
         rm = re.match(r'^\s+(\d+)\s+(\S+)\s+(\S+)\s+(.+?)\s*$', line)
         if rm and sev and sev != 'Chats':
-            summary = rm.group(4).strip()
-            if any(p in summary.lower() for p in _normal_seq):
+            desc = rm.group(4).strip()   # NB: not `summary` — that name holds the file-summary dict
+            if any(p in desc.lower() for p in _normal_seq):
                 if sev in sev_key:      # keep the badge total consistent with items
                     expert[sev_key[sev]] = max(0, expert[sev_key[sev]] - int(rm.group(1)))
                 continue
             expert['items'].append({'severity': sev_key.get(sev, sev.lower()),
                                     'count': int(rm.group(1)), 'protocol': rm.group(3),
-                                    'summary': summary})
+                                    'summary': desc})
     expert['items'].sort(key=lambda i: i['count'], reverse=True)
     expert['items'] = expert['items'][:20]
 


### PR DESCRIPTION
The severity-calibration change named its expert-item loop variable 'summary', which is the SAME name do_pcap_analyze() uses for the capinfos file-summary dict it returns. Each non-Chat expert line overwrote it, so 'summary' came back as the last expert line's text (e.g. 'Duplicate ACK (#2)') instead of the stats dict.

do_pcap_capture() then did (out.get('summary') or {}).get('packets') on that string -> AttributeError: 'str' object has no attribute 'get' -> HTTP
500. The upload/stored paths didn't crash but silently lost their summary stats (packets/size/duration rendered as '—').

Rename the loop variable to 'desc'. Verified: summary is a dict again with correct packet counts across all stored captures.