### PR TITLE
Adv Scan: ZAP auto-resolves a live web port for bare-host targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ When deployed on systems with 8GB+ RAM, Ragnar automatically unlocks advanced se
 
 ### Advanced Vulnerability Scanning
 - **Pre-flight recon** — Optional reconnaissance phase before ZAP: **port discovery** (parallel TCP connect-scan of common web ports, each classified http/https via a TLS probe), TLS audit, passive DNS subdomain enumeration, and HTTP content discovery. In the handoff gate the operator ticks exactly which discovered `scheme://host:port` URLs, subdomains and paths get fed to ZAP — so a bare IP is scanned on the ports that are *actually* listening instead of blindly defaulting to :80/:443
-- **OWASP ZAP** *(8GB+ RAM)* — Spider + AJAX spider + active scan with automatic browser detection; greys out on smaller boards
+- **OWASP ZAP** *(8GB+ RAM)* — Spider + AJAX spider + active scan with automatic browser detection; greys out on smaller boards. When you give a **bare host with no port**, ZAP now probes common web ports and scans whichever is actually listening (HTTPS-only or alt-port services included) instead of assuming :80 and failing — the same auto-resolution applies to **delegated mesh scans**, where the probe runs from the delegate's network vantage
 - **Authenticated scanning** — 8 auth types: form-based, HTTP Basic, OAuth2, Bearer Token, API Key, Cookie, Script-based
 - **Nuclei** — 5000+ vulnerability templates from ProjectDiscovery; if the binary isn't present the scanner card shows a **⤓ Install** button that fetches the right build for your board (templates download automatically after)
 - **Nikto** — Comprehensive web server assessment

--- a/advanced_vuln_scanner.py
+++ b/advanced_vuln_scanner.py
@@ -1086,6 +1086,11 @@ class AdvancedVulnScanner:
             elif t:
                 t = 'http://' + t
             target = t
+            # If no explicit port was given, probe for a live web port so ZAP
+            # scans the service that's actually listening instead of assuming
+            # :80 and hard-failing on an HTTPS-only or alt-port host. Skipped
+            # for nmap (raw host) by the scan_type guard above.
+            target = self._resolve_web_target(target)
 
         with self._lock:
             self._scan_counter += 1
@@ -2671,6 +2676,94 @@ class AdvancedVulnScanner:
 
         # Other HTTP errors
         return f"ZAP API error {code}: {error_detail[:200] if error_detail else 'Unknown error'}"
+
+    # Common web ports probed when the operator gives a bare host with NO explicit
+    # port. ZAP hard-validates reachability and would otherwise assume :80 and fail
+    # on a host that only serves HTTPS or runs on an alt port (Nuclei never
+    # validated, which is why it "worked" where ZAP didn't). Ordered by preference.
+    _WEB_PROBE_PORTS = (80, 443, 8080, 8443, 8000, 8888, 8081, 3000, 5000,
+                        9443, 9090, 8090, 8008, 8181)
+
+    def _probe_web_port(self, host: str, port: int, timeout: float = 2.0):
+        """Return (open: bool, scheme: str) for host:port — https if a TLS
+        handshake succeeds (self-signed tolerated), else http if the raw TCP
+        connect succeeds."""
+        import ssl
+        try:
+            raw = socket.create_connection((host, port), timeout=timeout)
+        except Exception:
+            return False, ""
+        try:
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            server_hostname = None
+            try:
+                socket.inet_aton(host)
+            except OSError:
+                server_hostname = host  # SNI only for real hostnames
+            tls = ctx.wrap_socket(raw, server_hostname=server_hostname)
+            tls.close()
+            return True, "https"
+        except Exception:
+            try:
+                raw.close()
+            except Exception:
+                pass
+            return True, "http"
+
+    def _resolve_web_target(self, target: str) -> str:
+        """When `target` is a URL with no explicit port, probe common web ports
+        and rewrite it to a scheme://host[:port] that is actually listening, so
+        ZAP scans the live service instead of blindly defaulting to :80.
+
+        Respects an explicit port (returns unchanged). Returns the original
+        target unchanged if nothing is reachable (validation then reports the
+        clear per-port error)."""
+        try:
+            parsed = urllib.parse.urlparse(target)
+        except Exception:
+            return target
+        if not parsed.netloc or parsed.port:
+            return target  # no host, or operator pinned a port — respect it
+        host = parsed.netloc.split(':')[0].strip('[]')
+        if not host:
+            return target
+
+        import concurrent.futures
+        found = {}
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(self._WEB_PROBE_PORTS)) as ex:
+            futs = {ex.submit(self._probe_web_port, host, p): p
+                    for p in self._WEB_PROBE_PORTS}
+            for fut in concurrent.futures.as_completed(futs, timeout=6):
+                p = futs[fut]
+                try:
+                    ok, scheme = fut.result()
+                except Exception:
+                    ok, scheme = False, ""
+                if ok:
+                    found[p] = scheme
+        if not found:
+            return target  # nothing listening — let validation explain
+
+        # Prefer the scheme the operator implied (bare IP -> http), then the
+        # other canonical port, then the lowest-numbered open port.
+        implied = (parsed.scheme or 'http').lower()
+        order = [80, 443] if implied == 'http' else [443, 80]
+        chosen_port = next((p for p in order if p in found),
+                           min(found.keys()))
+        scheme = found[chosen_port]
+        rest = parsed.path or ''
+        if parsed.query:
+            rest += '?' + parsed.query
+        if (scheme == 'http' and chosen_port == 80) or (scheme == 'https' and chosen_port == 443):
+            resolved = f"{scheme}://{host}{rest}"
+        else:
+            resolved = f"{scheme}://{host}:{chosen_port}{rest}"
+        if resolved != target:
+            logger.info(f"[TARGET-RESOLVE] {target} -> {resolved} "
+                        f"(open web ports: {sorted(found)})")
+        return resolved
 
     def _validate_target_url(self, target: str) -> Tuple[bool, str]:
         """Validate that a target URL is properly formatted and potentially reachable"""

--- a/tests/test_zap_target_resolve.py
+++ b/tests/test_zap_target_resolve.py
@@ -1,0 +1,94 @@
+"""Target port-resolution for ZAP scans.
+
+ZAP hard-validates reachability and would assume :80 for a bare host, failing
+on an HTTPS-only or alt-port service where Nuclei (which never validated) just
+runs. `_resolve_web_target` probes common web ports and rewrites the target to
+a port that's actually listening.
+"""
+from __future__ import annotations
+
+import sys
+import os
+import socket
+import threading
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _make_scanner():
+    from advanced_vuln_scanner import AdvancedVulnScanner
+    return AdvancedVulnScanner.__new__(AdvancedVulnScanner)
+
+
+def _listener(port_hint=0):
+    srv = socket.socket()
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", port_hint))
+    srv.listen(4)
+    port = srv.getsockname()[1]
+    stop = threading.Event()
+
+    def loop():
+        srv.settimeout(0.4)
+        while not stop.is_set():
+            try:
+                c, _ = srv.accept()
+                c.close()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+    threading.Thread(target=loop, daemon=True).start()
+    return srv, port, stop
+
+
+def test_resolves_bare_host_to_live_alt_port():
+    s = _make_scanner()
+    srv, port, stop = _listener()
+    s._WEB_PROBE_PORTS = (80, port)
+    try:
+        out = s._resolve_web_target("http://127.0.0.1")
+    finally:
+        stop.set()
+        srv.close()
+    assert out == f"http://127.0.0.1:{port}"
+
+
+def test_respects_explicit_port():
+    s = _make_scanner()
+    # Even if nothing is listening, an operator-pinned port is left untouched.
+    assert s._resolve_web_target("http://127.0.0.1:9999") == "http://127.0.0.1:9999"
+
+
+def test_leaves_target_unchanged_when_nothing_listening():
+    s = _make_scanner()
+    # A port range that (almost certainly) has nothing bound on loopback.
+    s._WEB_PROBE_PORTS = (7, 9)
+    assert s._resolve_web_target("http://127.0.0.1") == "http://127.0.0.1"
+
+
+def test_prefers_canonical_80_when_multiple_open():
+    s = _make_scanner()
+    srv80, p80, stop80 = _listener(80) if os.geteuid() == 0 else (None, None, None)
+    srv_alt, p_alt, stop_alt = _listener()
+    try:
+        if srv80 is None:
+            # Can't bind :80 without privileges — just assert alt-port resolution.
+            s._WEB_PROBE_PORTS = (p_alt,)
+            assert s._resolve_web_target("http://127.0.0.1") == f"http://127.0.0.1:{p_alt}"
+        else:
+            s._WEB_PROBE_PORTS = (80, p_alt)
+            # 80 is canonical for http -> no :port suffix
+            assert s._resolve_web_target("http://127.0.0.1") == "http://127.0.0.1"
+    finally:
+        if stop_alt:
+            stop_alt.set()
+        srv_alt and srv_alt.close()
+        if stop80:
+            stop80.set()
+        srv80 and srv80.close()
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Only the ZAP runners call _validate_target_url, which hard-failed a bare host on :80 while Nuclei (no validation) ran — so a HTTPS-only or alt-port target reported 'Cannot connect to <host>:80' under ZAP but scanned fine under Nuclei. start_scan now probes common web ports (parallel, http/https classified via a TLS handshake) and rewrites a portless target to a scheme://host[:port] that is actually listening; explicit ports are respected and an unreachable target is left for validation to explain.

Delegated mesh scans call start_scan on the peer, so the probe runs from the delegate's network vantage — correct for on-site-only targets.