### PR TITLE
Dashboard AI insights: parallelize calls + stop silent hang

### DIFF
--- a/ai_service.py
+++ b/ai_service.py
@@ -782,11 +782,6 @@ Keep it tight and practical."""
             output["message"] = self.initialization_error or "AI disabled"
             return output
 
-        # Passive-monitoring posture (Watchtower + Wi-Fi Defense), if supplied by
-        # the caller — the route gathers it since the aggregator lives there.
-        if posture is not None:
-            output["posture_analysis"] = self.analyze_security_posture(posture)
-
         net = {
             "target_count": self.shared_data.targetnbr,
             "port_count": self.shared_data.portnbr,
@@ -794,22 +789,39 @@ Keep it tight and practical."""
             "credential_count": self.shared_data.crednbr,
         }
 
-        # Summary
-        output["network_summary"] = self.analyze_network_summary(net)
+        # Assemble the independent analyses as callables, then run them
+        # CONCURRENTLY. Each is its own OpenAI round-trip (~4-6s); running the
+        # four back-to-back made the dashboard's insights card take ~18s cold,
+        # which read as "never loads" (and could trip proxy timeouts). Fan them
+        # out so the whole call costs about the slowest single request instead.
+        tasks = {"network_summary": lambda: self.analyze_network_summary(net)}
+
+        # Passive-monitoring posture (Watchtower + Wi-Fi Defense), if supplied by
+        # the caller — the route gathers it since the aggregator lives there.
+        if posture is not None:
+            tasks["posture_analysis"] = lambda: self.analyze_security_posture(posture)
 
         # Additional analyses if intelligence system is available
         if hasattr(self.shared_data, "network_intelligence") and \
            self.shared_data.network_intelligence:
-
             findings = self.shared_data.network_intelligence.get_active_findings_for_dashboard()
-
             vulns = list(findings.get("vulnerabilities", {}).values())
             if vulns:
-                output["vulnerability_analysis"] = self.analyze_vulnerabilities(vulns)
-
                 creds = list(findings.get("credentials", {}).values())
                 combined = vulns + creds
-                output["weakness_analysis"] = self.identify_network_weaknesses(net, combined)
+                tasks["vulnerability_analysis"] = lambda: self.analyze_vulnerabilities(vulns)
+                tasks["weakness_analysis"] = lambda: self.identify_network_weaknesses(net, combined)
+
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(tasks)) as ex:
+            future_key = {ex.submit(fn): key for key, fn in tasks.items()}
+            for fut in concurrent.futures.as_completed(future_key):
+                key = future_key[fut]
+                try:
+                    output[key] = fut.result()
+                except Exception as exc:  # one analysis failing shouldn't sink the rest
+                    self.logger.error(f"AI insight '{key}' failed: {exc}")
+                    output[key] = None
 
         return output
 

--- a/docs/AI_INTEGRATION.md
+++ b/docs/AI_INTEGRATION.md
@@ -93,7 +93,11 @@ Returns AI service status and configuration
 ```
 
 ### GET /api/ai/insights
-Returns comprehensive AI insights
+Returns comprehensive AI insights. The independent analyses (network summary,
+vulnerability, weakness, posture) are generated **concurrently** server-side, so
+a cold call costs about one LLM round-trip (~5–10s) rather than the sum of all
+four; results are cached (1h server-side, 1h client-side). The dashboard card
+shows a loading state and, on timeout/error, a visible Retry rather than hanging.
 ```json
 {
   "enabled": true,

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -7533,7 +7533,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260809-wifi-report-bt-ai"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260809-ai-insights-parallel"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -22859,20 +22859,45 @@ async function loadAIInsights() {
             modelName.textContent = status.model;
         }
         
-        // Load comprehensive insights
+        // Load comprehensive insights. This is several LLM round-trips server
+        // side (parallelized to ~5-10s); show a clear loading state and bound
+        // the wait so a hung request surfaces an error instead of sitting on
+        // "Loading AI analysis..." forever.
         console.log('Fetching fresh AI insights from server...');
-    const insightsResponse = await networkAwareFetch('/api/ai/insights');
-        const insights = await insightsResponse.json();
-        
+        const netSummaryEl = document.getElementById('ai-network-summary');
+        if (netSummaryEl) netSummaryEl.textContent = 'Analyzing… this can take a few seconds.';
+
+        const ctrl = new AbortController();
+        const timer = setTimeout(() => ctrl.abort(), 60000); // 60s hard cap
+        let insights;
+        try {
+            const insightsResponse = await networkAwareFetch('/api/ai/insights', { signal: ctrl.signal });
+            if (!insightsResponse.ok) throw new Error(`HTTP ${insightsResponse.status}`);
+            insights = await insightsResponse.json();
+        } finally {
+            clearTimeout(timer);
+        }
+
         // Cache the insights
         aiInsightsCache.data = insights;
         aiInsightsCache.timestamp = now;
-        
+
         displayAIInsights(insights);
-        
+
     } catch (error) {
         console.error('Error loading AI insights:', error);
-        // Silently fail - don't disrupt the dashboard if AI is unavailable
+        // Don't leave the card stuck on a loading spinner — show what happened
+        // and offer a retry. Cache stays empty so the next load tries again.
+        aiInsightsCache.data = null;
+        aiInsightsCache.timestamp = null;
+        const netSummaryEl = document.getElementById('ai-network-summary');
+        if (netSummaryEl) {
+            const why = error && error.name === 'AbortError'
+                ? 'The AI analysis took too long to respond.'
+                : 'Could not reach the AI service.';
+            netSummaryEl.innerHTML = '<span class="text-amber-400">' + _esc(why) + '</span> '
+                + '<button onclick="refreshAIInsights()" class="ml-1 underline text-purple-300 hover:text-purple-200">Retry</button>';
+        }
     }
 }
 


### PR DESCRIPTION
The dashboard "AI Insights" card often read as "never loads": generate_insights made four sequential OpenAI round-trips (~18s cold), and the frontend fetch had no timeout and failed silently, so the card sat on "Loading AI analysis..." indefinitely (and long enough to trip proxy timeouts).

- ai_service.generate_insights now fans the four independent analyses (network summary, vulnerability, weakness, posture) out across a thread pool, so a cold call costs ~one round-trip instead of four (measured 18s -> 8s). A single analysis failing no longer sinks the rest.
- loadAIInsights shows a clear loading state, bounds the wait with a 60s AbortController, and on error/timeout renders a visible message + Retry button instead of silently leaving the spinner; cache stays empty so a retry re-fetches.
- Bump JS cache-bust; note the behaviour in AI_INTEGRATION.md.