### PR TITLE
PCAP capture: add Wi-Fi monitor-mode (802.11) capture

### DIFF
--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -1926,6 +1926,16 @@ There are **three ways to feed it a capture**, all landing on the same analysis
    analyzes it immediately. Capturing needs root — the Ragnar service already
    runs as root.
 
+   **📡 Monitor mode** (Wi-Fi adapters only) — tick it to capture raw **802.11**
+   instead of the adapter's own managed traffic: beacons, deauth/disassoc, and
+   nearby devices' frames, with an optional **channel** to park on. Ragnar flips
+   the radio into monitor mode via the same primitive the Wi-Fi Defense tools use
+   (a separate `ragmon0` vif where the driver allows it, otherwise switching the
+   adapter itself) and **always restores it afterward**. The resulting 802.11
+   capture feeds the analyzer's Wi-Fi/AP breakdown (deauth reasons, retries,
+   SSIDs). Best with a dedicated adapter (e.g. an Alfa) — monitor mode briefly
+   takes that card off its network. Needs a radio that supports monitor mode.
+
 Every source then shows:
 
 - **Summary** — packets, size, duration, average packet size, data rate,

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -14243,11 +14243,18 @@ def _pcap_zero_note(iface, seconds):
     return base + ' — wrong interface, the cable is down, or the filter matched nothing.'
 
 
-def do_pcap_capture(interface=None, seconds=10, bpf=None, max_seconds=60):
+def do_pcap_capture(interface=None, seconds=10, bpf=None, max_seconds=60,
+                    monitor=False, channel=None):
     """Record live traffic on `interface` for `seconds` into a saved pcap (kept in
     the capture dir so it then shows up under 'stored'), and analyze it. Passive:
     a plain ``tcpdump -w`` with no injected traffic. Needs root for the capture
-    (the Ragnar service runs as root)."""
+    (the Ragnar service runs as root).
+
+    With ``monitor=True`` on a Wi-Fi interface, flip the adapter into monitor
+    mode (via wifi_defense.enable_monitor — a separate vif where the driver
+    allows it, else switching the adapter) and capture raw 802.11 with radiotap,
+    optionally parked on ``channel``. Monitor mode is always torn down afterward,
+    restoring the managed link."""
     if not _have('tcpdump'):
         return {'success': False, 'missing_tool': 'tcpdump',
                 'error': 'tcpdump is not installed. Click Install to add it.'}
@@ -14262,6 +14269,10 @@ def do_pcap_capture(interface=None, seconds=10, bpf=None, max_seconds=60):
         return {'success': False,
                 'error': 'unknown interface — pick one of: %s'
                          % ', '.join(sorted(valid))}
+    if monitor and not _is_wireless(interface):
+        return {'success': False,
+                'error': '%s is not a Wi-Fi interface — monitor mode only applies '
+                         'to wireless adapters.' % interface}
     try:
         seconds = int(seconds)
     except (TypeError, ValueError):
@@ -14272,20 +14283,55 @@ def do_pcap_capture(interface=None, seconds=10, bpf=None, max_seconds=60):
     safe_if = re.sub(r'[^A-Za-z0-9_.-]', '_', interface)
     path = os.path.join(_pcap_capture_dir(), 'ragnar-%s-%s.pcap' % (safe_if, ts))
 
-    # -U writes each packet as it arrives, so the file is a valid pcap even though
-    # we stop tcpdump by killing it at the time window (it never self-terminates).
-    cmd = ['tcpdump', '-i', interface, '-w', path, '-s', '0', '-U', '-q']
-    if bpf:
-        bpf = str(bpf).strip()
-        if len(bpf) > 200:
-            return {'success': False, 'error': 'capture filter too long'}
-        cmd.append(bpf)          # tcpdump joins trailing args into the BPF filter
+    # For monitor capture, put the radio into monitor mode first (and remember to
+    # restore it). cap_iface is what tcpdump actually listens on (a monitor vif
+    # like ragmon0, or the adapter itself in switch mode).
+    cap_iface = interface
+    mon_state = None
+    warning = None
+    if monitor:
+        try:
+            import wifi_defense
+        except Exception as exc:      # pragma: no cover - defensive
+            return {'success': False, 'error': 'monitor mode unavailable: %s' % exc}
+        res = wifi_defense.enable_monitor(interface)
+        if not isinstance(res, dict) or res.get('error'):
+            return {'success': False,
+                    'error': 'could not enable monitor mode: %s'
+                             % (res or {}).get('error', 'unknown')}
+        mon_state = res
+        cap_iface = res.get('mon_iface') or interface
+        warning = res.get('warning')
+        if channel:
+            try:
+                _run(['iw', 'dev', cap_iface, 'set', 'channel', str(int(channel))],
+                     timeout=5)
+            except (ValueError, TypeError):
+                channel = None       # ignore a non-numeric channel
+
     try:
-        subprocess.run(cmd, timeout=seconds, capture_output=True)
-    except subprocess.TimeoutExpired:
-        pass                     # expected: the timeout IS how we end the capture
-    except Exception as exc:     # pragma: no cover - defensive
-        return {'success': False, 'error': 'capture failed: %s' % exc}
+        # -U writes each packet as it arrives, so the file is a valid pcap even
+        # though we stop tcpdump by killing it at the time window (it never
+        # self-terminates).
+        cmd = ['tcpdump', '-i', cap_iface, '-w', path, '-s', '0', '-U', '-q']
+        if bpf:
+            bpf = str(bpf).strip()
+            if len(bpf) > 200:
+                return {'success': False, 'error': 'capture filter too long'}
+            cmd.append(bpf)          # tcpdump joins trailing args into the BPF filter
+        try:
+            subprocess.run(cmd, timeout=seconds, capture_output=True)
+        except subprocess.TimeoutExpired:
+            pass                     # expected: the timeout IS how we end the capture
+        except Exception as exc:     # pragma: no cover - defensive
+            return {'success': False, 'error': 'capture failed: %s' % exc}
+    finally:
+        if mon_state:                # always restore the managed link
+            try:
+                import wifi_defense
+                wifi_defense.disable_monitor(mon_state.get('mon_iface'))
+            except Exception:        # pragma: no cover - best-effort restore
+                pass
 
     if not os.path.isfile(path) or os.path.getsize(path) == 0:
         return {'success': False,
@@ -14298,8 +14344,17 @@ def do_pcap_capture(interface=None, seconds=10, bpf=None, max_seconds=60):
         out['captured_name'] = os.path.basename(path)
         out['interface'] = interface
         out['seconds'] = seconds
+        out['monitor'] = bool(monitor)
+        if warning:
+            out['monitor_warning'] = warning
         if out.get('success') and not (out.get('summary') or {}).get('packets'):
-            out['note'] = _pcap_zero_note(interface, seconds)
+            if monitor:
+                out['note'] = ('Monitor capture saw 0 frames in %ds%s — the radio may '
+                               'be on a channel with no nearby APs. Set a channel with '
+                               'active traffic and retry.'
+                               % (seconds, (' on ch %s' % channel) if channel else ''))
+            else:
+                out['note'] = _pcap_zero_note(interface, seconds)
     return out
 
 
@@ -15638,7 +15693,9 @@ def register_network_diagnostics(app, logger=None):
         return jsonify(do_pcap_capture(
             interface=(data.get('interface') or '').strip() or None,
             seconds=data.get('seconds', 10),
-            bpf=(data.get('bpf') or '').strip() or None))
+            bpf=(data.get('bpf') or '').strip() or None,
+            monitor=bool(data.get('monitor')),
+            channel=(data.get('channel') or None)))
 
     @app.route('/api/net/flows', methods=['GET'])
     def net_flows():

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -1909,7 +1909,11 @@
                             <label class="text-sm text-gray-400 sm:flex-1 sm:min-w-[12rem]">Filter <span class="text-gray-600">(optional BPF)</span><br><input id="pcap-cap-bpf" type="text" placeholder="e.g. tcp port 443 or host 10.0.0.5" class="mt-1 w-full bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-gray-300"></label>
                             <button onclick="startPcapCapture()" class="w-full sm:w-auto bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Start capture</button>
                         </div>
-                        <p class="text-xs text-gray-500 mt-2">Records passively with tcpdump, then analyzes the result. The file is saved under Ragnar, so it also shows up in “Open stored pcap”.</p>
+                        <div class="flex flex-wrap items-center gap-3 mt-2">
+                            <label class="flex items-center gap-2 text-sm text-gray-400" title="Wi-Fi only: flip the adapter into monitor mode and capture raw 802.11 (beacons, deauths, nearby devices), then restore it. Best with a dedicated adapter like an Alfa — it drops that card's normal Wi-Fi link during the capture."><input id="pcap-cap-monitor" type="checkbox" onchange="document.getElementById('pcap-cap-chan-wrap').classList.toggle('hidden', !this.checked)" class="accent-Ragnar-500"> 📡 Monitor mode <span class="text-gray-600">(sniff 802.11, Wi-Fi adapter only)</span></label>
+                            <label id="pcap-cap-chan-wrap" class="hidden text-sm text-gray-400">Channel <span class="text-gray-600">(optional)</span> <input id="pcap-cap-chan" type="number" min="1" max="196" placeholder="e.g. 6" class="ml-1 w-20 bg-slate-800 border border-slate-700 rounded px-2 py-1 text-sm text-gray-300"></label>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-2">Records passively with tcpdump, then analyzes the result. The file is saved under Ragnar, so it also shows up in “Open stored pcap”. Monitor mode needs a Wi-Fi adapter that supports it and briefly takes that card off its network.</p>
                     </div>
                     <div id="pcap-panel" class="hidden mt-3 text-sm"></div>
                     <div id="pcap-results" class="hidden mt-3 text-sm"></div>
@@ -7439,7 +7443,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260802-pcap-iface-static"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260802-pcap-monitor"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -5513,11 +5513,12 @@ function renderPcapResults(d, out) {
         ? `<p class="text-xs text-green-400 mb-2">🎥 Captured <span class="font-mono">${escapeHtml(d.captured_name)}</span> on ${escapeHtml(d.interface || '')} for ${d.seconds || ''}s — saved to Ragnar (see “Open stored pcap”).</p>`
         : (d.source_name ? `<p class="text-xs text-gray-400 mb-2">📁 <span class="font-mono">${escapeHtml(d.source_name)}</span></p>` : '');
     const note = d.note ? `<p class="text-xs text-amber-300 mb-2">${escapeHtml(d.note)}</p>` : '';
+    const monWarn = d.monitor_warning ? `<p class="text-xs text-amber-300 mb-2">📡 ${escapeHtml(d.monitor_warning)}</p>` : '';
 
     const aiBtn = `<div class="mt-3 flex flex-wrap gap-2"><button onclick="aiAnalyzePcap()" class="bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-3 py-1.5 rounded text-sm whitespace-nowrap">🧠 Explain with AI</button>
         <button onclick="pcapExportReport()" title="Open a printable capture report (Save as PDF)" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded text-sm whitespace-nowrap">📄 Export as PDF</button>
         <div id="pcap-ai-results" class="hidden mt-2 w-full"></div></div>`;
-    out.innerHTML = srcNote + note + stats + `<div class="overflow-x-auto">${protoTable}${talkTable}</div>` + _pcapWifiHtml(d.wifi) + expert + aiBtn;
+    out.innerHTML = srcNote + note + monWarn + stats + `<div class="overflow-x-auto">${protoTable}${talkTable}</div>` + _pcapWifiHtml(d.wifi) + expert + aiBtn;
     _lastPcap = d;
     _lastPcapAI = null;   // new capture — drop any AI summary from a previous one
 }
@@ -5755,13 +5756,19 @@ async function startPcapCapture() {
     let secs = parseInt((document.getElementById('pcap-cap-secs') || {}).value, 10);
     if (!Number.isFinite(secs)) secs = 10;
     const bpf = ((document.getElementById('pcap-cap-bpf') || {}).value || '').trim();
+    const monitor = !!(document.getElementById('pcap-cap-monitor') || {}).checked;
+    const channel = ((document.getElementById('pcap-cap-chan') || {}).value || '').trim();
     const out = document.getElementById('pcap-results');
     const btn = event && event.target ? event.target : null;
     _ndBusy(btn, true, 'Capturing…');
     out.classList.remove('hidden');
-    out.innerHTML = '<p class="text-sm text-gray-400">Capturing on ' + (iface ? escapeHtml(iface) : 'auto (wired first)') + ' for ' + secs + 's… (this blocks for the capture window)</p>';
+    out.innerHTML = '<p class="text-sm text-gray-400">' + (monitor ? '📡 Monitor-mode capturing 802.11 on ' : 'Capturing on ')
+        + (iface ? escapeHtml(iface) : 'auto (wired first)')
+        + (monitor && channel ? ' ch ' + escapeHtml(channel) : '')
+        + ' for ' + secs + 's… (this blocks for the capture window'
+        + (monitor ? ', plus a moment to switch the radio in and out of monitor mode' : '') + ')</p>';
     try {
-        const d = await postAPI('/api/net/pcap/capture', { interface: iface, seconds: secs, bpf: bpf });
+        const d = await postAPI('/api/net/pcap/capture', { interface: iface, seconds: secs, bpf: bpf, monitor: monitor, channel: channel });
         if (!d.success) {
             out.innerHTML = d.missing_tool ? _ndMissingTool(d, null)
                 : '<p class="text-sm text-red-400">Error: ' + escapeHtml(d.error || 'failed') + '</p>';


### PR DESCRIPTION
An Alfa/USB Wi-Fi adapter in managed mode captures nothing useful — the value is sniffing raw 802.11. Add a 'Monitor mode' option to Capture live:

- Backend: do_pcap_capture(monitor=True, channel=...) flips the radio via wifi_defense.enable_monitor() (separate ragmon0 vif where the driver allows it, else switches the adapter), optionally parks a channel, captures radiotap/802.11 with tcpdump, and ALWAYS tears monitor mode back down in a finally (verified it restores even when capture errors). Guards against selecting a wired interface. The 802.11 pcap feeds the existing WiFi/AP analysis in do_pcap_analyze.
- UI: monitor checkbox + optional channel field in the static capture form; startPcapCapture sends them; results surface any switch-mode warning.

Hardware-unvalidated (no monitor-capable adapter on the dev box); logic and guaranteed teardown verified with the real wired-guard path and a mocked enable/capture/disable orchestration.