### PR TITLE
feat(ai): support any OpenAI-compatible base URL (Ollama, LM Studio, vLLM, ...)

### DIFF
--- a/ai_service.py
+++ b/ai_service.py
@@ -39,6 +39,12 @@ class AIService:
         self.enabled = cfg.get("ai_enabled", False)
         self.model = cfg.get("ai_model", "gpt-5.4-nano")
 
+        # Optional: talk to any OpenAI-compatible endpoint (Ollama, LM Studio,
+        # vLLM, LocalAI, ...) instead of OpenAI's own API. Empty string keeps the
+        # original OpenAI behavior. The config key wins; OPENAI_BASE_URL env is a
+        # fallback. When set, an API key becomes optional (local servers ignore it).
+        self.base_url = self._resolve_base_url()
+
         # These must remain for backward compatibility (but not used)
         self.max_tokens = cfg.get("ai_max_tokens")
         self.temperature = cfg.get("ai_temperature")
@@ -64,19 +70,32 @@ class AIService:
     #   INITIALIZATION
     # ===================================================================
 
+    def _resolve_base_url(self) -> str:
+        """OpenAI-compatible endpoint override, or '' to use OpenAI directly.
+
+        Precedence: config `ai_base_url`, then the standard OPENAI_BASE_URL env.
+        """
+        cfg = getattr(self.shared_data, "config", {}) or {}
+        return (cfg.get("ai_base_url") or os.environ.get("OPENAI_BASE_URL") or "").strip()
+
     def _initialize_client(self):
         if not self.enabled:
             return
 
-        if not self.api_token:
-            self.initialization_error = "No OpenAI API key found."
+        if not self.api_token and not self.base_url:
+            self.initialization_error = "No OpenAI API key found (set ai_base_url to use a keyless local endpoint)."
             self.logger.warning(self.initialization_error)
             return
 
         try:
-            self.client = OpenAI(api_key=self.api_token)
+            client_kwargs = {"api_key": self.api_token or "not-needed"}
+            if self.base_url:
+                client_kwargs["base_url"] = self.base_url
+            self.client = OpenAI(**client_kwargs)
             self.initialization_error = None
-            self.logger.info(f"AI Service initialized using model: {self.model}")
+            self.logger.info(
+                f"AI Service initialized using model: {self.model} via {self.base_url or 'OpenAI'}"
+            )
         except Exception as exc:
             self.client = None
             self.initialization_error = f"OpenAI client initialization failed: {exc}"
@@ -86,9 +105,10 @@ class AIService:
     def reload_token(self) -> bool:
         """Refresh the API token from disk and reinitialize the OpenAI client."""
 
-        # Keep enabled flag synced with latest config intent
+        # Keep enabled flag + endpoint synced with latest config intent
         if hasattr(self.shared_data, "config"):
             self.enabled = self.shared_data.config.get("ai_enabled", self.enabled)
+        self.base_url = self._resolve_base_url()
 
         self.api_token = self.env_manager.get_token()
         self.client = None
@@ -98,9 +118,9 @@ class AIService:
             self.logger.info("AI service disabled in config; skipping token reload.")
             return False
 
-        if not self.api_token:
-            self.logger.warning("AI token reload requested but no token present in environment.")
-            self.initialization_error = "No OpenAI API key found."
+        if not self.api_token and not self.base_url:
+            self.logger.warning("AI reload requested but no API key or base URL is configured.")
+            self.initialization_error = "No OpenAI API key found (set ai_base_url to use a keyless local endpoint)."
             return False
 
         self._initialize_client()
@@ -130,10 +150,11 @@ class AIService:
 
     def ensure_ready(self):
         """Lazily initialize the OpenAI client if configuration says AI is enabled."""
-        # Sync enabled state with config in case it changed
+        # Sync enabled state + endpoint with config in case they changed
         if hasattr(self.shared_data, "config"):
             self.enabled = self.shared_data.config.get("ai_enabled", self.enabled)
-        
+        self.base_url = self._resolve_base_url()
+
         if not self.enabled:
             return False
 
@@ -141,18 +162,18 @@ class AIService:
         if self.client is not None and self.initialization_error is None:
             return True
 
-        # Don't keep retrying when we've already recorded a permanent failure
-        # But allow retry if token was added after initial failure
-        if self.initialization_error and self.api_token:
-            # Clear error and retry if we have a token now
+        # Don't keep retrying when we've already recorded a permanent failure,
+        # but allow retry if a token or base URL is now available.
+        if self.initialization_error and (self.api_token or self.base_url):
+            # Clear error and retry now that we have credentials/endpoint
             self.initialization_error = None
 
         # Refresh token from disk if we don't have one yet
         if not self.api_token:
             self.api_token = self.env_manager.get_token()
 
-        if not self.api_token:
-            self.initialization_error = "No OpenAI API key found."
+        if not self.api_token and not self.base_url:
+            self.initialization_error = "No OpenAI API key found (set ai_base_url to use a keyless local endpoint)."
             self.logger.warning(self.initialization_error)
             return False
 

--- a/shared.py
+++ b/shared.py
@@ -835,6 +835,10 @@ class SharedData:
             "ai_enabled": False,
             "openai_api_token": "",
             "ai_model": "gpt-5.4-nano",
+            # Point the AI at any OpenAI-compatible server (Ollama, LM Studio,
+            # vLLM, LocalAI, ...). Leave empty to use OpenAI. When set, the API
+            # key is optional. Example: "http://localhost:11434/v1"
+            "ai_base_url": "",
             "ai_analysis_enabled": True,
             "ai_vulnerability_summaries": True,
             "ai_network_insights": True,

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -7976,12 +7976,14 @@ def _apply_config_update(data):
         shared_data.screen_reversed = normalize_rotation(shared_data.config.get('screen_reversed', 0))
         shared_data.web_screen_reversed = normalize_rotation(shared_data.config.get('web_screen_reversed', 0))
         
-        # Reload AI service if ai_enabled was changed
-        if 'ai_enabled' in data:
+        # Reload AI service if any AI setting changed (enable flag, model, or the
+        # OpenAI-compatible endpoint) so a base-URL/model switch takes effect live.
+        if any(k in data for k in ('ai_enabled', 'ai_base_url', 'ai_model')):
             ai_service = getattr(shared_data, 'ai_service', None)
-            
+            ai_enabled_now = shared_data.config.get('ai_enabled', False)
+
             # If AI service doesn't exist and user enabled it, try to initialize
-            if not ai_service and data['ai_enabled']:
+            if not ai_service and ai_enabled_now:
                 try:
                     shared_data.initialize_ai_service()
                     ai_service = shared_data.ai_service
@@ -7995,7 +7997,7 @@ def _apply_config_update(data):
                     ai_reload_error = str(e)
             # If AI service exists, reload or disable it
             elif ai_service:
-                if data['ai_enabled']:
+                if ai_enabled_now:
                     ai_reload_success = ai_service.reload_token()
                     if not ai_reload_success:
                         ai_reload_error = getattr(ai_service, 'initialization_error', None)


### PR DESCRIPTION
## What

Adds an optional **`ai_base_url`** so Ragnar's AI can talk to any
**OpenAI-compatible** endpoint — Ollama, LM Studio, vLLM, LocalAI, a local
llama.cpp server, etc. — instead of only OpenAI's hosted API.

## Why

Ragnar's `ai_service.py` currently builds `OpenAI(api_key=...)` with no base
URL and hard-requires a key, so there's no supported way to point it at a
self-hosted model. Running the AI locally is attractive for privacy (recon
data never leaves the network) and for offline use. This is a small, opt-in
hook that enables it without changing anything for existing OpenAI users.

## How

- New config key `ai_base_url` (default `""`). Resolution order: `ai_base_url`
  config, then the standard `OPENAI_BASE_URL` env var, else empty.
- When a base URL is set, the API key becomes **optional** — local servers
  ignore it — so the client is built with a `"not-needed"` placeholder and the
  three `"No OpenAI API key found"` guards (`_initialize_client`,
  `reload_token`, `ensure_ready`) are relaxed to accept *either* a key or a
  base URL.
- Changing `ai_base_url` / `ai_model` in the web settings now reloads the AI
  service live, the same way `ai_enabled` already did.

## Backward compatibility

With `ai_base_url` empty and a key present (the default), the code path is
unchanged — same `OpenAI(api_key=...)` client, same behavior.

## Example

```jsonc
// shared_config.json
"ai_enabled": true,
"ai_model": "qwen2.5:7b",
"ai_base_url": "http://localhost:11434/v1"   // Ollama; no API key needed
```

## Testing

- `python3 -m py_compile ai_service.py shared.py webapp_modern.py` — clean.
- Resolver precedence (config > `OPENAI_BASE_URL` > `""`, trimmed) verified.
- Ran the resulting client (base URL + placeholder key) against a local
  Ollama `qwen2.5:7b` over its `/v1` endpoint and got a normal chat completion
  back; default OpenAI path exercised unchanged.

Diffstat: `ai_service.py`, `shared.py`, `webapp_modern.py` — +48 / −21.
