### PR TITLE
detector self-test: add MAC Watch + DHCP Guardian (both with Scapy e2e)

### DIFF
--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -1553,18 +1553,25 @@ def _parse_dhcp_capture(output):
     chaddr is what a starvation tool spoofs, so distinct chaddrs is the signal."""
     requests = 0
     clients = set()
-    kind = None
+    # tcpdump prints the BOOTP fixed fields (Client-Ethernet-Address) BEFORE the
+    # option that carries the message type (DHCP-Message: Discover), so hold the
+    # chaddr as it goes by and attribute it once the message type is known. The
+    # earlier order-assumption dropped the first client and mis-shifted the rest.
+    pending_mac = None
     for raw in output.splitlines():
         line = raw.strip()
+        m = re.search(r'Client-Ethernet-Address\s+([0-9a-fA-F:]{17})', line)
+        if m:
+            pending_mac = m.group(1).lower()
+            continue
         m = re.search(r'DHCP-Message.*?:\s*(\w+)', line)
         if m:
             kind = m.group(1).lower()
             if kind in ('discover', 'request'):
                 requests += 1
-            continue
-        m = re.search(r'Client-Ethernet-Address\s+([0-9a-fA-F:]{17})', line)
-        if m and kind in ('discover', 'request'):
-            clients.add(m.group(1).lower())
+                if pending_mac:
+                    clients.add(pending_mac)
+            pending_mac = None          # each option block ends this packet's chaddr
     return requests, clients
 
 
@@ -3489,6 +3496,178 @@ def _arp_selftest():
 
     return {'success': all(s['pass'] for s in scenarios),
             'scenarios': scenarios, 'scapy': {'ran': False, 'reason': 'offline only'}}
+
+
+def _mac_selftest():
+    """Self-test the MAC-spoofing classifier, plus a Scapy end-to-end leg that
+    reads a crafted frame's source MAC back off the wire (tcpdump -e) and
+    classifies it — proving the capture→extract→classify path, not just the
+    string classifier. No root, no live traffic."""
+    scenarios = []
+
+    def run(name, mac, expect):
+        got = _classify_mac(mac)['klass']
+        scenarios.append({'name': name, 'expect': expect, 'got': got,
+                          'pass': got == expect})
+
+    # b8:27:eb is a seeded Raspberry Pi OUI (deterministic without the OUI CSV).
+    run('mac-universal', 'b8:27:eb:11:22:33', 'universal')
+    # same OUI with the locally-administered bit set -> vendor-OUI impersonation.
+    run('mac-spoofed-vendor-oui', 'ba:27:eb:11:22:33', 'spoofed_vendor_oui')
+    run('mac-virtual-laa', '02:42:ac:11:00:02', 'virtual_laa')          # Docker
+    run('mac-randomized', 'f6:11:22:33:44:55', 'randomized')            # LAA, no vendor
+    run('mac-invalid-mcast', '01:00:5e:00:00:01', 'invalid')
+
+    scapy_result = {'ran': False, 'reason': 'scapy or tcpdump unavailable'}
+    try:
+        import tempfile
+        from scapy.all import Ether, wrpcap
+        if _have('tcpdump'):
+            frames, want = [], {}
+            for mac, exp in (('b8:27:eb:44:55:66', 'universal'),
+                             ('ba:27:eb:44:55:66', 'spoofed_vendor_oui'),
+                             ('02:42:ac:11:00:09', 'virtual_laa')):
+                frames.append(Ether(src=mac, dst='ff:ff:ff:ff:ff:ff', type=0x0800)
+                              / (b'\x00' * 40))
+                want[mac] = exp
+            with tempfile.NamedTemporaryFile(suffix='.pcap', delete=False) as tf:
+                pcap_path = tf.name
+            wrpcap(pcap_path, frames)
+            res = _run(['tcpdump', '-e', '-nn', '-t', '-r', pcap_path], timeout=10)
+            ok = True
+            for line in res['out'].splitlines():
+                m = re.match(r'\s*([0-9a-fA-F:]{17})\s*>', line)
+                if m and m.group(1).lower() in want:
+                    src = m.group(1).lower()
+                    if _classify_mac(src)['klass'] != want.pop(src):
+                        ok = False
+            ok = ok and not want           # every crafted MAC was seen + classified
+            scenarios.append({'name': 'mac-scapy-e2e', 'expect': 'wire MAC classified',
+                              'got': 'ok' if ok else 'mismatch/missing', 'pass': ok})
+            scapy_result = {'ran': True, 'pass': ok,
+                            'tcpdump_out': res['out'].strip()[:200]}
+            try:
+                os.remove(pcap_path)
+            except OSError:
+                pass
+    except Exception as e:
+        scapy_result = {'ran': False, 'reason': f'{type(e).__name__}: {e}'}
+
+    passed = all(s['pass'] for s in scenarios) and (not scapy_result.get('ran')
+                                                    or scapy_result.get('pass'))
+    return {'success': passed, 'scenarios': scenarios, 'scapy': scapy_result}
+
+
+def _dhcp_selftest():
+    """Self-test the DHCP Guardian text parsers and verdict logic (rogue server /
+    starvation / clean), plus a Scapy end-to-end leg that crafts real DHCP
+    DISCOVERs and reads them back through tcpdump. No root, no live traffic;
+    the verdict leg monkeypatches the discover/capture seams and restores them."""
+    scenarios = []
+
+    def ck(name, cond, got=''):
+        scenarios.append({'name': name, 'expect': 'pass', 'got': str(got),
+                          'pass': bool(cond)})
+
+    # -- parsers (pure) --
+    # Real tcpdump order: the BOOTP chaddr (Client-Ethernet-Address) prints BEFORE
+    # the DHCP-Message option that names the type.
+    cap_text = (
+        "  Client-Ethernet-Address de:ad:be:ef:00:01\n"
+        "    DHCP-Message (53), length 1: Discover\n"
+        "  Client-Ethernet-Address de:ad:be:ef:00:02\n"
+        "    DHCP-Message (53), length 1: Discover\n"
+        "  Client-Ethernet-Address de:ad:be:ef:00:03\n"
+        "    DHCP-Message (53), length 1: Request\n")
+    req, clients = _parse_dhcp_capture(cap_text)
+    ck('capture: counts requests', req == 3, got=req)
+    ck('capture: distinct client MACs', len(clients) == 3, got=len(clients))
+    disc_text = ("|_broadcast-dhcp-discover:\n"
+                 "|   Response 1 of 1:\n"
+                 "|     Server Identifier: 192.168.1.1\n"
+                 "|     Router: 192.168.1.1\n"
+                 "|     Domain Name Server: 1.1.1.1, 8.8.8.8\n"
+                 "|     IP Offered: 192.168.1.50\n")
+    offers = _parse_dhcp_discover(disc_text)
+    ck('discover: one offer parsed',
+       len(offers) == 1 and offers[0]['server_id'] == '192.168.1.1', got=offers)
+    ck('discover: DNS list parsed',
+       offers and offers[0]['dns'] == ['1.1.1.1', '8.8.8.8'])
+
+    # -- verdict logic via monkeypatched discover/capture seams --
+    import tempfile
+    g = globals()
+    saved = {k: g[k] for k in ('_dhcp_discover', '_dhcp_capture',
+                               '_default_gateway', 'do_arp_check',
+                               '_DHCP_BASELINE_PATH')}
+    try:
+        g['_default_gateway'] = lambda: '192.168.1.1'
+        g['do_arp_check'] = lambda *a, **k: {'verdict': 'clean'}
+        state = {'offers': [], 'err': None, 'req': 0, 'clients': 0}
+        g['_dhcp_discover'] = lambda iface, t=0: (state['offers'], state['err'])
+        g['_dhcp_capture'] = lambda iface, s: (state['req'], state['clients'], None)
+
+        def _fresh():
+            g['_DHCP_BASELINE_PATH'] = tempfile.mktemp(suffix='.json')
+
+        # rogue: two servers, none trusted yet.
+        _fresh()
+        state['offers'] = [{'server_id': '192.168.1.1', 'router': '192.168.1.1', 'dns': []},
+                           {'server_id': '10.6.6.6', 'router': '10.6.6.6', 'dns': []}]
+        ck('verdict rogue (2 servers)', do_dhcp_guardian(learn=False)['verdict'] == 'rogue',
+           got=do_dhcp_guardian(learn=False)['verdict'])
+
+        # starvation: many distinct clients.
+        _fresh()
+        state['offers'] = [{'server_id': '192.168.1.1', 'router': '192.168.1.1', 'dns': []}]
+        state['clients'] = _DHCP_STARV_MIN_CLIENTS + 2
+        ck('verdict starvation', do_dhcp_guardian(learn=False)['verdict'] == 'starvation',
+           got=do_dhcp_guardian(learn=False)['verdict'])
+
+        # clean: single trusted server, no starvation.
+        _fresh()
+        state['clients'] = 0
+        ck('verdict clean (single server)', do_dhcp_guardian(learn=True)['verdict'] == 'clean',
+           got=do_dhcp_guardian(learn=True)['verdict'])
+    finally:
+        for k, v in saved.items():
+            g[k] = v
+
+    # -- Scapy end-to-end: craft DHCP DISCOVERs -> pcap -> tcpdump -> parse --
+    scapy_result = {'ran': False, 'reason': 'scapy or tcpdump unavailable'}
+    try:
+        import tempfile
+        from scapy.all import Ether, IP, UDP, BOOTP, DHCP, wrpcap
+        if _have('tcpdump'):
+            pkts = []
+            for i in range(3):
+                mac = '02:00:00:00:00:%02x' % (i + 1)
+                chaddr = bytes(int(x, 16) for x in mac.split(':')) + b'\x00' * 10
+                pkts.append(Ether(src=mac, dst='ff:ff:ff:ff:ff:ff')
+                            / IP(src='0.0.0.0', dst='255.255.255.255')
+                            / UDP(sport=68, dport=67) / BOOTP(chaddr=chaddr)
+                            / DHCP(options=[('message-type', 'discover'), 'end']))
+            with tempfile.NamedTemporaryFile(suffix='.pcap', delete=False) as tf:
+                pcap_path = tf.name
+            wrpcap(pcap_path, pkts)
+            res = _run(['tcpdump', '-e', '-nn', '-t', '-v', '-r', pcap_path,
+                        'udp and (port 67 or port 68)'], timeout=10)
+            req2, clients2 = _parse_dhcp_capture(res['out'])
+            ok = req2 == 3 and len(clients2) == 3
+            scenarios.append({'name': 'dhcp-scapy-e2e', 'expect': '3 discovers / 3 clients',
+                              'got': f'{req2} req / {len(clients2)} clients', 'pass': ok})
+            scapy_result = {'ran': True, 'pass': ok,
+                            'tcpdump_out': res['out'].strip()[:200]}
+            try:
+                os.remove(pcap_path)
+            except OSError:
+                pass
+    except Exception as e:
+        scapy_result = {'ran': False, 'reason': f'{type(e).__name__}: {e}'}
+
+    passed = all(s['pass'] for s in scenarios) and (not scapy_result.get('ran')
+                                                    or scapy_result.get('pass'))
+    return {'success': passed, 'scenarios': scenarios, 'scapy': scapy_result}
 
 
 def _tcp_reachable(host, port, timeout=4):
@@ -14495,6 +14674,7 @@ def do_routing_selftest():
               'ldap': _ldap_selftest(),
               'ospf': _ospf_selftest(), 'bgp': _bgp_selftest(),
               'arp': _arp_selftest(), 'dns': _dns_selftest(),
+              'mac': _mac_selftest(), 'dhcp': _dhcp_selftest(),
               'bgp_speaker': bgp_speaker.selftest(), 'path_asymmetry': path_asymmetry.selftest()}
     return {
         'success': all(s['success'] for s in suites.values()),

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -2280,10 +2280,10 @@
                 <!-- Routing-scanner self-test + Scapy -->
                 <div class="glass rounded-xl p-4 sm:p-6 mt-6">
                     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                        <h3 class="text-lg font-semibold">Detector Self-Test <span class="text-xs font-normal text-gray-500">(IGMP · IPv6 · NDP · RA Guard · NTP · ICMP · SNMP · TLS · Cert · STP · DTP · CDP · VTP · SMB · Relay · EIGRP · IS-IS · FHRP · OSPF · LDAP · ARP · DNS · BGP · speaker · OWD)</span></h3>
+                        <h3 class="text-lg font-semibold">Detector Self-Test <span class="text-xs font-normal text-gray-500">(IGMP · IPv6 · NDP · RA Guard · NTP · ICMP · SNMP · TLS · Cert · STP · DTP · CDP · VTP · SMB · Relay · EIGRP · IS-IS · FHRP · OSPF · LDAP · ARP · MAC · DHCP · DNS · BGP · speaker · OWD)</span></h3>
                         <div id="scapy-status" class="text-xs text-gray-400"></div>
                     </div>
-                    <p class="text-sm text-gray-400 mb-3 mt-1">Validates every passive detector by running each classifier against crafted attack captures — no root, no live traffic. Covers the routing/L2 scanners (IGMP, IPv6 first-hop, NDP, STP, DTP, CDP incl. <strong>CDPwn</strong> CVE screening, VTP, EIGRP, IS-IS, FHRP, OSPF), the host/AD detectors (SNMP, TLS, Cert, SMB, LDAP, Relay), and the poisoning checks (<strong>ARP</strong> incl. HSRP/VRRP virtual-MAC awareness, <strong>DNS</strong> poison parser/anchors). Installing <strong>Scapy</strong> adds an end-to-end leg that builds real packets, writes a pcap and parses it back through <span class="font-mono">tcpdump</span> (and Cert Watch grades a real local handshake), so the whole capture→parse→classify path is exercised. Recommended for a fully-validated security tool.</p>
+                    <p class="text-sm text-gray-400 mb-3 mt-1">Validates every passive detector by running each classifier against crafted attack captures — no root, no live traffic. Covers the routing/L2 scanners (IGMP, IPv6 first-hop, NDP, STP, DTP, CDP incl. <strong>CDPwn</strong> CVE screening, VTP, EIGRP, IS-IS, FHRP, OSPF), the host/AD detectors (SNMP, TLS, Cert, SMB, LDAP, Relay), and the poisoning / rogue-device checks (<strong>ARP</strong> incl. HSRP/VRRP virtual-MAC awareness, <strong>MAC</strong> spoof/vendor-OUI/randomization, <strong>DHCP</strong> rogue-server/starvation, <strong>DNS</strong> poison parser/anchors). Installing <strong>Scapy</strong> adds an end-to-end leg that builds real packets, writes a pcap and parses it back through <span class="font-mono">tcpdump</span> (and Cert Watch grades a real local handshake), so the whole capture→parse→classify path is exercised. Recommended for a fully-validated security tool.</p>
                     <div class="flex flex-wrap items-center gap-2">
                         <button onclick="runRoutingSelftest()" class="bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Run self-test</button>
                         <button id="scapy-install-btn" onclick="installNetTool('scapy', this, runRoutingSelftest)" class="hidden bg-slate-700 hover:bg-slate-600 text-gray-200 px-4 py-2 rounded text-sm whitespace-nowrap" title="Install the Scapy Python module for the end-to-end packet-crafting self-test">Install Scapy</button>
@@ -8067,7 +8067,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260816-selftest-3"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260816-selftest-4"></script>
 
 
 

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -9217,6 +9217,7 @@ async function runRoutingSelftest() {
 
         const names = { igmp: 'IGMP Watch', ipv6: 'IPv6 First-Hop Watch', ndp: 'NDP Watch (IPv6 neighbor spoofing)', raguard: 'IPv6 RA Guard', ntp: 'NTP Watch', icmp: 'ICMP Watch', snmp: 'SNMP Watch', cert: 'Cert Watch', tls: 'TLS Watch (passive JA4/QUIC)', stp: 'STP/BPDU Watch (spanning tree)', smb: 'SMB Watch (SMBv1 + poisoning + Kerberos downgrade)', relay: 'Relay/Coercion Watch (NTLM relay)', ldap: 'LDAP Watch (Active Directory)', dtp: 'DTP Watch (VLAN hopping)', cdp: 'CDP Watch (Cisco Discovery leak/flood)', vtp: 'VTP Watch (VTP bomb / VLAN-DB wipe)', eigrp: 'EIGRP Watch (Cisco IGP)', isis: 'IS-IS Watch (IGP)', fhrp: 'FHRP Watch (HSRP/VRRP/GLBP/CARP)', ospf: 'OSPF Scanner', bgp: 'BGP Path Watch',
                         arp: 'ARP Poisoning (incl. HSRP/VRRP virtual-MAC awareness)', dns: 'DNS Doctor (poison parser / anchors / ASN)',
+                        mac: 'MAC Watch (spoof / vendor-OUI / randomization)', dhcp: 'DHCP Guardian (rogue server / starvation)',
                         bgp_speaker: 'BGP Speaker (codec/FSM/RIB)', path_asymmetry: 'Path Asymmetry (OWD)' };
         const overall = d.success
             ? '<div class="mb-2 px-3 py-2 rounded border bg-green-950/40 border-green-900 text-green-400 text-sm">✓ All detector self-tests passed' + (d.scapy_available ? ' (including Scapy end-to-end)' : ' — install Scapy for the end-to-end leg') + '</div>'
@@ -9225,7 +9226,7 @@ async function runRoutingSelftest() {
             '<table class="min-w-full text-xs text-gray-300 whitespace-nowrap"><thead>' +
             '<tr class="text-left text-gray-500"><th class="px-2 py-1">Scanner</th><th class="px-2 py-1">Scenarios</th><th class="px-2 py-1">End-to-end</th><th class="px-2 py-1">Result</th></tr>' +
             '</thead><tbody>';
-        ['igmp', 'ipv6', 'ndp', 'raguard', 'ntp', 'icmp', 'snmp', 'cert', 'tls', 'stp', 'smb', 'relay', 'ldap', 'dtp', 'cdp', 'vtp', 'eigrp', 'isis', 'fhrp', 'ospf', 'arp', 'dns', 'bgp', 'bgp_speaker', 'path_asymmetry'].forEach(k => {
+        ['igmp', 'ipv6', 'ndp', 'raguard', 'ntp', 'icmp', 'snmp', 'cert', 'tls', 'stp', 'smb', 'relay', 'ldap', 'dtp', 'cdp', 'vtp', 'eigrp', 'isis', 'fhrp', 'ospf', 'arp', 'mac', 'dhcp', 'dns', 'bgp', 'bgp_speaker', 'path_asymmetry'].forEach(k => {
             const s = d.suites[k]; if (!s) return;
             const okAll = s.success;
             html += `<tr class="border-t border-slate-800">


### PR DESCRIPTION
The two were missing from the Detector Self-Test. Added _mac_selftest (the spoof/vendor-OUI/virtual/randomized classifier + a Scapy leg that reads a crafted frame's source MAC off the wire via tcpdump and classifies it) and _dhcp_selftest (the tcpdump/nmap text parsers + rogue/starvation/clean verdict logic via a restored monkeypatch + a Scapy leg that crafts real DHCP DISCOVERs -> pcap -> tcpdump -> parse). Wired both into do_routing_selftest (27 suites, all green) and the card label/description + JS renderer.

The DHCP Scapy leg caught a real bug in _parse_dhcp_capture: tcpdump prints Client-Ethernet-Address BEFORE the DHCP-Message type, but the parser only counted a client MAC once the type was already seen — so it dropped the first client and mis-shifted the rest, undercounting distinct clients and risking a MISSED DHCP starvation alert. Fixed to hold the chaddr and attribute it when the message type is known (server OFFER/ACK still excluded). Verified against real tcpdump output.