### PR TITLE
pwnagotchi: install undeclared prctl dep so the service stops exit-co…

### DIFF
--- a/docs/PWNAGOTCHI.md
+++ b/docs/PWNAGOTCHI.md
@@ -49,7 +49,14 @@ sudo ./scripts/install_pwnagotchi.sh
 The script:
 
 1. Clones [pwnagotchiworking](https://github.com/PierreGode/pwnagotchiworking) into `/opt/pwnagotchi`
-2. Installs Python dependencies (scapy, flask-cors, gpiozero, etc.)
+2. Installs Python dependencies (scapy, flask-cors, gpiozero, etc.). The package is
+   installed with `--no-deps`, so every runtime dependency is listed explicitly in
+   the installer — including **`python-prctl`** (imported as `prctl` by
+   `pwnagotchi/plugins/__init__.py` but *not* declared in the upstream
+   `pyproject.toml`). Without it every launch dies with
+   `ModuleNotFoundError: No module named 'prctl'` and `pwnagotchi.service`
+   exit-codes in a restart loop, so `libcap-dev`/`gcc` are also installed to build
+   its C extension when no prebuilt wheel is available.
 3. Patches Pillow 10+ compatibility (`ImageFont.getsize` shim)
 4. Detects the WiFi interface for monitor mode
 5. Generates `/usr/bin/monstart` and `/usr/bin/monstop`

--- a/scripts/install_pwnagotchi.sh
+++ b/scripts/install_pwnagotchi.sh
@@ -246,7 +246,7 @@ fi
 # -------------------------------------------------------------------
 packages=(
     git python3 python3-pip python3-setuptools python3-dev python3-venv
-    libpcap-dev libffi-dev libssl-dev libcap2-bin
+    gcc libpcap-dev libffi-dev libssl-dev libcap2-bin libcap-dev
     python3-smbus i2c-tools libglib2.0-dev pkg-config meson
 )
 
@@ -310,7 +310,15 @@ python3 -m pip install \
     --no-deps \
     -e . 2>&1 || true
 
-# Install dependencies separately with fallback to PyPI if piwheels fails
+# Install dependencies separately with fallback to PyPI if piwheels fails.
+# NOTE: we install with --no-deps above, so EVERY runtime dependency must be
+# listed here by hand — pip will not pull the package's own declared deps. And
+# some are needed but NOT declared in pwnagotchiworking's pyproject.toml:
+#   * python-prctl (import name "prctl") is imported unconditionally by
+#     pwnagotchi/plugins/__init__.py but missing from pyproject dependencies.
+#     Without it EVERY launch dies with "ModuleNotFoundError: No module named
+#     'prctl'" — the service exit-codes and restart-loops. It builds against
+#     libcap headers, hence libcap-dev in the apt list above.
 echo "[INFO] Installing Python dependencies..."
 python3 -m pip install \
     --break-system-packages \
@@ -319,7 +327,7 @@ python3 -m pip install \
     PyYAML dbus-python file-read-backwards flask flask-cors flask-wtf \
     gast gpiozero inky numpy pycryptodome python-dateutil requests \
     rpi-lgpio rpi_hardware_pwm scapy setuptools shimmy smbus2 spidev \
-    tomlkit toml tweepy websockets pisugar 2>&1 || true
+    tomlkit toml tweepy websockets pisugar python-prctl 2>&1 || true
 
 # pydrive2 is a hard dependency (pwnagotchi crashes without it).
 # Force PyPI only - piwheels drops connections on large packages like google-api-python-client.
@@ -729,9 +737,12 @@ write_status "installing" "Verifying Pwnagotchi runtime" "verify"
 
 verify_errors=()
 
-# 1. The pwnagotchi package must import (this is what the launcher runs).
-if ! import_err="$(python3 -c 'import pwnagotchi' 2>&1)"; then
-    verify_errors+=("pwnagotchi package does not import: ${import_err##*$'\n'}")
+# 1. Import the exact chain the launcher runs — pwnagotchi.cli pulls in
+#    pwnagotchi.elf → pwnagotchi.plugins, which is where undeclared deps like
+#    prctl bite. A bare `import pwnagotchi` (top package) does NOT touch plugins
+#    and would pass while the service still exit-codes on launch.
+if ! import_err="$(python3 -c 'import pwnagotchi.cli' 2>&1)"; then
+    verify_errors+=("pwnagotchi does not import (the service will exit-code on launch): ${import_err##*$'\n'}")
 fi
 
 # 2. pydrive2 is a hard dependency — pwnagotchi crashes on start without it.

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -4821,16 +4821,18 @@ def _invalidate_pwn_runtime_cache() -> None:
 
 
 def _pwn_runtime_import_ok() -> Tuple[bool, str]:
-    """(ok, detail) — whether `import pwnagotchi, pydrive2` succeeds in a fresh
-    interpreter, i.e. whether the launcher will actually start rather than exit
-    with a status code. Cached for _PWN_RUNTIME_TTL seconds."""
+    """(ok, detail) — whether the launcher will actually start rather than exit
+    with a status code. Imports `pwnagotchi.cli` (the real entry chain, which
+    pulls in pwnagotchi.plugins where undeclared deps like prctl bite — a bare
+    `import pwnagotchi` misses it) plus the crash-on-start dep pydrive2, in a
+    fresh interpreter. Cached for _PWN_RUNTIME_TTL seconds."""
     now = time.monotonic()
     if _PWN_RUNTIME_CACHE['ok'] is not None and (now - _PWN_RUNTIME_CACHE['ts']) < _PWN_RUNTIME_TTL:
         return _PWN_RUNTIME_CACHE['ok'], _PWN_RUNTIME_CACHE['detail']
     ok, detail = True, ''
     try:
         proc = subprocess.run(
-            ['python3', '-c', 'import pwnagotchi, pydrive2'],
+            ['python3', '-c', 'import pwnagotchi.cli, pydrive2'],
             capture_output=True, text=True, timeout=30, check=False,
         )
         if proc.returncode != 0:


### PR DESCRIPTION
…de looping

Users saw pwnagotchi.service restart-loop after reinstall with:
  ModuleNotFoundError: No module named 'prctl'
raised from pwnagotchi/plugins/__init__.py (import prctl).

Root cause: python-prctl is imported unconditionally by the plugin loader but is NOT declared in pwnagotchiworking's pyproject.toml dependencies. The installer installs the package with --no-deps and a hand-maintained dependency list, which also omitted it — so prctl was never installed and no reinstall could fix it. Every launch died in the cli->elf->plugins import chain, status=1, Restart=on-failure looped it.

- install_pwnagotchi.sh: add python-prctl to the pip dependency list, and libcap-dev + gcc to apt so its C extension builds when piwheels has no wheel for the board's Python.
- Verification now imports pwnagotchi.cli (the real launch chain, which pulls in plugins) instead of the bare top package — a bare import misses plugins and would have passed while the service still exit-codes.
- webapp_modern.py: runtime health probe imports pwnagotchi.cli, pydrive2 for the same reason, so the Installation Check catches this class of dep break instead of showing a green badge that loops on launch.
- docs/PWNAGOTCHI.md: document the undeclared prctl dependency.