### PR TITLE
install: add Firefox as a required package (ZAP AJAX spider)

### DIFF
--- a/install_ragnar.sh
+++ b/install_ragnar.sh
@@ -322,6 +322,10 @@ package_candidates() {
         dnsmasq) echo "dnsmasq" ;;
         wireless-tools) echo "wireless-tools" ;;
         bridge-utils) echo "bridge-utils" ;;
+        # Debian and Raspberry Pi OS ship the browser as firefox-esr (plain
+        # "firefox" is not a package there); Ubuntu and others use "firefox".
+        # Try ESR first, then fall back so one entry works across suites.
+        firefox) echo "firefox-esr firefox" ;;
         *) echo "$pkg" ;;
     esac
 }
@@ -557,6 +561,10 @@ install_dependencies() {
         "lldpd"
         "ethtool"
         "speedtest-cli"
+        # Firefox powers the ZAP AJAX-spider browser crawl (advanced_vuln_scanner
+        # looks up firefox/firefox-esr at runtime). Resolves to firefox-esr on
+        # Debian/Pi OS via package_candidates.
+        "firefox"
     )
 
     if [ "$IS_ARM" = true ]; then

--- a/update_ragnar.sh
+++ b/update_ragnar.sh
@@ -239,6 +239,19 @@ if [ ${#_missing_optional[@]} -gt 0 ]; then
     echo -e "  ${YELLOW}⚠${NC} Not available in this suite: ${_missing_optional[*]} — the features using them stay disabled"
 fi
 
+# Firefox backs the ZAP AJAX-spider browser crawl (advanced_vuln_scanner looks up
+# firefox/firefox-esr at runtime). Ship it to update-only boxes too. Debian and
+# Pi OS provide it as firefox-esr; try that first, then plain firefox for other
+# suites. Idempotent — skipped when either binary is already present.
+if ! command -v firefox >/dev/null 2>&1 && ! command -v firefox-esr >/dev/null 2>&1; then
+    if DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends firefox-esr >/dev/null 2>&1 \
+       || DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends firefox >/dev/null 2>&1; then
+        echo -e "  ${GREEN}✓${NC} Installed Firefox (ZAP AJAX spider)"
+    else
+        echo -e "  ${YELLOW}⚠${NC} Could not install Firefox — the ZAP AJAX spider falls back to a lighter crawl"
+    fi
+fi
+
 echo -e "${BLUE}Step 5.3: Ensuring recon engine dependencies...${NC}"
 # sslyze (TLS audit), dnspython (DNS recon) and tldextract (domain parsing) back
 # three independent recon_engine features. They are deliberately NOT in


### PR DESCRIPTION
The ZAP AJAX-spider browser crawl in advanced_vuln_scanner looks up firefox/firefox-esr at runtime; ship it as a required dependency so the JS-rendering crawl works out of the box. Debian and Raspberry Pi OS provide the browser as firefox-esr (plain 'firefox' is not a package there), so package_candidates maps firefox -> 'firefox-esr firefox' to resolve across suites. Mirrored into update_ragnar.sh (ESR first, then firefox) so update-only boxes get it too; both paths idempotent.