### PR TITLE
Mesh/share: confirm dialog dismisses on Confirm, not just Cancel

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -8004,7 +8004,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260814-mesh-secret-7"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260814-mesh-secret-8"></script>
 
 </body>
 </html>

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -23391,8 +23391,14 @@ function showFileConfirmModal(title, content, onConfirm) {
     const newConfirmBtn = confirmBtn.cloneNode(true);
     confirmBtn.parentNode.replaceChild(newConfirmBtn, confirmBtn);
     
-    // Add new listener
-    newConfirmBtn.addEventListener('click', onConfirm);
+    // Add new listener. Dismiss the dialog immediately on confirm — the work in
+    // onConfirm runs async (fetch + .then), so waiting on it would leave the modal
+    // up until the request returns. Some callbacks also call closeFileModal() in
+    // their .then; that's now a harmless no-op.
+    newConfirmBtn.addEventListener('click', function () {
+        closeFileModal();
+        onConfirm();
+    });
     
     modal.classList.remove('hidden');
     modal.classList.add('flex');


### PR DESCRIPTION
Revoke share token (and Remove remote share) ran their work in an async fetch callback but never closed the confirm modal, so clicking Confirm did the revoke in the background yet left the dialog up until Cancel was clicked. Dismiss the modal centrally the moment Confirm is pressed.