### PR TITLE
pwnagotchi: verify runtime before claiming reinstall success

### DIFF
--- a/docs/PWNAGOTCHI.md
+++ b/docs/PWNAGOTCHI.md
@@ -74,12 +74,23 @@ all-or-nothing:
 | `config.toml` | `/etc/pwnagotchi/config.toml` present |
 | launcher wrapper | `/usr/bin/pwnagotchi-launcher` present and executable |
 | pwnagotchi executable | real `pwnagotchi` binary resolvable |
+| pwnagotchi + pydrive2 import | `import pwnagotchi, pydrive2` succeeds in a clean interpreter (the launcher will start instead of exit-coding) |
 
 Each row shows ✓ / ✗. The badge reflects three states:
 
 - **Healthy** — everything present.
 - **Needs Repair** (red) — a *critical* piece is missing: the clone, service unit,
-  `config.toml`, launcher wrapper, or the executable.
+  `config.toml`, launcher wrapper, the executable, or the **runtime import**.
+
+> **Why the runtime-import row exists:** the pip steps in the installer all swallow
+> their own errors so a flaky network never aborts an install. The cost was that a
+> reinstall could report success while the `pwnagotchi` package or its crash-on-start
+> dependency `pydrive2` never actually landed — the service is launched on demand, so
+> the breakage only surfaced as an exit code (status=127 for a missing binary, status=1
+> for a missing import) the moment you swapped. The installer now **verifies the runtime
+> before claiming success** (and fails with the real cause otherwise), and this row keeps
+> the dashboard honest so a half-installed box shows *Needs Repair* rather than a green
+> badge that exit-codes on launch.
 - **Degraded** (amber) — only recommended pieces are missing (git metadata, or the
   service `ExecStart` no longer points at the launcher). Pwnagotchi still runs, but
   updates or the MANU/AUTO flags may not work.

--- a/scripts/install_pwnagotchi.sh
+++ b/scripts/install_pwnagotchi.sh
@@ -711,6 +711,64 @@ if ! systemctl is-active ragnar >/dev/null 2>&1; then
     systemctl start ragnar
 fi
 
+# -------------------------------------------------------------------
+# RUNTIME VERIFICATION (must pass before we claim success)
+# -------------------------------------------------------------------
+# The pip steps above all swallow their own errors (|| true / || echo) so a
+# flaky network or a failed build never aborts the install. That is deliberate
+# — but it means the installer used to march straight to "installed" even when
+# the pwnagotchi package or a hard dependency never actually landed. The service
+# is disabled and launched on demand, so the breakage stayed invisible until the
+# user swapped to Pwnagotchi and the launcher exec'd a binary that either does
+# not exist (status=127) or crashes on a missing import like pydrive2 (status=1).
+#
+# Verify here exactly what the service will need at launch, and fail honestly
+# with the real cause instead of reporting a success that exit-codes on start.
+echo "[INFO] Verifying Pwnagotchi runtime..."
+write_status "installing" "Verifying Pwnagotchi runtime" "verify"
+
+verify_errors=()
+
+# 1. The pwnagotchi package must import (this is what the launcher runs).
+if ! import_err="$(python3 -c 'import pwnagotchi' 2>&1)"; then
+    verify_errors+=("pwnagotchi package does not import: ${import_err##*$'\n'}")
+fi
+
+# 2. pydrive2 is a hard dependency — pwnagotchi crashes on start without it.
+if ! python3 -c 'import pydrive2' 2>/dev/null; then
+    verify_errors+=("pydrive2 is missing (pwnagotchi crashes on start without it). Reinstall: sudo PIP_CONFIG_FILE=/dev/null pip3 install --break-system-packages --ignore-installed --index-url https://pypi.org/simple pydrive2")
+fi
+
+# 3. The real binary the launcher execs must exist and be executable. Mirror the
+#    launcher's own resolution: any pwnagotchi entry point that is NOT our shim.
+pwn_binary=""
+for candidate in "$(command -v pwnagotchi 2>/dev/null || true)" /usr/local/bin/pwnagotchi /usr/bin/pwnagotchi; do
+    if [[ -n "$candidate" && -x "$candidate" && "$candidate" != "/usr/bin/pwnagotchi-launcher" ]]; then
+        pwn_binary="$candidate"
+        break
+    fi
+done
+if [[ -z "$pwn_binary" ]]; then
+    verify_errors+=("pwnagotchi executable was not created (pip install -e . likely failed). The service would exit with status=127 on start.")
+fi
+
+if [[ ${#verify_errors[@]} -gt 0 ]]; then
+    # Drop the generic ERR handler so our specific status message is the one that
+    # reaches pwnagotchi_status.json / the dashboard, not "Installation failed".
+    trap - ERR
+    echo "[ERROR] Pwnagotchi runtime verification FAILED:"
+    for e in "${verify_errors[@]}"; do
+        echo "[ERROR]   - $e"
+    done
+    # Keep the message single-line + JSON-safe for the status file / dashboard.
+    fail_msg="Install incomplete: ${verify_errors[0]//\"/}"
+    write_status "error" "${fail_msg} Check ${LOG_FILE}." "verify"
+    echo "[ERROR] Not marking as installed — the service would exit-code on launch."
+    echo "[ERROR] Full log: ${LOG_FILE}"
+    exit 1
+fi
+echo "[INFO] Runtime verification passed (binary: ${pwn_binary})"
+
 write_status "installed" "Pwnagotchi installed successfully. Use Ragnar dashboard to launch." "complete"
 echo "[INFO] =========================================="
 echo "[INFO] Installation complete!"

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -4415,6 +4415,7 @@ _PWN_COMPONENT_SPEC = (
     ('config_file', '/etc/pwnagotchi/config.toml', True),
     ('launcher', 'pwnagotchi-launcher wrapper', True),
     ('binary', 'pwnagotchi executable', True),
+    ('runtime', 'pwnagotchi + pydrive2 import (launches without exit-code)', True),
 )
 
 
@@ -4427,6 +4428,11 @@ def _pwnagotchi_component_health() -> dict:
     """
     repo_dir = os.path.isdir(PWN_REPO_PATH)
     launcher_ok = os.path.isfile(PWN_LAUNCHER_PATH) and os.access(PWN_LAUNCHER_PATH, os.X_OK)
+    binary_ok = _resolve_pwnagotchi_binary() is not None
+    # Only probe the runtime once the binary exists — a missing binary is already
+    # a critical failure, and skipping the import subprocess in that case avoids a
+    # guaranteed-failing (and slow) probe on a half-installed box.
+    runtime_ok = _pwn_runtime_import_ok()[0] if binary_ok else False
     components = {
         'repo_dir': repo_dir,
         'repo_git': repo_dir and os.path.isdir(os.path.join(PWN_REPO_PATH, '.git')),
@@ -4434,7 +4440,8 @@ def _pwnagotchi_component_health() -> dict:
         'service_launcher': _pwn_service_execstart_ok(),
         'config_file': os.path.exists(PWN_CONFIG_FILE),
         'launcher': launcher_ok,
-        'binary': _resolve_pwnagotchi_binary() is not None,
+        'binary': binary_ok,
+        'runtime': runtime_ok,
     }
 
     labels = {key: label for key, label, _critical in _PWN_COMPONENT_SPEC}
@@ -4796,6 +4803,44 @@ def _resolve_pwnagotchi_binary() -> Optional[str]:
         if candidate and candidate != PWN_LAUNCHER_PATH and os.path.exists(candidate):
             return candidate
     return None
+
+
+# The pwnagotchi binary existing on disk does NOT mean it will start: a reinstall
+# whose pip step half-failed can leave the entry-point script in place while the
+# package or its crash-on-start dependency (pydrive2) never imports. The service
+# is launched on demand, so that only surfaces as an exit code the moment the user
+# swaps. Probe it the same way the launcher will — a clean-interpreter import —
+# and cache it: this runs on every status poll and a subprocess import per poll
+# would hammer a Pi Zero, while the result only changes across an install/repair.
+_PWN_RUNTIME_CACHE = {'ts': 0.0, 'ok': None, 'detail': ''}
+_PWN_RUNTIME_TTL = 30.0  # seconds
+
+
+def _invalidate_pwn_runtime_cache() -> None:
+    _PWN_RUNTIME_CACHE.update(ts=0.0, ok=None, detail='')
+
+
+def _pwn_runtime_import_ok() -> Tuple[bool, str]:
+    """(ok, detail) — whether `import pwnagotchi, pydrive2` succeeds in a fresh
+    interpreter, i.e. whether the launcher will actually start rather than exit
+    with a status code. Cached for _PWN_RUNTIME_TTL seconds."""
+    now = time.monotonic()
+    if _PWN_RUNTIME_CACHE['ok'] is not None and (now - _PWN_RUNTIME_CACHE['ts']) < _PWN_RUNTIME_TTL:
+        return _PWN_RUNTIME_CACHE['ok'], _PWN_RUNTIME_CACHE['detail']
+    ok, detail = True, ''
+    try:
+        proc = subprocess.run(
+            ['python3', '-c', 'import pwnagotchi, pydrive2'],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+        if proc.returncode != 0:
+            ok = False
+            err_lines = [l.strip() for l in proc.stderr.splitlines() if l.strip()]
+            detail = err_lines[-1] if err_lines else 'pwnagotchi import failed'
+    except Exception as exc:  # pragma: no cover - best effort
+        ok, detail = False, f'runtime probe failed: {exc}'
+    _PWN_RUNTIME_CACHE.update(ts=now, ok=ok, detail=detail)
+    return ok, detail
 
 
 def _pwn_launcher_script(target: str) -> str:
@@ -12837,6 +12882,10 @@ def install_pwnagotchi_from_dashboard():
                 stderr=subprocess.DEVNULL,
                 start_new_session=True
             )
+            # The install/repair will change what imports — drop the cached probe
+            # so the runtime component reflects the new state on the next poll
+            # instead of showing a stale ✓/✗ for up to _PWN_RUNTIME_TTL seconds.
+            _invalidate_pwn_runtime_cache()
         except Exception as exc:
             logger.error(f"Failed to spawn installer: {exc}")
             return jsonify({'success': False, 'error': f'Failed to start installer: {exc}'}), 500


### PR DESCRIPTION
The reinstall already rewrites pwnagotchi.service every run, so a missing unit was never the problem. The installer's pip steps all swallow their errors (|| true / || echo) so a flaky network never aborts an install -- but it also meant the installer marched to 'installed successfully' even when the pwnagotchi package or its crash-on-start dep pydrive2 never landed. The service is launched on demand, so that only surfaced as a service exit code (status=127 missing binary / status=1 missing import) when the user swapped to Pwnagotchi.

- install_pwnagotchi.sh: add a runtime-verification gate before the final 'installed' status -- import pwnagotchi, import pydrive2, and resolve the real binary. On failure, write an 'error' status with the actual cause and exit 1 instead of reporting a success that exit-codes on launch. Clear the generic ERR trap first so the specific message survives.
- webapp_modern.py: add a cached 'runtime' health component (clean-interp import probe) so the Installation Check reflects a broken runtime and the self-heal can't flip 'error' back to 'installed'; invalidate the cache when an install/repair is spawned.
- docs/PWNAGOTCHI.md: document the runtime-import row and why it exists.