### PR TITLE
Mesh: enable IP forwarding when advertising subnet routes

### DIFF
--- a/mesh_manager.py
+++ b/mesh_manager.py
@@ -718,6 +718,8 @@ def join(auth_key, hostname='', tags=None, advertise_routes=None,
         args += ['--advertise-tags', ','.join(tags)]
     if advertise_routes:
         args += ['--advertise-routes', ','.join(advertise_routes)]
+        # A subnet router is useless without IP forwarding — enable it up front.
+        ensure_ip_forwarding()
     if enable_ssh:
         # Tailscale SSH is the out-of-band way back in when Ragnar's own web UI
         # is wedged — the reason to deploy a Pi as a remote hands device at all.
@@ -917,20 +919,66 @@ def _explain_serve_failure(rc, detail, use_https):
     return detail or f'tailscale serve failed (exit {rc}).'
 
 
+FORWARDING_SYSCTL_FILE = '/etc/sysctl.d/99-ragnar-tailscale-forwarding.conf'
+
+
+def ensure_ip_forwarding():
+    """Enable (and persist) IPv4/IPv6 forwarding so this node can actually route
+    for the subnets it advertises.
+
+    A Tailscale subnet router with forwarding OFF is the classic silent failure:
+    `tailscale up --advertise-routes` warns, the route shows in the admin
+    console, peers route to it — and every forwarded packet is dropped. So we
+    turn it on whenever routes are advertised. Best-effort (needs root); returns
+    True on success. AP mode does not use forwarding, so enabling it is safe.
+    """
+    content = ("# Managed by Ragnar — required for Tailscale subnet routing\n"
+               "net.ipv4.ip_forward = 1\n"
+               "net.ipv6.conf.all.forwarding = 1\n")
+    ok = True
+    try:
+        try:
+            existing = open(FORWARDING_SYSCTL_FILE).read()
+        except FileNotFoundError:
+            existing = None
+        if existing != content:
+            with open(FORWARDING_SYSCTL_FILE, 'w') as fh:
+                fh.write(content)
+    except Exception:
+        ok = False
+    # Apply immediately without waiting for a reboot.
+    for key in ('net.ipv4.ip_forward=1', 'net.ipv6.conf.all.forwarding=1'):
+        try:
+            subprocess.run(['sysctl', '-w', key], capture_output=True, timeout=10)
+        except Exception:
+            ok = False
+    return ok
+
+
 def advertise_routes(routes, timeout=30):
     """Advertise LAN subnets so the tailnet can reach the node's local network.
 
     This is what turns a remote Ragnar into a way into the whole site: with the
     route approved in the admin console, every device on the far-side LAN
     becomes addressable by its real IP from anywhere on the tailnet.
+
+    Advertising a route is useless without IP forwarding, so we enable it here
+    (persistently) whenever a non-empty route set is advertised.
     """
     if not installed():
         return False, 'Tailscale is not installed on this node.'
     value = ','.join(routes) if routes else ''
+    fwd_ok = ensure_ip_forwarding() if routes else True
     rc, out, err = _run(['set', f'--advertise-routes={value}'], timeout=timeout)
     invalidate_cache()
     if rc == 0:
-        return True, ('Advertising ' + value) if value else 'Stopped advertising subnet routes.'
+        if not value:
+            return True, 'Stopped advertising subnet routes.'
+        msg = 'Advertising ' + value
+        if not fwd_ok:
+            msg += ' (warning: could not enable IP forwarding — packets may not route)'
+        msg += '. Approve the route in the Tailscale admin console for peers to use it.'
+        return True, msg
     return False, (err or out or f'tailscale set failed (exit {rc}).').strip()
 
 

--- a/update_ragnar.sh
+++ b/update_ragnar.sh
@@ -300,6 +300,26 @@ else
     echo -e "  ${YELLOW}⚠${NC} tcpdump missing — Traffic Analysis tab stays hidden (apt install tcpdump)"
 fi
 
+echo -e "${BLUE}Step 5.4b: Tailscale subnet-router IP forwarding...${NC}"
+# A Ragnar that advertises subnet routes (e.g. an on-site unit that lets an
+# off-site scanner reach the LAN over the tunnel) must have IP forwarding on, or
+# tailscaled silently drops every forwarded packet. The web UI enables this when
+# you advertise a route; this self-heals boxes that were already advertising
+# before that fix. Only touches nodes that ARE advertising — others are left as-is.
+if command -v tailscale >/dev/null 2>&1 && \
+   tailscale debug prefs 2>/dev/null | tr -d ' \n' | grep -q '"AdvertiseRoutes":\["'; then
+    cat > /etc/sysctl.d/99-ragnar-tailscale-forwarding.conf <<'EOF'
+# Managed by Ragnar — required for Tailscale subnet routing
+net.ipv4.ip_forward = 1
+net.ipv6.conf.all.forwarding = 1
+EOF
+    sysctl -w net.ipv4.ip_forward=1 >/dev/null 2>&1 || true
+    sysctl -w net.ipv6.conf.all.forwarding=1 >/dev/null 2>&1 || true
+    echo -e "  ${GREEN}✓${NC} IP forwarding on (this node advertises subnet routes)"
+else
+    echo -e "  ${GREEN}✓${NC} Not a subnet router — IP forwarding left unchanged"
+fi
+
 echo -e "${BLUE}Step 5.5: Restoring local runtime data...${NC}"
 for file in "${PRESERVE_FILES[@]}"; do
     backup_file="$BACKUP_DIR/$(basename $file)"

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -3143,8 +3143,10 @@
                         <input id="mesh-routes-input" type="text" placeholder="10.20.0.0/24, 192.168.50.0/24"
                                class="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm font-mono">
                         <p class="text-[11px] text-gray-500 mt-1">
-                            Makes this unit a way into its whole local network. Routes still need approving
-                            in the admin console.
+                            Makes this unit a way into its whole local network — e.g. an off-site Ragnar can
+                            scan these internal subnets over the tunnel. Ragnar enables IP forwarding
+                            automatically; the routes still need <strong>approving in the Tailscale admin
+                            console</strong> before peers can use them.
                         </p>
                     </div>
                     <div class="md:col-span-2 flex flex-wrap items-center gap-4">


### PR DESCRIPTION
Advertising a Tailscale subnet route is a silent no-op without IP forwarding — tailscaled warns, the route shows in the admin console, peers route to it, and every forwarded packet is dropped. This is exactly the "off-site Pi 5 scans an office-internal service over the tunnel" path (on-site unit = subnet router).

- mesh_manager.ensure_ip_forwarding(): persist net.ipv4.ip_forward=1 + net.ipv6.conf.all.forwarding=1 to /etc/sysctl.d and apply now. Called from advertise_routes() (non-empty) and join() when it advertises routes. The advertise message now also reminds to approve the route in the admin console.
- update_ragnar.sh: self-heal boxes already advertising routes before this fix (only touches nodes that ARE advertising; others left as-is).
- mesh UI note: clarify the off-site-scan use case + that forwarding is auto-on and routes still need admin-console approval.

AP mode doesn't use forwarding, so enabling it is safe. Not added to install (a fresh box isn't advertising yet; the UI enables it when you advertise).