### PR TITLE
Dashboard AI insights: compute in background so slow boards never block

### DIFF
--- a/docs/AI_INTEGRATION.md
+++ b/docs/AI_INTEGRATION.md
@@ -93,16 +93,18 @@ Returns AI service status and configuration
 ```
 
 ### GET /api/ai/insights
-Returns comprehensive AI insights. The independent analyses (network summary,
-vulnerability, weakness, posture) are generated **concurrently** server-side
-(capped at 2 in flight so several units sharing one API key don't trip OpenAI's
-per-key rate limits), each with a 25s per-request timeout so a stuck/rate-limited
-call fails fast instead of hanging. Results are cached (1h server-side; client-
-side 1h on full success, 2min if any analysis failed so it retries soon). The
-response includes `attempted` (which analyses ran) and `failed` (which of those
-came back empty) so the dashboard can show a per-section "Temporarily
-unavailable + Retry" instead of a stuck "Analyzing…". The card also bounds its
-own wait (60s) and surfaces a Retry on timeout/error rather than hanging.
+Returns comprehensive AI insights. The four analyses (network summary,
+vulnerability, weakness, posture) are generated in a **background thread** and
+the endpoint **answers immediately** — so a slow board (e.g. a Pi Zero) never
+blocks the dashboard on the multi-second generation, which is what timed out and
+showed "could not reach". While the first run is in flight the response carries
+`status:"computing"` (plus any previous result), and the page **polls** every
+~6s until it lands; completed results are cached (1h server-side; client-side 1h
+on full success, 2min if any analysis failed). Pass `?refresh=1` (the Refresh
+button) to force a recompute. Inside the background run the analyses go 2-at-a-
+time so units sharing one API key don't trip OpenAI's per-key rate limits, each
+with a 25s per-request timeout; `attempted`/`failed` tell the UI which analyses
+ran and which came back empty (per-section "Temporarily unavailable + Retry").
 ```json
 {
   "enabled": true,

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -7533,7 +7533,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260809-ai-insights-resilient"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260809-ai-insights-bg"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -22817,12 +22817,33 @@ let aiInsightsCache = {
     ttl: 3600000 // 1 hour in milliseconds
 };
 
-// Load AI status and insights
-async function loadAIInsights() {
+// The server computes insights in the background and returns status:'computing'
+// until the first run lands, so the page polls rather than blocking on the slow
+// generation (which is what timed out on Pi Zeros). This tracks that poll.
+let _aiInsightsPoll = { timer: null, attempts: 0, max: 24 }; // ~24 × 6s ≈ 2.5 min
+function _aiClearPoll() { if (_aiInsightsPoll.timer) { clearTimeout(_aiInsightsPoll.timer); _aiInsightsPoll.timer = null; } }
+function _aiSchedulePoll() {
+    _aiClearPoll();
+    if (_aiInsightsPoll.attempts >= _aiInsightsPoll.max) return;  // give up quietly after the budget
+    _aiInsightsPoll.attempts++;
+    _aiInsightsPoll.timer = setTimeout(() => loadAIInsights(), 6000);
+}
+// Friendly "still working" state for the first run (no prior result to show).
+function _aiShowComputing() {
+    const msg = '<span class="text-purple-300">Analyzing…</span> '
+        + '<span class="text-gray-500 text-xs">first run can take up to a minute on small boards.</span>';
+    ['ai-network-summary', 'ai-vuln-summary', 'ai-weakness-summary'].forEach(id => {
+        const el = document.getElementById(id); if (el) el.innerHTML = msg;
+    });
+}
+
+// Load AI status and insights. `force` re-runs the server-side generation
+// (used by the Refresh button) and bypasses the client cache.
+async function loadAIInsights(force = false) {
     try {
         // Check client-side cache first
         const now = Date.now();
-        if (aiInsightsCache.data && aiInsightsCache.timestamp) {
+        if (!force && aiInsightsCache.data && aiInsightsCache.timestamp) {
             const age = now - aiInsightsCache.timestamp;
             if (age < aiInsightsCache.ttl) {
                 // Use cached data - don't make API call
@@ -22831,7 +22852,7 @@ async function loadAIInsights() {
                 return;
             }
         }
-        
+
         // First check AI status
     const statusResponse = await networkAwareFetch('/api/ai/status');
         const status = await statusResponse.json();
@@ -22859,28 +22880,41 @@ async function loadAIInsights() {
             modelName.textContent = status.model;
         }
         
-        // Load comprehensive insights. This is several LLM round-trips server
-        // side (parallelized to ~5-10s); show a clear loading state and bound
-        // the wait so a hung request surfaces an error instead of sitting on
-        // "Loading AI analysis..." forever.
-        console.log('Fetching fresh AI insights from server...');
-        const netSummaryEl = document.getElementById('ai-network-summary');
-        if (netSummaryEl) netSummaryEl.textContent = 'Analyzing… this can take a few seconds.';
+        // Fetch insights. The server computes them in the BACKGROUND and answers
+        // immediately, so this request is quick — a short timeout is right, and a
+        // real timeout now means a genuine connectivity problem, not slow AI.
+        console.log('Fetching AI insights from server...');
+        if (force) { _aiInsightsPoll.attempts = 0; _aiShowComputing(); }
 
         const ctrl = new AbortController();
-        const timer = setTimeout(() => ctrl.abort(), 60000); // 60s hard cap
+        const timer = setTimeout(() => ctrl.abort(), 20000);
         let insights;
         try {
-            const insightsResponse = await networkAwareFetch('/api/ai/insights', { signal: ctrl.signal });
+            const url = '/api/ai/insights' + (force ? '?refresh=1' : '');
+            const insightsResponse = await networkAwareFetch(url, { signal: ctrl.signal });
             if (!insightsResponse.ok) throw new Error(`HTTP ${insightsResponse.status}`);
             insights = await insightsResponse.json();
         } finally {
             clearTimeout(timer);
         }
 
-        // Cache the insights. If some analyses failed (rate-limited on a shared
-        // key, etc.), keep the cache short so it retries soon instead of showing
-        // a half-empty card for the full hour.
+        if (insights.status === 'computing') {
+            // First run (or a forced refresh) is still generating server-side.
+            // Show any prior result meanwhile, else a friendly "Analyzing…", and
+            // keep polling until the completed result lands. Don't cache this.
+            const hasData = !!(insights.network_summary || insights.vulnerability_analysis
+                || insights.weakness_analysis || insights.posture_analysis);
+            if (hasData) displayAIInsights(insights);
+            else _aiShowComputing();
+            _aiSchedulePoll();
+            return;
+        }
+
+        // Completed result — stop polling, cache and display it. If some analyses
+        // failed (rate-limited on a shared key, etc.), keep the cache short so it
+        // retries soon instead of showing a half-empty card for the full hour.
+        _aiClearPoll();
+        _aiInsightsPoll.attempts = 0;
         aiInsightsCache.data = insights;
         aiInsightsCache.timestamp = now;
         aiInsightsCache.ttl = (insights.failed && insights.failed.length) ? 120000 : 3600000;
@@ -22889,23 +22923,20 @@ async function loadAIInsights() {
 
     } catch (error) {
         console.error('Error loading AI insights:', error);
+        _aiClearPoll();
         // Don't leave the card stuck on a loading spinner — show what happened
         // on every section and offer a retry. Cache stays empty so the next
         // load tries again.
         aiInsightsCache.data = null;
         aiInsightsCache.timestamp = null;
         const why = error && error.name === 'AbortError'
-            ? 'The AI analysis took too long to respond.'
+            ? 'The AI service did not respond.'
             : 'Could not reach the AI service.';
         const errHtml = '<span class="text-amber-400">' + _esc(why) + '</span> '
             + '<button onclick="refreshAIInsights()" class="ml-1 underline text-purple-300 hover:text-purple-200">Retry</button>';
-        const netSummaryEl = document.getElementById('ai-network-summary');
-        if (netSummaryEl) netSummaryEl.innerHTML = errHtml;
-        // Clear the other two sections' stale "Analyzing…" placeholders too.
-        const vulnEl = document.getElementById('ai-vuln-summary');
-        if (vulnEl) vulnEl.innerHTML = errHtml;
-        const weakEl = document.getElementById('ai-weakness-summary');
-        if (weakEl) weakEl.innerHTML = errHtml;
+        ['ai-network-summary', 'ai-vuln-summary', 'ai-weakness-summary'].forEach(id => {
+            const el = document.getElementById(id); if (el) el.innerHTML = errHtml;
+        });
     }
 }
 
@@ -23032,26 +23063,20 @@ function displayAIInsights(insights) {
 // Refresh AI insights (force refresh, clear both client and server cache)
 async function refreshAIInsights() {
     try {
-        // Clear client-side cache
+        // Clear client-side cache and stop any in-flight poll.
         aiInsightsCache.data = null;
         aiInsightsCache.timestamp = null;
-        
-        // Clear server-side cache
-    await networkAwareFetch('/api/ai/clear-cache', { method: 'POST' });
-        
-        // Show loading state
-        const networkSummary = document.getElementById('ai-network-summary');
-        const vulnSummary = document.getElementById('ai-vuln-summary');
-        const weaknessSummary = document.getElementById('ai-weakness-summary');
-        
-        if (networkSummary) networkSummary.textContent = 'Generating new AI analysis...';
-        if (vulnSummary) vulnSummary.textContent = 'Analyzing vulnerabilities...';
-        if (weaknessSummary) weaknessSummary.textContent = 'Identifying network weaknesses...';
-        
-        // Reload insights (will fetch fresh data since cache is cleared)
-        await loadAIInsights();
-        
-        showNotification('AI insights refreshed successfully', 'success');
+        _aiClearPoll();
+        _aiInsightsPoll.attempts = 0;
+
+        // Clear the server-side per-call cache too.
+        await networkAwareFetch('/api/ai/clear-cache', { method: 'POST' });
+
+        // Kick off a forced server-side recompute; loadAIInsights(true) shows the
+        // "Analyzing…" state and polls until the fresh result lands.
+        await loadAIInsights(true);
+
+        showNotification('Refreshing AI insights…', 'success');
     } catch (error) {
         console.error('Error refreshing AI insights:', error);
         showNotification('Failed to refresh AI insights', 'error');

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -22322,30 +22322,80 @@ def get_ai_status():
         return jsonify({'error': str(e)}), 500
 
 
-@app.route('/api/ai/insights')
-def get_ai_insights():
-    """Get comprehensive AI-generated insights about the network"""
+# Dashboard AI insights are several LLM round-trips. Running them inline made the
+# request outlast the client's patience (and any proxy in front) on a slow board
+# like a Pi Zero, so the card showed "could not reach". Compute them in a
+# background thread instead and serve the last completed result immediately — the
+# page polls until the first run lands, and never blocks on the generation.
+_ai_insights_state = {
+    'data': None,        # last completed insights dict (with posture_data)
+    'ts': 0.0,           # when it completed
+    'computing': False,  # a background run is in flight
+    'lock': threading.Lock(),
+}
+_AI_INSIGHTS_TTL = 3600  # serve a completed result for an hour before recomputing
+
+
+def _compute_ai_insights_bg():
+    """Background worker: build the dashboard insights and stash them. Only one
+    runs at a time (guarded by the 'computing' flag set by the route)."""
     try:
         ai_service = getattr(shared_data, 'ai_service', None)
-        
+        if not ai_service or not ai_service.is_enabled():
+            return
+        posture = _build_ai_posture()
+        result = ai_service.generate_insights(posture=posture)
+        if posture is not None:
+            result['posture_data'] = posture
+        with _ai_insights_state['lock']:
+            _ai_insights_state['data'] = result
+            _ai_insights_state['ts'] = time.time()
+    except Exception as exc:
+        logger.error(f"[ai] background insights failed: {exc}")
+    finally:
+        with _ai_insights_state['lock']:
+            _ai_insights_state['computing'] = False
+
+
+@app.route('/api/ai/insights')
+def get_ai_insights():
+    """Comprehensive AI insights, computed in the background so a slow board's
+    dashboard never blocks on the generation. Returns the last completed result
+    immediately when fresh; otherwise kicks off a background run and returns
+    status='computing' (plus any stale result) for the page to poll."""
+    try:
+        ai_service = getattr(shared_data, 'ai_service', None)
+
         if not ai_service or not ai_service.is_enabled():
             return jsonify({
                 'enabled': False,
                 'message': 'AI service is not enabled. Configure OpenAI API token in settings.'
             })
 
-        # Passive-monitoring posture from Watchtower (aggregates the Wi-Fi Defense
-        # family + wired watchers) — fed to the dashboard AI so it reports on the
-        # live security surface, not just the scan counts.
-        posture = _build_ai_posture()
+        force = request.args.get('refresh') == '1'
+        now = time.time()
+        with _ai_insights_state['lock']:
+            data = _ai_insights_state['data']
+            ts = _ai_insights_state['ts']
+            # A result where some analyses failed (rate-limited) expires fast so
+            # it recomputes soon; a clean result is held for the full hour.
+            ttl = 120 if (data and data.get('failed')) else _AI_INSIGHTS_TTL
+            fresh = data is not None and not force and (now - ts) < ttl
+            start = (not fresh) and (not _ai_insights_state['computing'])
+            if start:
+                _ai_insights_state['computing'] = True
+        if start:
+            socketio.start_background_task(_compute_ai_insights_bg)
 
-        # Generate insights
-        insights = ai_service.generate_insights(posture=posture)
-        if posture is not None:
-            insights['posture_data'] = posture
+        if fresh:
+            return jsonify({**data, 'cached': True})
 
-        return jsonify(insights)
-        
+        # Not fresh: a run is now in flight. Hand back any prior result so the
+        # card can still show something, plus a 'computing' flag the page polls on.
+        if data is not None and not force:
+            return jsonify({**data, 'status': 'computing', 'stale': True})
+        return jsonify({'enabled': True, 'status': 'computing'})
+
     except Exception as e:
         logger.error(f"Error getting AI insights: {e}")
         return jsonify({'error': str(e)}), 500
@@ -22747,7 +22797,12 @@ def clear_ai_cache():
             })
         
         ai_service.clear_cache()
-        
+        # Also invalidate the dashboard's background-insights cache so a refresh
+        # recomputes instead of re-serving the last completed result.
+        with _ai_insights_state['lock']:
+            _ai_insights_state['data'] = None
+            _ai_insights_state['ts'] = 0.0
+
         return jsonify({
             'success': True,
             'message': 'AI cache cleared successfully'


### PR DESCRIPTION
On a Pi Zero the dashboard's /api/ai/insights blocked on the full multi-call LLM generation, which outlasted the client (and any proxy) and showed "could not reach the AI service" on every section. Reducing concurrency to 2 for shared-key safety had made the wall-clock time worse on those boards.

- /api/ai/insights now runs the generation in a background thread and answers immediately: fresh completed result when available, else status:"computing" (plus any prior result) for the page to poll. Never blocks on the LLM calls.
- Results held server-side 1h (2min when some analyses failed, so it recomputes soon); ?refresh=1 forces a recompute and clear-cache invalidates it.
- Frontend polls every ~6s (bounded ~2.5min) on status:"computing", shows a friendly "Analyzing… first run can take up to a minute on small boards", and only errors on a real connectivity failure (short 20s fetch timeout now that the endpoint returns instantly). Refresh forces a server recompute.
- Docs + JS cache-bust bumped.