### PR TITLE
Power panel: reconcile under-voltage vs healthy estimated headroom

### DIFF
--- a/docs/power.md
+++ b/docs/power.md
@@ -46,7 +46,12 @@ polled status endpoint stays cheap.
    register value, core voltage, temperature, and Pi 5 PMIC board power.
 3. **Estimated draw (what's using the power).** A realistic 5 V current for each
    USB device that is actually plugged in, plus the board's own draw, summed
-   against the recommended supply with the headroom at peak.
+   against the recommended supply with the headroom at peak. When the board
+   reports under-voltage **while the estimated budget still shows headroom**, a
+   note reconciles the two: that is a **cable/connector voltage drop**, not
+   excess current — the 5 V rail sags between the PSU and the board (a thin/long
+   micro-USB cable, a tired connector, or a flat 5.0 V supply), so a short thick
+   cable and a 5.1 V supply fix it before a bigger PSU would.
 4. **Reference configs.** The two named field profiles — *Stationary / recon*
    (Alfa + Ethernet) and *Roaming / wardrive* (Alfa + GPS + ESP32) — costed at
    peak on the detected board.

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -7563,7 +7563,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260809-power-badge2"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260809-power-badge3"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -19488,6 +19488,16 @@ function buildPowerDetailHtml(d) {
     if (d.usb_max_current_enabled === false) {
         html += `<p class="text-[11px] text-amber-400/80 mt-1">usb_max_current_enable is not set — USB peripheral current is capped to 600 mA total on this board.</p>`;
     }
+    // Reconcile the confusing case this panel can otherwise show: the SoC
+    // reports under-voltage while the estimated budget still has plenty of
+    // headroom. That is not a contradiction — the loss is between the PSU and
+    // the board (cable/connector), not too much current — and saying so stops
+    // the numbers reading like a bug.
+    const uv = d.summary && d.summary.undervoltage;
+    if (uv && est.headroom_ma > 0 && !est.tight) {
+        html += `<p class="text-[12px] text-amber-300 mt-2 border-l-2 border-amber-700 pl-2">
+            Under-voltage <em>despite</em> headroom on paper? That points at a <strong>cable/connector voltage drop</strong>, not too much current: the draw is well under the supply's rating, but the 5&nbsp;V rail still sags below spec between the PSU and the board — a thin/long micro-USB cable, a tired connector, or a flat 5.0&nbsp;V supply with no margin. Try a short thick cable and a 5.1&nbsp;V supply before reaching for a bigger PSU.</p>`;
+    }
     html += `</div>`;
 
     // 4) Reference maxima for the two named field configs.


### PR DESCRIPTION
The panel could show under-voltage NOW alongside a comfortable estimated budget (e.g. 1.4 A draw, 1.1 A headroom on a Pi 3) and read like a contradiction. It isn't — the loss is a cable/connector voltage drop between the PSU and the board, not excess current. Adds a note that appears only in that exact case (under-voltage present AND positive, non-tight headroom) pointing at a short thick cable / 5.1 V supply before a bigger PSU. Confirmed live against the Pi 3 (0x50005, hwmon flapping, ARM held at 600 MHz).