### PR TITLE
Move UPS Power card from Config tab to System tab below Power

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -4990,6 +4990,36 @@
                         <div class="text-2xl font-bold" id="power-card-status">--</div>
                         <div class="text-xs text-gray-400" id="power-card-details">Supply health</div>
                     </div>
+
+                    <!-- UPS Lite Management Card -->
+                    <div class="glass-card p-4 flex flex-col justify-between">
+                        <div class="flex items-center justify-between mb-4">
+                            <div class="flex items-center gap-3">
+                                <!-- Graphical Miniature Battery Vector Component -->
+                                <div class="relative w-10 h-6 border-2 border-gray-400 rounded-md p-0.5 flex items-center">
+                                    <div class="absolute -right-[5px] top-[4px] w-[3px] h-[10px] bg-gray-400 rounded-r-sm"></div>
+                                    <div id="mini-bat-fill" class="h-full bg-green-500 rounded-sm transition-all duration-500" style="width: 0%;"></div>
+                                </div>
+                                <div>
+                                    <div class="text-xs font-semibold text-gray-200">UPS Power</div>
+                                    <div id="mini-bat-volt" class="text-[10px] text-gray-400 font-mono">-- V</div>
+                                </div>
+                            </div>
+                            <!-- Absolute Numeric Percentage Output -->
+                            <div id="mini-bat-pct" class="text-2xl font-bold text-white font-sans">--%</div>
+                        </div>
+
+                        <!-- Interface I2C Device Address Settings Dropdown Selector -->
+                        <div class="flex items-center justify-between pt-2 border-t border-gray-700/40">
+                            <label for="i2c-select" class="text-xs font-medium text-gray-400">I2C Device Address:</label>
+                            <select id="i2c-select" class="bg-gray-900 border border-gray-700 text-white text-xs rounded-md p-1 focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 font-mono cursor-pointer" onchange="changeI2CAddress(this.value)">
+                                <option value="auto" class="bg-gray-900 text-white">Auto-Detect</option>
+                                <option value="0x32" class="bg-gray-900 text-white">0x32 (Clone v1.2)</option>
+                                <option value="0x36" class="bg-gray-900 text-white">0x36 (Original)</option>
+                                <option value="0x62" class="bg-gray-900 text-white">0x62 (Alternative)</option>
+                            </select>
+                        </div>
+                    </div>
                 </div>
 
                 <!-- Power & Supply detail — throttle flags + estimated draw budget -->
@@ -6595,39 +6625,6 @@
                             </button>
                         </div>
                         
-<!-- UPS Lite Management Card -->
-<div class="glass rounded-lg p-4 border border-gray-700/30 h-full flex flex-col justify-between">
-    <div class="flex items-center justify-between mb-4">
-        <div class="flex items-center gap-3">
-            <!-- Graphical Miniature Battery Vector Component -->
-            <div class="relative w-10 h-6 border-2 border-gray-400 rounded-md p-0.5 flex items-center">
-                <div class="absolute -right-[5px] top-[4px] w-[3px] h-[10px] bg-gray-400 rounded-r-sm"></div>
-                <div id="mini-bat-fill" class="h-full bg-green-500 rounded-sm transition-all duration-500" style="width: 0%;"></div>
-            </div>
-            <div>
-                <div class="text-xs font-semibold text-gray-200">UPS Power</div>
-                <div id="mini-bat-volt" class="text-[10px] text-gray-400 font-mono">-- V</div>
-            </div>
-        </div>
-        <!-- Absolute Numeric Percentage Output -->
-        <div id="mini-bat-pct" class="text-2xl font-bold text-white font-sans">--%</div>
-    </div>
-
-    <!-- Interface I2C Device Address Settings Dropdown Selector -->
-    <div class="flex items-center justify-between pt-2 border-t border-gray-700/40">
-        <label for="i2c-select" class="text-xs font-medium text-gray-400">I2C Device Address:</label>
-        <select id="i2c-select" class="bg-gray-900 border border-gray-700 text-white text-xs rounded-md p-1 focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 font-mono cursor-pointer" onchange="changeI2CAddress(this.value)">
-            <option value="auto" class="bg-gray-900 text-white">Auto-Detect</option>
-            <option value="0x32" class="bg-gray-900 text-white">0x32 (Clone v1.2)</option>
-            <option value="0x36" class="bg-gray-900 text-white">0x36 (Original)</option>
-            <option value="0x62" class="bg-gray-900 text-white">0x62 (Alternative)</option>
-        </select>
-    </div>
-</div>
-    
-
-
-
                         <!-- Service Control Card -->
                         <div class="glass rounded-lg p-4">
                             <div class="flex items-center justify-between mb-3">


### PR DESCRIPTION
This pull request refactors the placement of the UPS Lite Management Card in the `web/index_modern.html` file. The card, which displays UPS power information and allows I2C device address selection, has been moved from the "Ragnar Updates" section to the main "Power" section for improved UI organization.

UI structure improvements:

* Moved the UPS Lite Management Card (including the battery graphic, voltage, percentage display, and I2C address selector) from the "Ragnar Updates" section to directly under the main "Power" section for better visibility and logical grouping with other power-related information. [[1]](diffhunk://#diff-7a539845f7a3dbcb375c4f1fd20d0e033f28fd246928b5167f61ffef837e62f8R4993-R5022) [[2]](diffhunk://#diff-7a539845f7a3dbcb375c4f1fd20d0e033f28fd246928b5167f61ffef837e62f8L6598-L6630)