### PR TITLE
Dashboard AI insights: survive shared-key rate limits + per-call timeout

### DIFF
--- a/ai_service.py
+++ b/ai_service.py
@@ -74,7 +74,12 @@ class AIService:
             return
 
         try:
-            self.client = OpenAI(api_key=self.api_token)
+            # Bound every request: the SDK default is 600s, so a single stuck or
+            # rate-limited call (common when several field units share one API
+            # key and each fans out concurrent dashboard calls) would otherwise
+            # hang for minutes — well past any client timeout — instead of
+            # failing fast and letting the rest of the insights render.
+            self.client = OpenAI(api_key=self.api_token, timeout=25.0, max_retries=2)
             self.initialization_error = None
             self.logger.info(f"AI Service initialized using model: {self.model}")
         except Exception as exc:
@@ -812,8 +817,14 @@ Keep it tight and practical."""
                 tasks["vulnerability_analysis"] = lambda: self.analyze_vulnerabilities(vulns)
                 tasks["weakness_analysis"] = lambda: self.identify_network_weaknesses(net, combined)
 
+        # Cap concurrency at 2. Fanning out all four at once cut latency on a
+        # fast box, but when 6 units share one API key that's a 24-wide burst
+        # that trips OpenAI's per-key rate limits — the biggest call (weakness)
+        # loses first, which is exactly the "weakness never loads" report. Two
+        # at a time still roughly halves the sequential time while staying gentle
+        # on the shared key.
         import concurrent.futures
-        with concurrent.futures.ThreadPoolExecutor(max_workers=len(tasks)) as ex:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=min(2, len(tasks))) as ex:
             future_key = {ex.submit(fn): key for key, fn in tasks.items()}
             for fut in concurrent.futures.as_completed(future_key):
                 key = future_key[fut]
@@ -822,6 +833,13 @@ Keep it tight and practical."""
                 except Exception as exc:  # one analysis failing shouldn't sink the rest
                     self.logger.error(f"AI insight '{key}' failed: {exc}")
                     output[key] = None
+
+        # Tell the UI which analyses were attempted and which of those came back
+        # empty (failed/rate-limited) — so it can show "temporarily unavailable +
+        # retry" for a genuine failure instead of a permanent "Analyzing…", and
+        # distinguish that from a section that simply had nothing to report.
+        output["attempted"] = list(tasks.keys())
+        output["failed"] = [k for k in tasks if not output.get(k)]
 
         return output
 

--- a/docs/AI_INTEGRATION.md
+++ b/docs/AI_INTEGRATION.md
@@ -94,10 +94,15 @@ Returns AI service status and configuration
 
 ### GET /api/ai/insights
 Returns comprehensive AI insights. The independent analyses (network summary,
-vulnerability, weakness, posture) are generated **concurrently** server-side, so
-a cold call costs about one LLM round-trip (~5–10s) rather than the sum of all
-four; results are cached (1h server-side, 1h client-side). The dashboard card
-shows a loading state and, on timeout/error, a visible Retry rather than hanging.
+vulnerability, weakness, posture) are generated **concurrently** server-side
+(capped at 2 in flight so several units sharing one API key don't trip OpenAI's
+per-key rate limits), each with a 25s per-request timeout so a stuck/rate-limited
+call fails fast instead of hanging. Results are cached (1h server-side; client-
+side 1h on full success, 2min if any analysis failed so it retries soon). The
+response includes `attempted` (which analyses ran) and `failed` (which of those
+came back empty) so the dashboard can show a per-section "Temporarily
+unavailable + Retry" instead of a stuck "Analyzing…". The card also bounds its
+own wait (60s) and surfaces a Retry on timeout/error rather than hanging.
 ```json
 {
   "enabled": true,

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -7533,7 +7533,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260809-ai-insights-parallel"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260809-ai-insights-resilient"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -22878,27 +22878,49 @@ async function loadAIInsights() {
             clearTimeout(timer);
         }
 
-        // Cache the insights
+        // Cache the insights. If some analyses failed (rate-limited on a shared
+        // key, etc.), keep the cache short so it retries soon instead of showing
+        // a half-empty card for the full hour.
         aiInsightsCache.data = insights;
         aiInsightsCache.timestamp = now;
+        aiInsightsCache.ttl = (insights.failed && insights.failed.length) ? 120000 : 3600000;
 
         displayAIInsights(insights);
 
     } catch (error) {
         console.error('Error loading AI insights:', error);
         // Don't leave the card stuck on a loading spinner — show what happened
-        // and offer a retry. Cache stays empty so the next load tries again.
+        // on every section and offer a retry. Cache stays empty so the next
+        // load tries again.
         aiInsightsCache.data = null;
         aiInsightsCache.timestamp = null;
+        const why = error && error.name === 'AbortError'
+            ? 'The AI analysis took too long to respond.'
+            : 'Could not reach the AI service.';
+        const errHtml = '<span class="text-amber-400">' + _esc(why) + '</span> '
+            + '<button onclick="refreshAIInsights()" class="ml-1 underline text-purple-300 hover:text-purple-200">Retry</button>';
         const netSummaryEl = document.getElementById('ai-network-summary');
-        if (netSummaryEl) {
-            const why = error && error.name === 'AbortError'
-                ? 'The AI analysis took too long to respond.'
-                : 'Could not reach the AI service.';
-            netSummaryEl.innerHTML = '<span class="text-amber-400">' + _esc(why) + '</span> '
-                + '<button onclick="refreshAIInsights()" class="ml-1 underline text-purple-300 hover:text-purple-200">Retry</button>';
-        }
+        if (netSummaryEl) netSummaryEl.innerHTML = errHtml;
+        // Clear the other two sections' stale "Analyzing…" placeholders too.
+        const vulnEl = document.getElementById('ai-vuln-summary');
+        if (vulnEl) vulnEl.innerHTML = errHtml;
+        const weakEl = document.getElementById('ai-weakness-summary');
+        if (weakEl) weakEl.innerHTML = errHtml;
     }
+}
+
+// True when the server attempted this analysis but it came back empty (a
+// failure/rate-limit), as opposed to a section that had nothing to report.
+function _aiFieldFailed(insights, key) {
+    return Array.isArray(insights.failed) && insights.failed.includes(key);
+}
+
+// Inline "temporarily unavailable + retry" used for a failed analysis so a
+// rate-limited section shows a clear, actionable state instead of a permanent
+// "Analyzing…" that looks like it's still working.
+function _aiUnavailableHtml() {
+    return '<span class="text-amber-400">Temporarily unavailable.</span> '
+        + '<button onclick="refreshAIInsights()" class="ml-1 underline text-purple-300 hover:text-purple-200">Retry</button>';
 }
 
 // Display AI insights (separated for reuse with cache)
@@ -22907,7 +22929,9 @@ function displayAIInsights(insights) {
         // Update network summary
         const networkSummary = document.getElementById('ai-network-summary');
         if (networkSummary) {
-            networkSummary.innerHTML = formatAIText(insights.network_summary || 'Analyzing network...');
+            if (insights.network_summary) networkSummary.innerHTML = formatAIText(insights.network_summary);
+            else networkSummary.innerHTML = _aiFieldFailed(insights, 'network_summary')
+                ? _aiUnavailableHtml() : formatAIText('Analyzing network...');
         }
         
         // Update vulnerability analysis with summary/details split
@@ -22931,7 +22955,8 @@ function displayAIInsights(insights) {
                 
                 if (vulnSection) vulnSection.style.display = 'block';
             } else {
-                vulnSummary.textContent = 'No vulnerabilities detected';
+                if (_aiFieldFailed(insights, 'vulnerability_analysis')) vulnSummary.innerHTML = _aiUnavailableHtml();
+                else vulnSummary.textContent = 'No vulnerabilities detected';
                 vulnDetails.innerHTML = '';
                 if (vulnToggle) vulnToggle.style.display = 'none';
                 if (vulnSection) vulnSection.style.display = 'block';
@@ -22959,7 +22984,8 @@ function displayAIInsights(insights) {
                 
                 if (weaknessSection) weaknessSection.style.display = 'block';
             } else {
-                weaknessSummary.textContent = 'Analyzing network topology...';
+                if (_aiFieldFailed(insights, 'weakness_analysis')) weaknessSummary.innerHTML = _aiUnavailableHtml();
+                else weaknessSummary.textContent = 'No attack paths identified';
                 weaknessDetails.innerHTML = '';
                 if (weaknessToggle) weaknessToggle.style.display = 'none';
                 if (weaknessSection) weaknessSection.style.display = 'block';


### PR DESCRIPTION
Several field units sharing one OpenAI key each fanned four dashboard analyses out at once. That 24-wide burst tripped the key's per-request rate limits — the biggest call (weakness) lost first ("weakness never loads"), and with no request timeout (SDK default 600s) a stuck call hung past the card's 60s cap, so some units errored the whole card while single-call WiFi-analyze still worked.

Backend (ai_service):
- OpenAI client now uses timeout=25s, max_retries=2 — a stuck/rate-limited call fails fast instead of hanging for minutes.
- generate_insights caps concurrency at 2 (was one-per-task), halving the burst on the shared key while still ~2x faster than sequential.
- Returns `attempted` + `failed` so the UI can tell a rate-limited section apart from one that simply had nothing to report.

Frontend:
- Per-section "Temporarily unavailable + Retry" for a failed analysis instead of a permanent "Analyzing network topology…"; null-but-not-failed shows a real empty state ("No attack paths identified").
- Total-failure path now clears all three sections (not just the summary).
- Cache kept short (2min) when any analysis failed so it retries soon, 1h on full success.
- Bump JS cache-bust; docs updated.