### PR TITLE
Fix headless install blanking DPI/HDMI panels (HackBerry Pi)

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -106,6 +106,23 @@ If you *did* pick a display profile on non-Pi hardware, the driver summary will
 honestly report the display types that will not work — that is expected, not a
 failed install.
 
+#### Boards with a built-in DPI/HDMI panel (HackBerry Pi and similar)
+
+Some Pi-based devices ship with their own DPI/HDMI screen that already owns SPI0
+and the display GPIOs (e.g. the HackBerry Pi, HyperPixel, or any
+`dtoverlay=vc4-kms-dpi` panel). Ragnar's e-Paper/TFT driver drives those same
+pins, so a **display** install would blank that panel. For these boards pick a
+**headless (web-only) profile** — `Raspberry Pi headless` or `hbp0_ragnar`
+(HackBerry Pi) — which runs `headlessRagnar.py` and never touches the display.
+
+Headless installs set `RAGNAR_HEADLESS=1` (in the entrypoint and in the systemd
+unit), which skips EPD initialization entirely. This matters because the display
+is initialized at import time: without the guard, simply importing Ragnar's
+shared state would seize SPI0 + GPIO and blank the DPI panel — regardless of
+which entrypoint launched. If a device with a DPI panel was accidentally set up
+with a display profile, `sudo bash update_ragnar.sh` repoints an already-headless
+unit and adds the guard, or re-run the installer and choose a headless profile.
+
 #### Changing your screen
 
 The installer asks which screen you have, but that is only a starting value —

--- a/headlessRagnar.py
+++ b/headlessRagnar.py
@@ -15,6 +15,13 @@ import sys
 import subprocess
 import logging
 
+# Headless mode: never touch the physical display. SharedData() initializes the
+# EPD at import time (constructing EPDHelper / running auto_detect), which drives
+# SPI0 + control GPIOs and blanks a DPI/HDMI panel on shared-pin boards like the
+# HackBerry Pi. Set the guard BEFORE importing shared_data so the EPD init is
+# skipped regardless of how this entrypoint was launched (systemd, CLI, etc.).
+os.environ['RAGNAR_HEADLESS'] = '1'
+
 from init_shared import shared_data
 from comment import Commentaireia
 from webapp_modern import run_server

--- a/install_ragnar.sh
+++ b/install_ragnar.sh
@@ -1511,6 +1511,16 @@ ExecStartPre=-/usr/bin/python3 -OO /home/ragnar/Ragnar/wipe_epd.py
 EOF
     fi
 
+    if [ "$HEADLESS_MODE" = true ]; then
+        # Never initialize the EPD on headless (web-only) installs. SharedData()
+        # inits the display at import time, which seizes SPI0 + GPIO and blanks a
+        # DPI/HDMI panel on shared-pin boards (HackBerry Pi). The headless
+        # entrypoint also sets this itself; this makes it explicit in the unit.
+        cat >> /etc/systemd/system/ragnar.service << EOF
+Environment=RAGNAR_HEADLESS=1
+EOF
+    fi
+
     cat >> /etc/systemd/system/ragnar.service << EOF
 ExecStart=/usr/bin/python3 -OO /home/ragnar/Ragnar/${entrypoint_file}
 WorkingDirectory=/home/ragnar/Ragnar

--- a/shared.py
+++ b/shared.py
@@ -211,6 +211,11 @@ class SharedData:
     def __init__(self):
         # Detect Pager mode (set by pager_payload.sh before Python launch)
         self._pager_mode = os.environ.get('RAGNAR_PAGER_MODE') == '1'
+        # Detect Headless mode (set by headlessRagnar.py / systemd on web-only
+        # installs). Like Pager mode it must never initialize the EPD, which
+        # would seize SPI0 + GPIO and blank a DPI/HDMI panel on shared-pin
+        # boards (HackBerry Pi and similar).
+        self._headless_mode = os.environ.get('RAGNAR_HEADLESS') == '1'
 
         self.initialize_paths() # Initialize the paths used by the application
 
@@ -1117,8 +1122,8 @@ class SharedData:
     #         raise
     def initialize_epd_display(self):
         """Initialize the e-paper display."""
-        if EPDHelper is None or self._pager_mode:
-            logger.info("EPD not available (Pager mode or missing module) - skipping EPD init")
+        if EPDHelper is None or self._pager_mode or self._headless_mode:
+            logger.info("EPD not available (Pager/Headless mode or missing module) - skipping EPD init")
             self.epd_helper = None
             fallback_profile = DISPLAY_PROFILES.get(DEFAULT_EPD_TYPE, {"ref_width": 122, "ref_height": 250, "default_flip": False})
             epd_type = self.config.get('epd_type') or DEFAULT_EPD_TYPE

--- a/update_ragnar.sh
+++ b/update_ragnar.sh
@@ -389,6 +389,19 @@ if [ -f "$SENSING_UNIT" ] && grep -q '^Environment=WDP_GUARD_INTERVAL_US=200000'
     echo -e "${GREEN}Raised sensing fusion guard to 350 ms (was 200 ms).${NC}"
 fi
 
+# Headless (web-only) installs must never initialize the EPD: SharedData() inits
+# the display at import time, seizing SPI0 + GPIO and blanking a DPI/HDMI panel
+# on shared-pin boards (HackBerry Pi). The headless entrypoint now sets
+# RAGNAR_HEADLESS=1 itself, but make it explicit in the unit too. Idempotent:
+# only touches units that already run headlessRagnar.py and lack the var.
+RAGNAR_UNIT="/etc/systemd/system/ragnar.service"
+if [ -f "$RAGNAR_UNIT" ] && grep -q 'headlessRagnar\.py' "$RAGNAR_UNIT" \
+        && ! grep -q '^Environment=RAGNAR_HEADLESS=1' "$RAGNAR_UNIT"; then
+    sed -i '/^ExecStart=.*headlessRagnar\.py/i Environment=RAGNAR_HEADLESS=1' "$RAGNAR_UNIT"
+    systemctl daemon-reload
+    echo -e "${GREEN}Set RAGNAR_HEADLESS=1 on ragnar.service (protects DPI/HDMI panel).${NC}"
+fi
+
 echo -e "${BLUE}Step 6.6: Ensuring hardware watchdog (auto-reboot on hard hang)...${NC}"
 # Unattended / inline devices should reboot fast if the Pi wedges rather than
 # black-holing the link. Enable the BCM watchdog and have systemd pet it.


### PR DESCRIPTION
SharedData() initializes the EPD at import time (constructing EPDHelper / running EPDHelper.auto_detect()), which drives SPI0 + the display GPIOs. On boards with a built-in DPI/HDMI panel that shares those pins (HackBerry Pi, HyperPixel, vc4-kms-dpi overlays), this blanked the panel even on a web-only headless install, because the init runs during 'import shared_data' before headlessRagnar.py's own no-display logic ever executes.

Add a RAGNAR_HEADLESS guard mirroring the existing pager-mode gate:
- headlessRagnar.py sets RAGNAR_HEADLESS=1 before importing shared_data, so any headless launch (systemd, CLI) is protected regardless of unit config
- shared.py: initialize_epd_display() skips EPD init in headless mode (no EPDHelper, no auto-detect, no pins touched) via the existing safe skip body
- install_ragnar.sh: emits Environment=RAGNAR_HEADLESS=1 into the unit on headless installs
- update_ragnar.sh: idempotent migration adds the var to existing headlessRagnar.py units
- docs/INSTALL.md: document DPI/HDMI shared-pin boards and headless profiles