### PR TITLE
PCAP monitor capture: channel-hop by default for a real survey

### DIFF
--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -1928,7 +1928,9 @@ There are **three ways to feed it a capture**, all landing on the same analysis
 
    **📡 Monitor mode** (Wi-Fi adapters only) — tick it to capture raw **802.11**
    instead of the adapter's own managed traffic: beacons, deauth/disassoc, and
-   nearby devices' frames, with an optional **channel** to park on. Ragnar flips
+   nearby devices' frames. Leave **channel** blank to **sweep** 2.4/5 GHz
+   (hops 1/6/11 + common 5 GHz channels for a broad survey), or set a channel to
+   **park** there and focus on one AP. Ragnar flips
    the radio into monitor mode via the same primitive the Wi-Fi Defense tools use
    (a separate `ragmon0` vif where the driver allows it, otherwise switching the
    adapter itself) and **always restores it afterward**. The resulting 802.11

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -14243,6 +14243,23 @@ def _pcap_zero_note(iface, seconds):
     return base + ' — wrong interface, the cable is down, or the filter matched nothing.'
 
 
+# A broad 2.4 + 5 GHz sweep for monitor-mode surveys (non-overlapping 2.4 GHz +
+# common 5 GHz UNII channels). Channels the adapter can't tune just fail the `iw`
+# call harmlessly, so a 2.4-only card still works — it only dwells on 1/6/11.
+_PCAP_HOP_CHANNELS = [1, 6, 11, 36, 40, 44, 48, 149, 153, 157, 161]
+
+
+def _channel_hop(iface, stop, dwell=0.35):
+    """Round-robin the monitor interface across channels until `stop` is set, so a
+    survey capture sees APs/traffic on every band instead of one parked channel."""
+    i = 0
+    while not stop.is_set():
+        ch = _PCAP_HOP_CHANNELS[i % len(_PCAP_HOP_CHANNELS)]
+        _run(['iw', 'dev', iface, 'set', 'channel', str(ch)], timeout=3)
+        i += 1
+        stop.wait(dwell)
+
+
 def do_pcap_capture(interface=None, seconds=10, bpf=None, max_seconds=60,
                     monitor=False, channel=None):
     """Record live traffic on `interface` for `seconds` into a saved pcap (kept in
@@ -14252,9 +14269,10 @@ def do_pcap_capture(interface=None, seconds=10, bpf=None, max_seconds=60,
 
     With ``monitor=True`` on a Wi-Fi interface, flip the adapter into monitor
     mode (via wifi_defense.enable_monitor — a separate vif where the driver
-    allows it, else switching the adapter) and capture raw 802.11 with radiotap,
-    optionally parked on ``channel``. Monitor mode is always torn down afterward,
-    restoring the managed link."""
+    allows it, else switching the adapter) and capture raw 802.11 with radiotap.
+    With a ``channel`` it parks there (focus on one AP); with no channel it
+    channel-hops across 2.4/5 GHz for a broad survey. Monitor mode is always torn
+    down afterward, restoring the managed link."""
     if not _have('tcpdump'):
         return {'success': False, 'missing_tool': 'tcpdump',
                 'error': 'tcpdump is not installed. Click Install to add it.'}
@@ -14309,6 +14327,15 @@ def do_pcap_capture(interface=None, seconds=10, bpf=None, max_seconds=60,
             except (ValueError, TypeError):
                 channel = None       # ignore a non-numeric channel
 
+    # No fixed channel on a monitor capture → sweep channels so the survey isn't
+    # stuck on one (which is why a parked capture only sees a few beacons).
+    hop_stop = hop_thread = None
+    if monitor and not channel:
+        hop_stop = threading.Event()
+        hop_thread = threading.Thread(target=_channel_hop, args=(cap_iface, hop_stop),
+                                      daemon=True)
+        hop_thread.start()
+
     try:
         # -U writes each packet as it arrives, so the file is a valid pcap even
         # though we stop tcpdump by killing it at the time window (it never
@@ -14326,6 +14353,10 @@ def do_pcap_capture(interface=None, seconds=10, bpf=None, max_seconds=60,
         except Exception as exc:     # pragma: no cover - defensive
             return {'success': False, 'error': 'capture failed: %s' % exc}
     finally:
+        if hop_stop:                 # stop the channel hopper before teardown
+            hop_stop.set()
+            if hop_thread:
+                hop_thread.join(timeout=2)
         if mon_state:                # always restore the managed link
             try:
                 import wifi_defense
@@ -14345,14 +14376,20 @@ def do_pcap_capture(interface=None, seconds=10, bpf=None, max_seconds=60,
         out['interface'] = interface
         out['seconds'] = seconds
         out['monitor'] = bool(monitor)
+        if monitor:
+            out['channel_mode'] = ('parked ch %s' % channel) if channel else 'swept 2.4/5 GHz'
         if warning:
             out['monitor_warning'] = warning
         if out.get('success') and not (out.get('summary') or {}).get('packets'):
-            if monitor:
-                out['note'] = ('Monitor capture saw 0 frames in %ds%s — the radio may '
-                               'be on a channel with no nearby APs. Set a channel with '
-                               'active traffic and retry.'
-                               % (seconds, (' on ch %s' % channel) if channel else ''))
+            if monitor and channel:
+                out['note'] = ('Monitor capture saw 0 frames in %ds on ch %s — no nearby '
+                               'AP/traffic on that channel. Try leaving the channel blank '
+                               'to sweep all channels.' % (seconds, channel))
+            elif monitor:
+                out['note'] = ('Monitor capture saw 0 frames in %ds while sweeping — no '
+                               '802.11 in range, or the adapter could not tune any channel. '
+                               'Check the antenna and that the card supports monitor mode.'
+                               % seconds)
             else:
                 out['note'] = _pcap_zero_note(interface, seconds)
     return out

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -1911,9 +1911,9 @@
                         </div>
                         <div class="flex flex-wrap items-center gap-3 mt-2">
                             <label class="flex items-center gap-2 text-sm text-gray-400" title="Wi-Fi only: flip the adapter into monitor mode and capture raw 802.11 (beacons, deauths, nearby devices), then restore it. Best with a dedicated adapter like an Alfa — it drops that card's normal Wi-Fi link during the capture."><input id="pcap-cap-monitor" type="checkbox" onchange="document.getElementById('pcap-cap-chan-wrap').classList.toggle('hidden', !this.checked)" class="accent-Ragnar-500"> 📡 Monitor mode <span class="text-gray-600">(sniff 802.11, Wi-Fi adapter only)</span></label>
-                            <label id="pcap-cap-chan-wrap" class="hidden text-sm text-gray-400">Channel <span class="text-gray-600">(optional)</span> <input id="pcap-cap-chan" type="number" min="1" max="196" placeholder="e.g. 6" class="ml-1 w-20 bg-slate-800 border border-slate-700 rounded px-2 py-1 text-sm text-gray-300"></label>
+                            <label id="pcap-cap-chan-wrap" class="hidden text-sm text-gray-400" title="Leave blank to sweep 2.4/5 GHz channels (survey of everything nearby). Set a channel to park there and focus on one AP.">Channel <span class="text-gray-600">(blank = sweep all)</span> <input id="pcap-cap-chan" type="number" min="1" max="196" placeholder="sweep" class="ml-1 w-20 bg-slate-800 border border-slate-700 rounded px-2 py-1 text-sm text-gray-300"></label>
                         </div>
-                        <p class="text-xs text-gray-500 mt-2">Records passively with tcpdump, then analyzes the result. The file is saved under Ragnar, so it also shows up in “Open stored pcap”. Monitor mode needs a Wi-Fi adapter that supports it and briefly takes that card off its network.</p>
+                        <p class="text-xs text-gray-500 mt-2">Records passively with tcpdump, then analyzes the result. The file is saved under Ragnar, so it also shows up in “Open stored pcap”. Monitor mode needs a Wi-Fi adapter that supports it and briefly takes that card off its network; leave the channel blank to sweep all channels, or set one to focus on a single AP.</p>
                     </div>
                     <div id="pcap-panel" class="hidden mt-3 text-sm"></div>
                     <div id="pcap-results" class="hidden mt-3 text-sm"></div>
@@ -7443,7 +7443,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260802-pcap-analyzing"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260802-pcap-chanhop"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -5515,8 +5515,9 @@ function renderPcapResults(d, out) {
         ${exItems ? '<ul class="space-y-0.5 text-sm">' + exItems + '</ul>' : '<p class="text-sm text-gray-500">No expert findings.</p>'}`;
 
     // Where this capture came from (live capture / stored file), and any note.
+    const capMode = d.monitor ? ` · 📡 monitor (${escapeHtml(d.channel_mode || '802.11')})` : '';
     const srcNote = d.captured_name
-        ? `<p class="text-xs text-green-400 mb-2">🎥 Captured <span class="font-mono">${escapeHtml(d.captured_name)}</span> on ${escapeHtml(d.interface || '')} for ${d.seconds || ''}s — saved to Ragnar (see “Open stored pcap”).</p>`
+        ? `<p class="text-xs text-green-400 mb-2">🎥 Captured <span class="font-mono">${escapeHtml(d.captured_name)}</span> on ${escapeHtml(d.interface || '')} for ${d.seconds || ''}s${capMode} — saved to Ragnar (see “Open stored pcap”).</p>`
         : (d.source_name ? `<p class="text-xs text-gray-400 mb-2">📁 <span class="font-mono">${escapeHtml(d.source_name)}</span></p>` : '');
     const note = d.note ? `<p class="text-xs text-amber-300 mb-2">${escapeHtml(d.note)}</p>` : '';
     const monWarn = d.monitor_warning ? `<p class="text-xs text-amber-300 mb-2">📡 ${escapeHtml(d.monitor_warning)}</p>` : '';


### PR DESCRIPTION
A parked monitor capture only sees the few beacons on one channel (the user got 57 frames in 30s). Default to sweeping instead:

- No channel set -> a background hopper round-robins the monitor vif across 2.4 + common 5 GHz channels (1/6/11/36/40/44/48/149/153/157/161, ~0.35s dwell) for the capture window, so the survey sees APs/traffic on every band. A channel set still parks there to focus on one AP. Channels the card can't tune fail harmlessly, so a 2.4-only adapter just dwells 1/6/11.
- Hopper is a daemon thread, always stopped in the finally before monitor teardown.
- Response carries channel_mode ('swept 2.4/5 GHz' / 'parked ch N'), shown in the capture header; 0-frame note now suggests sweeping. UI: channel field labeled 'blank = sweep all'.

Verified with mocks: sweep hops 1/6/11, park sets only the chosen channel, monitor always torn down.