### PR TITLE
mac watch: HSRP/VRRP/GLBP virtual-MAC awareness + VIP-hijack detection

### DIFF
--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -408,7 +408,8 @@ neighbour-table snapshot can't see.
 **Detection-only** MAC-spoofing + randomization monitor — it *never spoofs or
 randomizes anything itself*. Passive: it reads the kernel neighbour table
 (`ip neigh`) and, optionally, runs an `arp-scan` sweep to widen coverage. Three
-jobs, rolled into one **clean / randomization / suspicious / spoofed** verdict:
+jobs, rolled into one **clean / randomization / fhrp / suspicious / spoofed**
+verdict:
 
 1. **Spoofing / cloning** (current *and* past):
    - **Disguised vendor** — a registered vendor OUI wearing the
@@ -427,8 +428,22 @@ jobs, rolled into one **clean / randomization / suspicious / spoofed** verdict:
 3. **Tracking** — an IP that cycles through **≥2 randomized MACs** over time is
    one device rotating to hide; its addresses are grouped into a followable
    track so it can be traced across the MACs it hides behind.
+4. **FHRP (HSRP/VRRP/GLBP) virtual-MAC awareness** — first-hop-redundancy
+   protocols give several physical routers one shared *virtual* MAC that is
+   legitimately shared and **moves between boxes on failover** — behaviour a
+   naive identity monitor misreads as spoofing. MAC Watch recognizes the
+   virtual-MAC formats (HSRP v1 `00:00:0c:07:ac:GG`, HSRP v2 `00:00:0c:9f:fX:XX`,
+   VRRP `00:00:5e:00:01:VV`, VRRPv3/IPv6 `00:00:5e:00:02:VV`, GLBP `00:07:b4:…`)
+   so the gateway's redundancy MAC is **inventoried (INFO), never flagged as a
+   clone/spoof**. The inverse is the alarm: it learns which IPs are FHRP VIPs
+   (any IP ever answered by a virtual MAC, plus declared `fhrp_declared_vips`)
+   and raises **spoofed** if a VIP is suddenly answered by a *non-virtual* MAC —
+   an ARP-spoof of the redundancy group. This is the identity-forensics side of
+   the `arp_guard` / [FHRP Watch](#fhrp-watch) cross-pivot; reconcile its
+   inventory against FHRP Watch findings.
 
-Every MAC is classified as **Vendor** (universal/burned-in), **Spoofed**
+Every MAC is classified as **Vendor** (universal/burned-in), **FHRP virtual**
+(HSRP/VRRP/GLBP redundancy), **Spoofed**
 (vendor OUI + LAA bit), **Randomized** (privacy), or **Virtual/VM**. Vendor
 names come from the `arp-scan` / `nmap` OUI database
 (`/usr/share/arp-scan/ieee-oui.txt`, ~35k prefixes) with a built-in seed

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -797,8 +797,10 @@ def _arp_baseline_save(d):
 # Recognition is a pure shape match (informational); real de-escalation needs an
 # operator-confirmed pin (a MAC is spoofable), mirroring python/arp_guard.py.
 def _arp_fhrp_classify(mac):
-    """(proto, group) if `mac` is in an HSRP/VRRP virtual-MAC range, else None.
-    HSRPv1 00:00:0c:07:ac:GG, HSRPv2 00:00:0c:9f:fG:GG, VRRP 00:00:5e:00:01:VV."""
+    """(proto, group) if `mac` is in an HSRP/VRRP/GLBP virtual-MAC range, else
+    None. HSRPv1 00:00:0c:07:ac:GG, HSRPv2 00:00:0c:9f:fG:GG,
+    VRRP(IPv4) 00:00:5e:00:01:VV, VRRPv3(IPv6) 00:00:5e:00:02:VV,
+    GLBP 00:07:b4:xx:xx:xx (group/forwarder suffix left raw, so group is None)."""
     try:
         b = bytes(int(p, 16) for p in (mac or '').split(':'))
     except (ValueError, AttributeError):
@@ -811,11 +813,18 @@ def _arp_fhrp_classify(mac):
         return ('HSRPv2', ((b[4] & 0x0f) << 8) | b[5])
     if b[:5] == b'\x00\x00\x5e\x00\x01':
         return ('VRRP', b[5])
+    if b[:5] == b'\x00\x00\x5e\x00\x02':
+        return ('VRRPv3-IPv6', b[5])
+    if b[:3] == b'\x00\x07\xb4':
+        return ('GLBP', None)
     return None
 
 
 def _arp_fhrp_desc(info):
-    return None if not info else '%s group %d' % info
+    if not info:
+        return None
+    proto, group = info
+    return proto if group is None else '%s group %d' % (proto, group)
 
 
 def _arp_suggest_fhrp():
@@ -1140,11 +1149,13 @@ def _vendor_for_prefix(prefix6):
 def _classify_mac(mac):
     """Classify one MAC. Returns {klass, vendor, note}.
 
-    klass ∈ {'universal', 'spoofed_vendor_oui', 'virtual_laa', 'randomized',
-             'invalid'}. A universal address is a normal burned-in NIC; the
-    three LAA buckets are kept distinct so privacy randomization (benign, an
-    aggregate) never gets conflated with a vendor OUI wearing the LAA bit
-    (impersonation) or with a VM/container NIC."""
+    klass ∈ {'universal', 'fhrp_virtual', 'spoofed_vendor_oui', 'virtual_laa',
+             'randomized', 'invalid'}. A universal address is a normal burned-in
+    NIC; fhrp_virtual is an HSRP/VRRP/GLBP redundancy virtual MAC (legitimately
+    shared and moved between routers on failover, so it must not read as a
+    clone/spoof); the two LAA buckets past that are kept distinct so privacy
+    randomization (benign, an aggregate) never gets conflated with a vendor OUI
+    wearing the LAA bit (impersonation) or with a VM/container NIC."""
     m = _mac_norm(mac)
     if not m:
         return {'klass': 'invalid', 'vendor': None, 'note': 'not a MAC'}
@@ -1153,6 +1164,15 @@ def _classify_mac(mac):
     if b0 & 0x01:  # multicast/broadcast — never a valid source address
         return {'klass': 'invalid', 'vendor': None, 'note': 'multicast/broadcast'}
     if not (b0 & 0x02):  # universal — legitimately-registered OUI
+        # FHRP (HSRP/VRRP/GLBP) virtual MACs use real universal OUIs (Cisco/IANA)
+        # that a bare vendor lookup would miss, reading them as an unregistered
+        # universal address. Recognize the redundancy shapes so the gateway's
+        # virtual MAC is inventoried (INFO), never mistaken for a spoof — and so
+        # VIP-hijack detection can tell a virtual owner from a non-virtual one.
+        fhrp = _arp_fhrp_classify(m)
+        if fhrp:
+            return {'klass': 'fhrp_virtual', 'vendor': fhrp[0],
+                    'note': (_arp_fhrp_desc(fhrp) or fhrp[0]) + ' virtual MAC'}
         vendor = _vendor_for_prefix(prefix6)
         return {'klass': 'universal', 'vendor': vendor, 'note': None}
     # Locally-administered: virtual, disguised-vendor, or privacy randomization.
@@ -1260,12 +1280,38 @@ def do_mac_watch(scan=True, interface=None):
                         'klass': info['klass'], 'vendor': info['vendor'],
                         'note': info['note']})
 
+    # Which MAC currently answers for each IP, and which IPs are answered right
+    # now by an FHRP (HSRP/VRRP/GLBP) virtual MAC — the redundancy VIPs. Used by
+    # the FHRP-awareness pass below to learn VIPs and catch a VIP hijack.
+    ip_to_mac = {}
+    for c in current:
+        for ip in c['ips']:
+            ip_to_mac.setdefault(ip, c['mac'])
+    fhrp_now = {}  # vip -> {mac, proto, group}
+    for c in current:
+        if c['klass'] != 'fhrp_virtual':
+            continue
+        info = _arp_fhrp_classify(c['mac'])
+        for ip in c['ips']:
+            fhrp_now[ip] = {'mac': c['mac'], 'proto': info[0] if info else None,
+                            'group': info[1] if info else None}
+
     # --- update the persistent store (this is what makes "past" possible) ----
     with _mac_watch_lock:
         store = _mac_watch_load()
         macs = store.setdefault('macs', {})
         ip_hist = store.setdefault('ip_history', {})
         events = store.setdefault('events', [])
+        # Learn FHRP VIPs: any IP ever answered by a virtual MAC is a redundancy
+        # VIP whose true owner is a virtual MAC. Persisted so hijack detection
+        # survives a reboot and works even when the virtual MAC is momentarily
+        # absent (failover). Operators can also declare VIPs up front via the
+        # 'fhrp_declared_vips' store key so hijack detection works on first scan.
+        fhrp_vips = store.setdefault('fhrp_vips', {})
+        for ip, meta in fhrp_now.items():
+            rec = fhrp_vips.setdefault(ip, {'first': now})
+            rec.update({'mac': meta['mac'], 'proto': meta['proto'],
+                        'group': meta['group'], 'last': now})
 
         for c in current:
             rec = macs.setdefault(c['mac'], {'first': now, 'count': 0,
@@ -1316,9 +1362,11 @@ def do_mac_watch(scan=True, interface=None):
                        f"locally-administered bit set — MAC-spoofing signature "
                        f"(IP {', '.join(c['ips']) or 'unknown'})")
 
-    # (2) Clones — one MAC currently bound to several IPs (gateway excluded).
+    # (2) Clones — one MAC currently bound to several IPs (gateway + FHRP virtual
+    # MACs excluded: a redundancy virtual MAC legitimately answers for its VIP).
     clones = [c for c in current
-              if len(c['ips']) >= _MAC_CLONE_MIN_IPS and c['mac'] != gw_mac]
+              if len(c['ips']) >= _MAC_CLONE_MIN_IPS and c['mac'] != gw_mac
+              and c['klass'] != 'fhrp_virtual']
     for c in clones:
         reasons.append(f"{c['mac']} answers for {len(c['ips'])} IPs "
                        f"({', '.join(c['ips'][:4])}"
@@ -1379,10 +1427,43 @@ def do_mac_watch(scan=True, interface=None):
         reasons.append(f"device at {t['ip']} rotated through {len(t['macs'])} "
                        f"randomized MACs — tracked across its address changes")
 
-    if spoofed or clones or hi_events:
+    # (6) FHRP (HSRP/VRRP/GLBP) awareness — inventory the redundancy virtual MACs
+    # (INFO), and flag any learned/declared VIP now answered by a *non-virtual*
+    # MAC as a gateway hijack (an ARP-spoof of the redundancy group — CRITICAL).
+    # The arp_guard / fhrpwatch cross-pivot, from the identity-forensics side.
+    with _mac_watch_lock:
+        store = _mac_watch_load()
+        known_vips = dict(store.get('fhrp_vips') or {})
+        declared_vips = [v for v in (store.get('fhrp_declared_vips') or []) if v]
+    fhrp_virtuals = [c for c in current if c['klass'] == 'fhrp_virtual']
+    for c in fhrp_virtuals:
+        reasons.append(f"{c['mac']} is an {c['note']} answering for "
+                       f"{', '.join(c['ips']) or 'no IP'} — FHRP redundancy (expected)")
+    fhrp_hijacks = []
+    for vip in sorted(set(list(known_vips) + declared_vips)):
+        cur_mac = ip_to_mac.get(vip)
+        if not cur_mac or _classify_mac(cur_mac)['klass'] == 'fhrp_virtual':
+            continue  # unanswered this pass, or still owned by a virtual MAC
+        meta = known_vips.get(vip) or {}
+        proto = meta.get('proto') or 'FHRP'
+        fhrp_hijacks.append({'vip': vip, 'mac': cur_mac, 'proto': proto,
+                             'expected_mac': meta.get('mac')})
+        reasons.append(f"FHRP VIP {vip} is answered by non-virtual MAC {cur_mac} "
+                       f"(a {proto} redundancy address is expected) — possible "
+                       f"gateway hijack / ARP-spoof of the redundancy group")
+    fhrp = {
+        'virtual': [{'mac': c['mac'], 'ips': c['ips'], 'proto': c['vendor'],
+                     'note': c['note']} for c in fhrp_virtuals],
+        'vips': sorted(set(list(known_vips) + declared_vips)),
+        'declared_vips': declared_vips,
+        'hijacks': fhrp_hijacks,
+    }
+
+    if spoofed or clones or hi_events or fhrp_hijacks:
         verdict = 'spoofed'
-    elif tracks or randomized:
-        verdict = 'suspicious' if tracks else 'randomization'
+    elif tracks or randomized or fhrp_virtuals:
+        verdict = 'suspicious' if tracks else ('fhrp' if fhrp_virtuals and not randomized
+                                               else 'randomization')
 
     return {
         'success': True, 'verdict': verdict,
@@ -1394,9 +1475,12 @@ def do_mac_watch(scan=True, interface=None):
             'randomized': len(randomized),
             'virtual': len(virtual),
             'tracks': len(tracks),
+            'fhrp_virtual': len(fhrp_virtuals),
+            'fhrp_hijacks': len(fhrp_hijacks),
         },
         'spoofed': spoofed,
         'clones': clones,
+        'fhrp': fhrp,
         # Every MAC seen this pass, worst class first, so the UI can list them.
         'observed_macs': sorted(
             current,
@@ -3517,6 +3601,47 @@ def _mac_selftest():
     run('mac-virtual-laa', '02:42:ac:11:00:02', 'virtual_laa')          # Docker
     run('mac-randomized', 'f6:11:22:33:44:55', 'randomized')            # LAA, no vendor
     run('mac-invalid-mcast', '01:00:5e:00:00:01', 'invalid')
+    # FHRP (HSRP/VRRP/GLBP) virtual MACs must classify as fhrp_virtual, not as an
+    # unregistered universal address that would read as a clone/spoof.
+    run('mac-fhrp-hsrpv1', '00:00:0c:07:ac:0a', 'fhrp_virtual')
+    run('mac-fhrp-hsrpv2', '00:00:0c:9f:f0:63', 'fhrp_virtual')
+    run('mac-fhrp-vrrp', '00:00:5e:00:01:05', 'fhrp_virtual')
+    run('mac-fhrp-vrrpv3', '00:00:5e:00:02:05', 'fhrp_virtual')
+    run('mac-fhrp-glbp', '00:07:b4:00:01:02', 'fhrp_virtual')
+
+    # VIP-hijack verdict leg: a learned FHRP VIP now answered by a non-virtual MAC
+    # is a redundancy-group hijack (verdict 'spoofed'); the clean case (VIP still
+    # owned by its virtual MAC) must stay benign. Monkeypatch the neighbour-table
+    # + store seams and restore them, so this needs no wire and no root.
+    g = globals()
+    saved = {k: g[k] for k in ('_neigh_entries', '_default_gateway', '_neigh_mac',
+                               '_local_macs', '_mac_watch_load', '_mac_watch_save',
+                               '_have')}
+    try:
+        vip = '10.9.9.1'
+        state = {'store': {'fhrp_vips': {vip: {'mac': '00:00:5e:00:01:05',
+                                               'proto': 'VRRP', 'group': 5}}}}
+        g['_default_gateway'] = lambda: None
+        g['_neigh_mac'] = lambda ip: None
+        g['_local_macs'] = lambda: set()
+        g['_have'] = lambda tool: False        # no arp-scan sweep
+        g['_mac_watch_load'] = lambda: state['store']
+        g['_mac_watch_save'] = lambda d: state.__setitem__('store', d)
+        # clean: VIP still answered by its VRRP virtual MAC
+        g['_neigh_entries'] = lambda: [(vip, '00:00:5e:00:01:05', 'REACHABLE')]
+        clean = do_mac_watch(scan=False)
+        scenarios.append({'name': 'mac-fhrp-vip-clean', 'expect': 'not spoofed',
+                          'got': clean.get('verdict'),
+                          'pass': not clean.get('fhrp', {}).get('hijacks')})
+        # hijack: VIP now answered by an ordinary vendor (non-virtual) MAC
+        g['_neigh_entries'] = lambda: [(vip, 'b8:27:eb:aa:bb:cc', 'REACHABLE')]
+        hij = do_mac_watch(scan=False)
+        scenarios.append({'name': 'mac-fhrp-vip-hijack', 'expect': 'spoofed',
+                          'got': hij.get('verdict'),
+                          'pass': hij.get('verdict') == 'spoofed'
+                          and bool(hij.get('fhrp', {}).get('hijacks'))})
+    finally:
+        g.update(saved)
 
     scapy_result = {'ran': False, 'reason': 'scapy or tcpdump unavailable'}
     try:
@@ -3526,6 +3651,7 @@ def _mac_selftest():
             frames, want = [], {}
             for mac, exp in (('b8:27:eb:44:55:66', 'universal'),
                              ('ba:27:eb:44:55:66', 'spoofed_vendor_oui'),
+                             ('00:00:5e:00:01:2a', 'fhrp_virtual'),
                              ('02:42:ac:11:00:09', 'virtual_laa')):
                 frames.append(Ether(src=mac, dst='ff:ff:ff:ff:ff:ff', type=0x0800)
                               / (b'\x00' * 40))

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -1734,7 +1734,7 @@
                             <div class="min-w-0">
                                 <h3 class="text-lg font-semibold mb-1">MAC Watch</h3>
                                 <p class="text-xs text-amber-300/90 mb-2">Detection-only MAC-spoofing + randomization monitor — never spoofs anything. Flags a vendor OUI wearing the locally-administered bit (disguised vendor), a MAC cloned across several IPs, and an IP whose MAC changed identity (current <em>and</em> past spoofing).</p>
-                                <p class="text-sm text-gray-400 mb-3">Also inventories privacy-randomized MACs on the segment, and <strong>tracks</strong> a device that rotates through several randomized addresses — following it across the MACs it hides behind. Reads the neighbour table (+ optional arp-scan sweep); history persists so past events survive restarts. Cross-MAC tracking here is IP-anchored (capture-free); true fingerprint tracking needs monitor mode.</p>
+                                <p class="text-sm text-gray-400 mb-3">Also inventories privacy-randomized MACs on the segment, and <strong>tracks</strong> a device that rotates through several randomized addresses — following it across the MACs it hides behind. Adds <strong>HSRP/VRRP/GLBP virtual-MAC awareness</strong>: it recognizes first-hop-redundancy virtual MACs so a shared gateway MAC that legitimately moves between routers on failover never reads as a spoof/clone — and flags the inverse, an FHRP redundancy VIP suddenly answered by a <em>non-virtual</em> MAC, as a gateway hijack (the arp_guard / FHRP-Watch cross-pivot). Reads the neighbour table (+ optional arp-scan sweep); history persists so past events survive restarts. Cross-MAC tracking here is IP-anchored (capture-free); true fingerprint tracking needs monitor mode.</p>
                             </div>
                         </div>
                         <div class="flex flex-wrap items-center gap-2">
@@ -2283,7 +2283,7 @@
                         <h3 class="text-lg font-semibold">Detector Self-Test <span class="text-xs font-normal text-gray-500">(IGMP · IPv6 · NDP · RA Guard · NTP · ICMP · SNMP · TLS · Cert · STP · DTP · CDP · VTP · SMB · Relay · EIGRP · IS-IS · FHRP · OSPF · LDAP · ARP · MAC · DHCP · DNS · BGP · speaker · OWD)</span></h3>
                         <div id="scapy-status" class="text-xs text-gray-400"></div>
                     </div>
-                    <p class="text-sm text-gray-400 mb-3 mt-1">Validates every passive detector by running each classifier against crafted attack captures — no root, no live traffic. Covers the routing/L2 scanners (IGMP, IPv6 first-hop, NDP, STP, DTP, CDP incl. <strong>CDPwn</strong> CVE screening, VTP, EIGRP, IS-IS, FHRP, OSPF), the host/AD detectors (SNMP, TLS, Cert, SMB, LDAP, Relay), and the poisoning / rogue-device checks (<strong>ARP</strong> incl. HSRP/VRRP virtual-MAC awareness, <strong>MAC</strong> spoof/vendor-OUI/randomization, <strong>DHCP</strong> rogue-server/starvation, <strong>DNS</strong> poison parser/anchors). Installing <strong>Scapy</strong> adds an end-to-end leg that builds real packets, writes a pcap and parses it back through <span class="font-mono">tcpdump</span> (and Cert Watch grades a real local handshake), so the whole capture→parse→classify path is exercised. Recommended for a fully-validated security tool.</p>
+                    <p class="text-sm text-gray-400 mb-3 mt-1">Validates every passive detector by running each classifier against crafted attack captures — no root, no live traffic. Covers the routing/L2 scanners (IGMP, IPv6 first-hop, NDP, STP, DTP, CDP incl. <strong>CDPwn</strong> CVE screening, VTP, EIGRP, IS-IS, FHRP, OSPF), the host/AD detectors (SNMP, TLS, Cert, SMB, LDAP, Relay), and the poisoning / rogue-device checks (<strong>ARP</strong> incl. HSRP/VRRP virtual-MAC awareness, <strong>MAC</strong> spoof/vendor-OUI/randomization incl. HSRP/VRRP virtual-MAC awareness, <strong>DHCP</strong> rogue-server/starvation, <strong>DNS</strong> poison parser/anchors). Installing <strong>Scapy</strong> adds an end-to-end leg that builds real packets, writes a pcap and parses it back through <span class="font-mono">tcpdump</span> (and Cert Watch grades a real local handshake), so the whole capture→parse→classify path is exercised. Recommended for a fully-validated security tool.</p>
                     <div class="flex flex-wrap items-center gap-2">
                         <button onclick="runRoutingSelftest()" class="bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Run self-test</button>
                         <button id="scapy-install-btn" onclick="installNetTool('scapy', this, runRoutingSelftest)" class="hidden bg-slate-700 hover:bg-slate-600 text-gray-200 px-4 py-2 rounded text-sm whitespace-nowrap" title="Install the Scapy Python module for the end-to-end packet-crafting self-test">Install Scapy</button>
@@ -8067,7 +8067,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260816-selftest-4"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260818-macwatch-fhrp"></script>
 
 
 

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -6407,7 +6407,7 @@ const _NETINT_STYLE = {
 // A verdict is clean/informational, an active attack (critical, red), or — anything
 // else non-clean — a suspicious finding (amber). Mirrors the server's _ni_rank so the
 // chips colour every scanner's verdicts without enumerating them all.
-const _NETINT_CLEAN = new Set(['clean', 'unknown', 'ok', 'none', 'hardened', 'learned', 'n/a', 'no-traffic', 'disabled']);
+const _NETINT_CLEAN = new Set(['clean', 'unknown', 'ok', 'none', 'hardened', 'learned', 'n/a', 'no-traffic', 'disabled', 'not-applicable', 'randomization', 'fhrp']);
 const _NETINT_CRITICAL = new Set(['hijacked', 'spoofed', 'rogue', 'starvation', 'compromised', 'root-hijack', 'bpdu-flood', 'vlan-hop', 'hijack', 'injection', 'rogue-router', 'poisoning', 'spoof-conflict', 'smbv1-active', 'coercion-attempt', 'relay-suspected', 'rogue-speaker', 'rogue-redirect', 'rogue-ra', 'rogue-irdp', 'cdpwn']);
 function _netintRank(verdict) {
     const v = verdict || 'unknown';
@@ -9217,7 +9217,7 @@ async function runRoutingSelftest() {
 
         const names = { igmp: 'IGMP Watch', ipv6: 'IPv6 First-Hop Watch', ndp: 'NDP Watch (IPv6 neighbor spoofing)', raguard: 'IPv6 RA Guard', ntp: 'NTP Watch', icmp: 'ICMP Watch', snmp: 'SNMP Watch', cert: 'Cert Watch', tls: 'TLS Watch (passive JA4/QUIC)', stp: 'STP/BPDU Watch (spanning tree)', smb: 'SMB Watch (SMBv1 + poisoning + Kerberos downgrade)', relay: 'Relay/Coercion Watch (NTLM relay)', ldap: 'LDAP Watch (Active Directory)', dtp: 'DTP Watch (VLAN hopping)', cdp: 'CDP Watch (Cisco Discovery leak/flood)', vtp: 'VTP Watch (VTP bomb / VLAN-DB wipe)', eigrp: 'EIGRP Watch (Cisco IGP)', isis: 'IS-IS Watch (IGP)', fhrp: 'FHRP Watch (HSRP/VRRP/GLBP/CARP)', ospf: 'OSPF Scanner', bgp: 'BGP Path Watch',
                         arp: 'ARP Poisoning (incl. HSRP/VRRP virtual-MAC awareness)', dns: 'DNS Doctor (poison parser / anchors / ASN)',
-                        mac: 'MAC Watch (spoof / vendor-OUI / randomization)', dhcp: 'DHCP Guardian (rogue server / starvation)',
+                        mac: 'MAC Watch (spoof / vendor-OUI / randomization / HSRP-VRRP virtual-MAC)', dhcp: 'DHCP Guardian (rogue server / starvation)',
                         bgp_speaker: 'BGP Speaker (codec/FSM/RIB)', path_asymmetry: 'Path Asymmetry (OWD)' };
         const overall = d.success
             ? '<div class="mb-2 px-3 py-2 rounded border bg-green-950/40 border-green-900 text-green-400 text-sm">✓ All detector self-tests passed' + (d.scapy_available ? ' (including Scapy end-to-end)' : ' — install Scapy for the end-to-end leg') + '</div>'
@@ -9361,6 +9361,7 @@ async function runDhcpSnoop() {
 const _MACWATCH_VERDICT_STYLE = {
     clean:         ['bg-green-950/40 border-green-900 text-green-400', '✓ No MAC spoofing or rotation detected'],
     randomization: ['bg-sky-950/40 border-sky-900 text-sky-300', 'ℹ Privacy-randomized MACs present (no spoofing)'],
+    fhrp:          ['bg-sky-950/40 border-sky-900 text-sky-300', 'ℹ FHRP (HSRP/VRRP/GLBP) redundancy virtual MAC present (expected)'],
     suspicious:    ['bg-amber-950/50 border-amber-800 text-amber-300', '⚠ Device rotating randomized MACs — being tracked'],
     spoofed:       ['bg-red-950/60 border-red-800 text-red-300', '🛑 MAC spoofing / cloning detected'],
     unknown:       ['bg-slate-800 border-slate-700 text-slate-400', '— Could not determine'],
@@ -9416,6 +9417,8 @@ async function runMacWatch(scan) {
             chip(s.randomized || 0, ' randomized') +
             chip(s.virtual || 0, ' virtual') +
             chip(s.tracks || 0, ' tracked devices') +
+            chip(s.fhrp_virtual || 0, ' FHRP virtual') +
+            chip(s.fhrp_hijacks || 0, ' FHRP hijacks', true) +
             '</div>';
 
         // Spoofed / disguised-vendor MACs
@@ -9430,6 +9433,22 @@ async function runMacWatch(scan) {
             html += '<p class="text-xs uppercase text-red-400 mt-3 mb-1">Cloned (one MAC, several IPs)</p>' +
                 '<ul class="text-xs text-gray-300 list-disc pl-5">' +
                 d.clones.map(c => `<li class="font-mono">${escapeHtml(c.mac)} → ${escapeHtml((c.ips || []).slice(0, 6).join(', '))}${(c.ips || []).length > 6 ? '…' : ''}</li>`).join('') +
+                '</ul>';
+        }
+        // FHRP (HSRP/VRRP/GLBP) VIP hijack — a redundancy VIP answered by a
+        // non-virtual MAC (ARP-spoof of the gateway group). Critical.
+        const fhrp = d.fhrp || {};
+        if (fhrp.hijacks && fhrp.hijacks.length) {
+            html += '<p class="text-xs uppercase text-red-400 mt-3 mb-1">FHRP VIP hijack (redundancy gateway spoof)</p>' +
+                '<ul class="text-xs text-gray-300 list-disc pl-5">' +
+                fhrp.hijacks.map(h => `<li class="font-mono">${escapeHtml(h.vip)} answered by ${escapeHtml(h.mac)} <span class="text-gray-500">(non-virtual — ${escapeHtml(h.proto || 'FHRP')} virtual MAC expected${h.expected_mac ? ', was ' + escapeHtml(h.expected_mac) : ''})</span></li>`).join('') +
+                '</ul>';
+        }
+        // FHRP virtual-MAC inventory (benign redundancy addresses on the segment).
+        if (fhrp.virtual && fhrp.virtual.length) {
+            html += '<p class="text-xs uppercase text-sky-400 mt-3 mb-1">FHRP redundancy virtual MACs (expected)</p>' +
+                '<ul class="text-xs text-gray-400 list-disc pl-5">' +
+                fhrp.virtual.map(v => `<li class="font-mono">${escapeHtml(v.mac)} <span class="text-gray-500">(${escapeHtml(v.note || v.proto || 'FHRP')})</span> → ${escapeHtml((v.ips || []).join(', ') || 'no IP')}</li>`).join('') +
                 '</ul>';
         }
         // Tracked devices (rotating randomized MACs)
@@ -9462,6 +9481,7 @@ async function runMacWatch(scan) {
             const KLASS = {
                 spoofed_vendor_oui: ['Spoofed', 'text-red-300'],
                 universal:          ['Vendor', 'text-gray-300'],
+                fhrp_virtual:       ['FHRP virtual', 'text-sky-300'],
                 randomized:         ['Randomized', 'text-sky-300'],
                 virtual_laa:        ['Virtual/VM', 'text-gray-400'],
             };
@@ -9509,13 +9529,15 @@ async function macWatchReset() {
 function exportMacWatchCsv() {
     const d = _ndLastMacWatch;
     const TYPE = { spoofed_vendor_oui: 'Spoofed', universal: 'Vendor',
-                  randomized: 'Randomized', virtual_laa: 'Virtual/VM' };
+                  fhrp_virtual: 'FHRP virtual', randomized: 'Randomized',
+                  virtual_laa: 'Virtual/VM' };
     _ndDownloadCsv('mac_watch' + (d && d.interface ? '_' + d.interface : ''),
         ['MAC', 'Type', 'Vendor', 'IPs', 'Flag', 'Note'],
         ((d && d.observed_macs) || []).map(c => {
             const ips = c.ips || [];
             const flag = c.klass === 'spoofed_vendor_oui' ? 'SPOOFED'
-                : (ips.length > 1 ? 'CLONE (multiple IPs)' : '');
+                : (c.klass === 'fhrp_virtual' ? 'FHRP redundancy'
+                : (ips.length > 1 ? 'CLONE (multiple IPs)' : ''));
             return [c.mac, TYPE[c.klass] || c.klass, c.vendor || '',
                     ips.join(' '), flag, c.note || ''];
         }));

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -1838,7 +1838,8 @@ def _ni_save_memory():
 # surface without needing to be enumerated here.
 _NI_CLEAN = {'clean', 'unknown', 'ok', 'none', 'hardened', 'learned', 'n/a',
              'no-traffic', 'disabled', 'not-applicable',
-             'randomization'}       # mac: privacy-MAC inventory is benign, not an alert
+             'randomization',       # mac: privacy-MAC inventory is benign, not an alert
+             'fhrp'}                # mac: HSRP/VRRP/GLBP virtual-MAC inventory is expected
 _NI_CRITICAL = {
     'hijacked', 'spoofed', 'rogue', 'starvation', 'compromised',        # dns/arp/dhcp
     'root-hijack', 'bpdu-flood',                                        # stp


### PR DESCRIPTION
Port the Mac Watch v2 collaborator fix into the in-app MAC Watch. FHRP redundancy virtual MACs (HSRP v1/v2, VRRP, VRRPv3-IPv6, GLBP) use real universal OUIs and legitimately move between routers on failover, so a naive identity monitor misreads them as a clone/spoof.

- _classify_mac: recognize FHRP virtual MACs as a new 'fhrp_virtual' klass (INFO inventory), never a spoof; extend the shared _arp_fhrp_classify to cover VRRPv3-IPv6 + GLBP and fix _arp_fhrp_desc for groupless protocols.
- do_mac_watch: learn FHRP VIPs (persisted; declarable via fhrp_declared_vips), exclude virtual MACs from clone detection, and raise 'spoofed' when a VIP is answered by a non-virtual MAC (ARP-spoof of the redundancy group) — the arp_guard/FHRP-Watch cross-pivot from the identity-forensics side.
- Network Integrity Monitor: 'fhrp' verdict ranks clean (benign inventory).
- _mac_selftest: +7 legs (5 classifier, clean + hijack verdict), +FHRP wire leg in the scapy e2e path. 27/27 aggregator suites pass.
- Web: FHRP chips, hijack + virtual-inventory blocks, klass labels, CSV type; card wording; self-test card wording; cache-bust bump. Docs updated.