### PR TITLE
Adv Scan: show scan egress (tunnel vs LAN) — confirms ZAP tunnels too

### DIFF
--- a/advanced_vuln_scanner.py
+++ b/advanced_vuln_scanner.py
@@ -141,6 +141,8 @@ class ScanProgress:
     auth_type: str = ""  # Auth type used for this scan (cookie, bearer_token, etc.)
     auth_status: str = ""  # Auth validation status (applied, verified, failed)
     delegated_to: str = ""  # Viking name of the mesh peer running this scan (delegated scans)
+    egress_iface: str = ""  # Interface the scan host routes the target over (e.g. eth0, tailscale0)
+    egress_tunneled: bool = False  # True when that interface is the Tailscale tunnel
     log_entries: List[Dict[str, str]] = field(default_factory=list)  # Buffered scan log entries
 
     def to_dict(self) -> Dict[str, Any]:
@@ -158,6 +160,8 @@ class ScanProgress:
             'auth_type': self.auth_type,
             'auth_status': self.auth_status,
             'delegated_to': self.delegated_to,
+            'egress_iface': self.egress_iface,
+            'egress_tunneled': self.egress_tunneled,
             'duration_seconds': (
                 (self.completed_at or datetime.now()) - self.started_at
             ).total_seconds() if self.started_at else 0
@@ -1080,6 +1084,10 @@ class AdvancedVulnScanner:
             status='pending'
         )
 
+        # Record how this host routes to the target (eth0 vs tailscale0), so a
+        # delegated scan can show whether it actually went through the tunnel.
+        progress.egress_iface, progress.egress_tunneled = self._target_egress(target)
+
         self.active_scans[scan_id] = progress
         self.scan_results[scan_id] = []
         self.scan_history.append(progress)
@@ -1180,6 +1188,11 @@ class AdvancedVulnScanner:
             progress.progress_percent = scan.get('progress_percent', progress.progress_percent)
             progress.current_check = scan.get('current_check', progress.current_check) or progress.current_check
             progress.findings_count = scan.get('findings_count', progress.findings_count)
+            # Mirror the peer's egress so the cockpit can show whether the remote
+            # scan reached the target through the tunnel (tailscale0) or its LAN.
+            if scan.get('egress_iface'):
+                progress.egress_iface = scan['egress_iface']
+                progress.egress_tunneled = bool(scan.get('egress_tunneled'))
             if scan.get('error_message'):
                 progress.error_message = scan['error_message']
             st = scan.get('status')
@@ -1619,6 +1632,36 @@ class AdvancedVulnScanner:
             flags += ['-c', '25', '-rate-limit', str(rate_limit)]
 
         return flags, env, severity, note
+
+    @staticmethod
+    def _target_egress(target: str):
+        """(iface, tunneled) for how THIS host routes to `target`.
+
+        Resolves the host, then `ip route get <ip>` and reads `dev <iface>`, so
+        the UI can show whether a scan actually leaves over the Tailscale tunnel
+        (tailscale0) or the box's own LAN. Scanner-agnostic — it's the OS routing
+        decision, so it's identical for nuclei, ZAP, nmap, etc. Best-effort."""
+        try:
+            import socket
+            import urllib.parse
+            host = (target or '').strip()
+            if '://' in host:
+                host = urllib.parse.urlparse(host).hostname or host
+            else:
+                host = host.split('/')[0].split(':')[0]
+            if not host:
+                return '', False
+            try:
+                ip = socket.gethostbyname(host)
+            except Exception:
+                ip = host  # already an IP, or unresolvable — let ip-route decide
+            out = subprocess.run(['ip', 'route', 'get', ip],
+                                 capture_output=True, text=True, timeout=5).stdout
+            m = re.search(r'\bdev\s+(\S+)', out or '')
+            iface = m.group(1) if m else ''
+            return iface, iface.startswith('tailscale')
+        except Exception:
+            return '', False
 
     @staticmethod
     def _available_mib() -> Optional[int]:

--- a/tests/test_delegated_scan.py
+++ b/tests/test_delegated_scan.py
@@ -56,9 +56,12 @@ def _wait(s, scan_id, want, tries=300):
 def test_delegated_scan_relays_and_ingests_findings():
     s = _scanner()
     script = [
-        {"status": "running", "progress_percent": 30, "findings_count": 0},
-        {"status": "running", "progress_percent": 80, "findings_count": 1},
-        {"status": "completed", "progress_percent": 100, "findings_count": 1},
+        {"status": "running", "progress_percent": 30, "findings_count": 0,
+         "egress_iface": "tailscale0", "egress_tunneled": True},
+        {"status": "running", "progress_percent": 80, "findings_count": 1,
+         "egress_iface": "tailscale0", "egress_tunneled": True},
+        {"status": "completed", "progress_percent": 100, "findings_count": 1,
+         "egress_iface": "tailscale0", "egress_tunneled": True},
     ]
     io = _peer_io(script, [{"severity": "high", "title": "x", "finding_id": "f1"}])
     scan_id = s.start_delegated_scan("http://t", ScanType.NUCLEI, "harald", io)
@@ -70,6 +73,9 @@ def test_delegated_scan_relays_and_ingests_findings():
     p = _wait(s, scan_id, "completed")
     assert p.status == "completed"
     assert p.progress_percent == 100
+    # The peer's egress (tunnelled via tailscale0) is mirrored to the cockpit,
+    # so the operator can confirm the delegated scan went through the tunnel.
+    assert p.egress_iface == "tailscale0" and p.egress_tunneled is True
     # Remote findings were pulled into normal scan_results.
     assert len(s.scan_results[scan_id]) == 1
     # Delegated tracking is cleaned up when done.

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -7511,7 +7511,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260805-config-export2"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260804-scan-egress"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -27253,9 +27253,12 @@ function updateActiveScans(scans, options = {}) {
                      onclick="toggleAdvVulnScanFindings('${scanId}')">
                     <div class="flex items-start justify-between gap-3">
                         <div>
-                            <div class="text-sm font-semibold text-white flex items-center gap-1.5">
+                            <div class="text-sm font-semibold text-white flex items-center gap-1.5 flex-wrap">
                                 ${escapeHtml(formatScanType(scan.scan_type))}
                                 ${scan.delegated_to ? `<span class="text-[10px] px-1.5 py-0.5 rounded-full bg-cyan-900/60 text-cyan-300 font-medium">🛰️ ${escapeHtml(scan.delegated_to)}</span>` : ''}
+                                ${scan.egress_iface ? (scan.egress_tunneled
+                                    ? `<span class="text-[10px] px-1.5 py-0.5 rounded-full bg-emerald-900/60 text-emerald-300 font-medium" title="Reached the target over the Tailscale tunnel (${escapeHtml(scan.egress_iface)})">🔒 tunneled</span>`
+                                    : `<span class="text-[10px] px-1.5 py-0.5 rounded-full bg-slate-700 text-gray-300 font-medium" title="Reached the target directly over ${escapeHtml(scan.egress_iface)}, not the tunnel">↗ ${escapeHtml(scan.egress_iface)}</span>`) : ''}
                             </div>
                             <div class="text-xs text-gray-400 mt-1">${escapeHtml(scan.target || 'Unknown target')}</div>
                         </div>


### PR DESCRIPTION
ZAP delegates and tunnels over Tailscale exactly like nuclei: Ragnar sets no upstream proxy for ZAP, so its HTTP(S) requests use the OS socket stack and follow the routing table — a subnet-routed target goes out tailscale0. Nothing scanner-specific. This makes it verifiable instead of taking it on faith.

- ScanProgress gains egress_iface / egress_tunneled, computed at scan start via `ip route get <resolved target>` (reads `dev <iface>`; tunneled = tailscale*). Scanner-agnostic — same for nuclei, ZAP, nmap, etc.
- The delegation relay mirrors the worker's egress to the cockpit, so a delegated ZAP/nuclei scan shows where it actually left from.
- UI: a "🔒 tunneled" (emerald) or "↗ <iface>" badge on the scan card.
- test covers egress mirrored through the relay. Cache-bust bumped.