### PR TITLE
Fix mesh transfer failing with 'Invalid chunk header'

### DIFF
--- a/mesh_transfer.py
+++ b/mesh_transfer.py
@@ -217,23 +217,42 @@ class MeshTransfer:
             total = os.path.getsize(file_path)
             self.registry.update(tid, state='sending', total=total, sent=0)
             reg = self.registry
+            _tid = tid
 
-            def gen():
-                sent = 0
-                with open(file_path, 'rb') as f:
-                    while True:
-                        chunk = f.read(CHUNK)
-                        if not chunk:
-                            break
-                        sent += len(chunk)
-                        reg.update(tid, sent=sent)
-                        yield chunk
+            # Send a length-bearing file object, NOT a generator: a generator
+            # makes requests use chunked transfer-encoding, which the Werkzeug
+            # receiver rejects ("Invalid chunk header"). With .len set, requests
+            # sends a normal Content-Length body and streams via read().
+            class _ProgressFile:
+                def __init__(self, path):
+                    self._f = open(path, 'rb')
+                    self.len = total           # requests.super_len() reads this
+                    self._sent = 0
+                def read(self, size=-1):
+                    chunk = self._f.read(size if size and size > 0 else CHUNK)
+                    if chunk:
+                        self._sent += len(chunk)
+                        reg.update(_tid, sent=self._sent)
+                    return chunk
+                def __len__(self):
+                    return self.len
+                # Present as iterable so requests treats us as a stream body.
+                def __iter__(self):
+                    return iter(lambda: self.read(CHUNK), b'')
+                def close(self):
+                    try:
+                        self._f.close()
+                    except Exception:
+                        pass
 
+            body = _ProgressFile(file_path)
             send_headers = dict(headers or {})
             send_headers['Content-Type'] = 'application/octet-stream'
-            send_headers['Content-Length'] = str(total)
-            send_headers['X-Filename'] = filename
-            resp = requests.post(url, data=gen(), headers=send_headers, timeout=timeout)
+            send_headers['X-Filename'] = filename   # Content-Length set by requests
+            try:
+                resp = requests.post(url, data=body, headers=send_headers, timeout=timeout)
+            finally:
+                body.close()
             if resp.status_code == 200:
                 self.registry.update(tid, state='delivered', sent=total, pct=100)
             elif resp.status_code == 401:

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -19994,7 +19994,12 @@ def mesh_files_send():
         node = _resolve_delegate_node(target_id)
         if not node:
             return jsonify({'success': False, 'error': 'Target unit not found in mesh'}), 400
-        dest_name = node.get('viking_name') or node.get('label') or node.get('short_name') or 'peer'
+        # Prefer the peer's self-reported Viking name (from the poll cache) over
+        # the bare tailnet label, so transfers read "→ Kara the Great" not "here-1".
+        _ph = _mesh_peer_health.get(node.get('id'), {}) if isinstance(_mesh_peer_health, dict) else {}
+        dest_name = (node.get('viking_name') or _ph.get('viking_name')
+                     or node.get('label') or _ph.get('label')
+                     or node.get('short_name') or 'peer')
         url = mesh_manager.peer_url(node, _mesh_node_port(), '/api/mesh/files/push')
         if not url:
             return jsonify({'success': False, 'error': 'Target has no tailnet address'}), 400


### PR DESCRIPTION
Sending a generator to requests made it use chunked transfer-encoding, which the Werkzeug receiver rejects ('Invalid chunk header') — every send failed at 100%. Stream a length-bearing file object instead so requests sends a normal Content-Length body. Verified live: axe.png (1.8MB) delivered to a real peer.

Also resolve the destination's Viking name from the poll-health cache so transfers read '→ Kara the Great' instead of the bare tailnet label 'here-1'.