### PR TITLE
Fix: confirm dialog invisible when triggered from another tab

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -7863,7 +7863,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260813-files-flag2"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260813-discard-modal-fix"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -23129,7 +23129,13 @@ function showFileConfirmModal(title, content, onConfirm) {
     const confirmBtn = document.getElementById('modal-confirm');
     
     if (!modal || !modalTitle || !modalContent || !confirmBtn) return;
-    
+
+    // The dialog is authored inside #files-tab. When triggered from another tab
+    // (e.g. the mesh Inbox's Discard, or Mesh Share's Unshare) that tab is
+    // display:none, so the dialog can't render — it only appears once you switch
+    // to Files. Reparent it to <body> so it shows regardless of the active tab.
+    if (modal.parentElement !== document.body) document.body.appendChild(modal);
+
     modalTitle.textContent = title;
     modalContent.innerHTML = content;
     


### PR DESCRIPTION
showFileConfirmModal's dialog (#file-operations-modal) is authored inside #files-tab. Triggered from the Ragnar Mesh tab — the inbox Discard and Mesh Share Unshare — that tab is display:none, so un-hiding the dialog did nothing until you switched to Files (hence 'click Discard, then refresh, then the box appears'). Now the dialog is reparented to <body> on show, so it renders over whatever tab is active. Verified headless: reparented, visible, confirm fires.