### PR TITLE
RuSense flasher: fix u.FL antenna checkbox overflow on mobile

### DIFF
--- a/rusense_flasher/index.html
+++ b/rusense_flasher/index.html
@@ -13,8 +13,14 @@
       .prov-fields { display: grid; grid-template-columns: 1fr 1fr; gap: .6rem; margin: .5rem 0 1rem; }
       .prov-fields #prov-port { max-width: 8rem; }
       .prov-fields #prov-node { max-width: 8rem; }
-      .prov-ext-ant { grid-column: 1 / -1; display: flex; align-items: center; gap: .5rem; color: #cdd8e3; font-size: .92rem; cursor: pointer; }
-      .prov-ext-ant input { width: auto; }
+      .prov-ext-ant { grid-column: 1 / -1; display: flex; align-items: flex-start; gap: .5rem; color: #cdd8e3; font-size: .92rem; line-height: 1.35; cursor: pointer; }
+      /* Specific enough to beat ".prov-fields input { width:100% }" (which
+         otherwise stretches the checkbox full-width and shoves the label off
+         the card on mobile). Keep the checkbox its natural size; let the text
+         take the rest and wrap. */
+      .prov-fields .prov-ext-ant input { width: auto; flex: 0 0 auto; margin-top: .15rem; }
+      .prov-ext-ant-text { flex: 1 1 auto; min-width: 0; }
+      .prov-ext-ant .panel-sub { white-space: normal; }
       .prov-fields input {
         width: 100%; box-sizing: border-box; padding: .6rem .7rem; border-radius: 8px;
         border: 1px solid rgba(255,255,255,.18); background: rgba(0,0,0,.25);
@@ -86,7 +92,8 @@
           <input id="prov-port" type="number" value="5005" min="1" max="65535" placeholder="Port" />
           <input id="prov-node" type="number" value="1" min="0" max="255" placeholder="Node ID (0-255, unique per node)" title="Give each node in the mesh a different ID, e.g. 1, 2, 3. Nodes with the same ID collide and only one shows up." />
           <label class="prov-ext-ant" title="Seeed XIAO ESP32-C6 only: drives the on-board RF switch to the external u.FL/IPEX socket at boot. Ignored on other boards. Only helps with an antenna actually attached.">
-            <input id="prov-ext-ant" type="checkbox" /> Use external u.FL antenna <span class="panel-sub">(Seeed XIAO ESP32-C6 only)</span>
+            <input id="prov-ext-ant" type="checkbox" />
+            <span class="prov-ext-ant-text">Use external u.FL antenna <span class="panel-sub">(Seeed XIAO ESP32-C6 only)</span></span>
           </label>
           <p class="prov-hint">⚠️ Give <strong>each node a unique Node ID</strong> (1, 2, 3…). Two nodes sharing an ID collide, so only one shows up in RuSense.</p>
           <p class="prov-hint">📡 Point <strong>every node at the same WiFi access point on one fixed 2.4 GHz channel</strong>. If several routers or a mesh/extenders share one SSID, nodes latch onto different APs, their clocks can't sync, and sensing drops offline. Use a single AP (a dedicated 2.4 GHz SSID served by one router is ideal) and disable auto-channel.</p>


### PR DESCRIPTION
The 'Use external u.FL antenna' label escaped the card on narrow screens: the generic '.prov-fields input { width:100% }' rule (later in source, same specificity) stretched the checkbox full-width, squeezing the label text to ~0 width so it broke one letter per line off the card edge.

Fix: '.prov-fields .prov-ext-ant input' (higher specificity) keeps the checkbox its natural size; wrap the label in .prov-ext-ant-text (flex:1 1 auto; min-width:0) so it takes the remaining width and wraps. align-items:flex-start so a two-line label aligns to the checkbox. Verified at 390px viewport.