### PR TITLE
Mesh: dice-roll a Viking name + gender choice for custom names

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -3146,14 +3146,28 @@
                                class="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm">
                         <p class="text-[11px] text-gray-500 mt-1">Where the box physically is.</p>
                     </div>
-                    <div class="md:col-span-2">
+                    <div>
                         <label class="block text-xs uppercase tracking-wider text-gray-400 mb-1">Viking name</label>
-                        <input id="mesh-viking-input" type="text"
-                               class="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm">
+                        <div class="flex gap-2">
+                            <input id="mesh-viking-input" type="text" oninput="meshOnJoinVikingInput()"
+                                   class="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm">
+                            <button type="button" onclick="meshRollJoinName()" title="Roll a random Viking name"
+                                    aria-label="Roll a random Viking name"
+                                    class="flex-shrink-0 bg-slate-700 hover:bg-slate-600 text-gray-200 px-3 rounded-lg text-lg leading-none transition-colors">🎲</button>
+                        </div>
                         <p class="text-[11px] text-gray-500 mt-1">
                             This unit's name in the army. Derived from the machine itself, so it already
-                            has one and keeps it across reinstalls — change it if you'd rather choose.
+                            has one and keeps it across reinstalls — change it, or roll a new one.
                         </p>
+                    </div>
+                    <div>
+                        <label class="block text-xs uppercase tracking-wider text-gray-400 mb-1">Portrait / gender</label>
+                        <select id="mesh-viking-gender" class="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm">
+                            <option value="">Auto (from name)</option>
+                            <option value="male">Male</option>
+                            <option value="female">Female</option>
+                        </select>
+                        <p id="mesh-join-gender-hint" class="text-[11px] text-gray-500 mt-1">Known names set this automatically.</p>
                     </div>
                     <div class="md:col-span-2">
                         <label class="block text-xs uppercase tracking-wider text-gray-400 mb-1">Tailscale auth key</label>
@@ -3258,9 +3272,23 @@
                         </div>
                         <div>
                             <label class="block text-xs uppercase tracking-wider text-gray-400 mb-1">Viking name</label>
-                            <input id="mesh-ident-viking" type="text"
-                                   class="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm">
-                            <p class="text-[11px] text-gray-500 mt-1">Its name in the army.</p>
+                            <div class="flex gap-2">
+                                <input id="mesh-ident-viking" type="text" oninput="meshOnVikingInput()"
+                                       class="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm">
+                                <button type="button" onclick="meshRollName(this)" title="Roll a random Viking name"
+                                        aria-label="Roll a random Viking name"
+                                        class="flex-shrink-0 bg-slate-700 hover:bg-slate-600 text-gray-200 px-3 rounded-lg text-lg leading-none transition-colors">🎲</button>
+                            </div>
+                            <p class="text-[11px] text-gray-500 mt-1">Its name in the army — or roll one.</p>
+                        </div>
+                        <div>
+                            <label class="block text-xs uppercase tracking-wider text-gray-400 mb-1">Portrait / gender</label>
+                            <select id="mesh-ident-gender" class="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm">
+                                <option value="">Auto (from name)</option>
+                                <option value="male">Male</option>
+                                <option value="female">Female</option>
+                            </select>
+                            <p id="mesh-ident-gender-hint" class="text-[11px] text-gray-500 mt-1">Known names set this automatically.</p>
                         </div>
                     </div>
                     <div class="flex items-center gap-3 mt-3">
@@ -7595,7 +7623,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260810-mesh-identity"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260810-mesh-dice-gender"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -31034,6 +31034,8 @@ function renderMesh(data) {
         if (vikingField && !vikingField.value && data.viking_name) {
             vikingField.value = data.viking_name;
         }
+        // Load the roster so the dice and the gender hint work before join too.
+        meshLoadVikingNames().then(() => meshOnJoinVikingInput());
     }
 
     // A page load that lands mid-install should resume the progress view rather
@@ -31059,6 +31061,10 @@ function renderMesh(data) {
         setIfIdle('mesh-ident-unit-id', data.unit_id ? String(data.unit_id) : '');
         setIfIdle('mesh-ident-label', data.site_label || '');
         setIfIdle('mesh-ident-viking', data.viking_name || '');
+        setIfIdle('mesh-ident-gender', data.viking_gender || '');
+        // Load the name roster (once) so the gender hint can tell known names
+        // from custom ones, then refresh the hint for whatever is in the box.
+        meshLoadVikingNames().then(() => meshOnVikingInput());
     }
     // Fleet update only makes sense once this unit is actually in the mesh, so it
     // can reach and relay to peers — same gate as the controls above.
@@ -31514,11 +31520,19 @@ async function meshJoin() {
     const unitId = parseInt(document.getElementById('mesh-unit-id-input').value, 10);
     const label = document.getElementById('mesh-label-input').value.trim();
     const viking = document.getElementById('mesh-viking-input').value.trim();
+    const gender = document.getElementById('mesh-viking-gender').value;
     const routes = document.getElementById('mesh-routes-input').value
         .split(',').map(r => r.trim()).filter(Boolean);
 
     if (!authKey) {
         out.innerHTML = '<span class="text-red-400">An auth key is required.</span>';
+        return;
+    }
+    // A custom name has no built-in gender, so require the operator to pick one.
+    await meshLoadVikingNames();
+    if (viking && meshNameIsKnown(viking) === false && !gender) {
+        out.innerHTML = '<span class="text-amber-400">Pick Male or Female for this custom name.</span>';
+        document.getElementById('mesh-viking-gender').focus();
         return;
     }
     btn.disabled = true;
@@ -31531,6 +31545,8 @@ async function meshJoin() {
         if (Number.isInteger(unitId) && unitId > 0) cfg.mesh_unit_id = unitId;
         if (label) cfg.mesh_site_label = label;
         if (viking) cfg.mesh_viking_name = viking;
+        // '' lets the server derive gender from a known name; else it's pinned.
+        cfg.mesh_viking_gender = gender;
         if (Object.keys(cfg).length) {
             await fetch('/api/config', {
                 method: 'POST',
@@ -31565,16 +31581,123 @@ async function meshJoin() {
     }
 }
 
+// The canonical Viking roster, fetched once from the server so the browser
+// never hard-codes it. Powers the dice roll and the known-vs-custom gender rule.
+let _meshVikingNames = null;
+async function meshLoadVikingNames() {
+    if (_meshVikingNames) return _meshVikingNames;
+    try {
+        const r = await fetch('/api/mesh/viking-names');
+        const d = await r.json();
+        if (d.success) {
+            _meshVikingNames = {
+                names: d.names || [],
+                female: new Set(d.female || []),
+                epithets: d.epithets || [],
+            };
+        }
+    } catch (_) { /* offline / no mesh module — dice + auto-gender just idle */ }
+    return _meshVikingNames;
+}
+
+// null = roster not loaded yet (can't judge); true/false = known/custom.
+function meshNameIsKnown(name) {
+    if (!_meshVikingNames) return null;
+    const first = (name || '').trim().split(/\s+/)[0];
+    return !!first && _meshVikingNames.names.includes(first);
+}
+
+function meshNameIsFemale(name) {
+    if (!_meshVikingNames) return false;
+    const first = (name || '').trim().split(/\s+/)[0];
+    return _meshVikingNames.female.has(first);
+}
+
+async function meshRollName() {
+    const list = await meshLoadVikingNames();
+    if (!list || !list.names.length) return;
+    const pick = arr => arr[Math.floor(Math.random() * arr.length)];
+    document.getElementById('mesh-ident-viking').value =
+        `${pick(list.names)} ${pick(list.epithets)}`;
+    // A rolled name is always from the known roster, so its gender derives
+    // itself — reset the override back to Auto.
+    document.getElementById('mesh-ident-gender').value = '';
+    meshOnVikingInput();
+}
+
+// Keep the gender hint honest as the name is typed: a known name derives its own
+// gender; a custom one must be told which portrait to wear.
+function meshOnVikingInput() {
+    const hint = document.getElementById('mesh-ident-gender-hint');
+    if (!hint) return;
+    const name = document.getElementById('mesh-ident-viking').value;
+    const known = meshNameIsKnown(name);
+    if (!name.trim() || known === null) {
+        hint.textContent = 'Known names set this automatically.';
+        hint.className = 'text-[11px] text-gray-500 mt-1';
+    } else if (known) {
+        hint.textContent =
+            `Known name — portrait derives automatically (${meshNameIsFemale(name) ? 'female' : 'male'}).`;
+        hint.className = 'text-[11px] text-gray-500 mt-1';
+    } else {
+        hint.textContent = 'Custom name — choose Male or Female for the portrait.';
+        hint.className = 'text-[11px] text-amber-400 mt-1';
+    }
+}
+
+// The onboarding join form carries the same name/gender pair as the identity
+// editor, so it gets the same dice and known-vs-custom hint.
+async function meshRollJoinName() {
+    const list = await meshLoadVikingNames();
+    if (!list || !list.names.length) return;
+    const pick = arr => arr[Math.floor(Math.random() * arr.length)];
+    document.getElementById('mesh-viking-input').value =
+        `${pick(list.names)} ${pick(list.epithets)}`;
+    document.getElementById('mesh-viking-gender').value = '';
+    meshOnJoinVikingInput();
+}
+
+function meshOnJoinVikingInput() {
+    const hint = document.getElementById('mesh-join-gender-hint');
+    if (!hint) return;
+    const name = document.getElementById('mesh-viking-input').value;
+    const known = meshNameIsKnown(name);
+    if (!name.trim() || known === null) {
+        hint.textContent = 'Known names set this automatically.';
+        hint.className = 'text-[11px] text-gray-500 mt-1';
+    } else if (known) {
+        hint.textContent =
+            `Known name — portrait derives automatically (${meshNameIsFemale(name) ? 'female' : 'male'}).`;
+        hint.className = 'text-[11px] text-gray-500 mt-1';
+    } else {
+        hint.textContent = 'Custom name — choose Male or Female for the portrait.';
+        hint.className = 'text-[11px] text-amber-400 mt-1';
+    }
+}
+
 async function meshSaveIdentity(btn) {
     const out = document.getElementById('mesh-ident-result');
     const unitId = parseInt(document.getElementById('mesh-ident-unit-id').value, 10);
     const label = document.getElementById('mesh-ident-label').value.trim();
     const viking = document.getElementById('mesh-ident-viking').value.trim();
+    const gender = document.getElementById('mesh-ident-gender').value;
+
+    // A custom name carries no built-in gender, so the portrait would be a
+    // coin toss unless the operator picks one — require it before saving.
+    await meshLoadVikingNames();
+    if (viking && meshNameIsKnown(viking) === false && !gender) {
+        out.textContent = 'Pick Male or Female for this custom name.';
+        out.className = 'text-sm text-amber-400';
+        document.getElementById('mesh-ident-gender').focus();
+        return;
+    }
 
     const cfg = {};
     // Unit 0 is the "unassigned" sentinel, so an empty box clears the number.
     cfg.mesh_unit_id = (Number.isInteger(unitId) && unitId > 0) ? unitId : 0;
     cfg.mesh_site_label = label;
+    // '' lets the server derive gender from a known name; 'male'/'female' pins it.
+    cfg.mesh_viking_gender = gender;
     if (viking) cfg.mesh_viking_name = viking;
 
     if (btn) btn.disabled = true;
@@ -31812,6 +31935,10 @@ window.meshCloseSetupHelp = meshCloseSetupHelp;
 window.refreshMesh = refreshMesh;
 window.meshJoin = meshJoin;
 window.meshSaveIdentity = meshSaveIdentity;
+window.meshRollName = meshRollName;
+window.meshOnVikingInput = meshOnVikingInput;
+window.meshRollJoinName = meshRollJoinName;
+window.meshOnJoinVikingInput = meshOnJoinVikingInput;
 window.meshInstall = meshInstall;
 window.meshServe = meshServe;
 window.meshLeave = meshLeave;

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -2260,6 +2260,27 @@ def _mesh_viking_name():
         return socket.gethostname()
 
 
+def _mesh_viking_female():
+    """Whether this unit's portrait should be the shieldmaiden.
+
+    Gender is derived from the Viking name when the name is one Ragnar knows
+    (the built-in list carries its own gender), but a custom name — 'Xena', a
+    surname, anything off-list — can't be derived, so the operator sets it
+    explicitly and that choice (mesh_viking_gender) wins when present.
+    """
+    gender = (shared_data.config.get('mesh_viking_gender') or '').strip().lower()
+    if gender == 'female':
+        return True
+    if gender == 'male':
+        return False
+    if mesh_available:
+        try:
+            return mesh_manager.is_female_viking(_mesh_viking_name())
+        except Exception:
+            return False
+    return False
+
+
 def _mesh_unit_name():
     """How this unit identifies itself to peers: 'Bjorn Ironside (Unit 03)'."""
     unit_id = _mesh_unit_id()
@@ -2343,6 +2364,9 @@ def _mesh_local_health():
     health = {
         'unit_id': _mesh_unit_id(),
         'viking_name': _mesh_viking_name(),
+        # Peers render this unit's portrait from this rather than re-deriving the
+        # gender, so a custom-named unit shows the right one across the fleet.
+        'viking_female': _mesh_viking_female(),
         'name': _mesh_unit_name(),
         'label': cfg.get('mesh_site_label') or socket.gethostname(),
         'hostname': socket.gethostname(),
@@ -2981,6 +3005,21 @@ def mesh_scan_capabilities():
                     'nuclei': cap['nuclei'], 'zap': cap['zap']})
 
 
+@app.route('/api/mesh/viking-names')
+def mesh_viking_names():
+    """The canonical Viking name/epithet lists, so the identity editor can roll
+    a fresh random name and know a name's gender without hard-coding the roster
+    in the browser (it lives once, in mesh_manager)."""
+    if not mesh_available:
+        return jsonify({'success': False, 'names': [], 'female': [], 'epithets': []})
+    return jsonify({
+        'success': True,
+        'names': list(mesh_manager.VIKING_NAMES),
+        'female': sorted(mesh_manager.VIKING_FEMALE_NAMES),
+        'epithets': list(mesh_manager.VIKING_EPITHETS),
+    })
+
+
 @app.route('/api/mesh/scan/start', methods=['POST'])
 def mesh_scan_start():
     """Run a delegated scan locally on behalf of a peer. Peer-write allowlisted."""
@@ -3413,8 +3452,10 @@ def mesh_status():
         'viking_name': _mesh_viking_name(),
         # Whether this unit's Viking name is a woman's — the header shows the
         # female Ragnar portrait when so.
-        'viking_female': (mesh_manager.is_female_viking(_mesh_viking_name())
-                          if mesh_available else False),
+        'viking_female': _mesh_viking_female(),
+        # The explicit gender override ('', 'male', 'female') so the editor can
+        # restore the operator's choice rather than re-deriving it every load.
+        'viking_gender': (shared_data.config.get('mesh_viking_gender') or ''),
         # Whether `tailscale serve --https` can actually work here. Reported so
         # the UI can say so up front instead of offering a button that hangs.
         'https_available': mesh_manager.https_available() if mesh_available else False,


### PR DESCRIPTION
The identity editor (and the onboarding join form) now have a 🎲 that rolls a fresh random Viking name from the canonical roster, and a Portrait/gender selector.

Known roster names carry their own gender, so the selector stays on Auto and the server derives the portrait as before. A custom name has no built-in gender, so saving/joining is blocked until the operator picks Male or Female, and that choice (mesh_viking_gender) then drives which portrait the unit wears across the fleet.

- webapp_modern.py: _mesh_viking_female() honours the explicit override then falls back to name derivation; status reports viking_female / viking_gender and local health carries viking_female for peers; new GET /api/mesh/viking-names serves the roster so the browser never hard-codes it.
- Editor + join form: dice button, gender select, live known-vs-custom hint, custom-name gender validation before save/join.