### PR TITLE
Sharpen SDR waterfall: 512 columns, 600 rows, finer sweep bins

### DIFF
--- a/docs/wifi-analyzer.md
+++ b/docs/wifi-analyzer.md
@@ -444,8 +444,11 @@ which makes the display lurch: a burst of rows jumps in, then it freezes — the
 sweeps are **time-integrated (max-hold) into one row every ~100 ms**. That is
 how a real spectrum-analyzer waterfall dwells: the scroll is smooth and steady
 regardless of sweep speed, and each row still catches short bursts that fired
-between frames. Frames stream to the browser. **Receive-only** — an SDR sweep
-never transmits.
+between frames. Frames stream to the browser. Each frame is **512 frequency
+columns** and the browser keeps **600 rows** of history, so the heatmap stays
+crisp — no chunky cells — even stretched full-screen; the sweep's FFT bin width
+is held finer than a column so every column is fed real data. **Receive-only** —
+an SDR sweep never transmits.
 
 **Hardware.** Needs a **HackRF One** (1 MHz–6 GHz — covers 2.4 *and* 5 GHz).
 The cheap RTL-SDR only reaches ~1.7 GHz and **cannot** see these bands. Install

--- a/sdr_spectrum.py
+++ b/sdr_spectrum.py
@@ -69,10 +69,14 @@ BANDS = {
     "6":   (5925, 6425),
 }
 
-_GRID_BINS = 256          # display columns per frame (band binned into this many)
-_RING_FRAMES = 300        # rolling history of sweep frames kept in memory
+_GRID_BINS = 512          # display columns per frame (band binned into this many)
+_RING_FRAMES = 600        # rolling history of sweep frames kept in memory
 _FLOOR_DBM = -120         # sentinel for a bucket no sweep bin landed in
-_BIN_WIDTH_HZ = 250000    # hackrf_sweep FFT resolution (250 kHz -> fast sweeps)
+# FFT resolution must stay finer than one display column or some columns get no
+# raw bin and paint a permanent floor streak. 512 columns over the 100 MHz 2.4
+# band is ~195 kHz/column, so 150 kHz keeps every column fed (~667 raw bins ->
+# 512 buckets) while sweeps stay fast enough for the steady cadence below.
+_BIN_WIDTH_HZ = 150000    # hackrf_sweep FFT resolution (finer than a display column)
 _DEFAULT_LNA = 24         # HackRF LNA gain (0-40, 8 dB steps)
 _DEFAULT_VGA = 20         # HackRF VGA/baseband gain (0-62, 2 dB steps)
 # hackrf_sweep finishes a full band far faster (and far more irregularly) than a

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -8067,7 +8067,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260818-sdr-waterfall-smooth"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260818-sdr-waterfall-res"></script>
 
 
 

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -2019,7 +2019,7 @@ function _wifiSdrPoll() {
         if (typeof d.floor_dbm === 'number') s.floor = d.floor_dbm;
         if (d.max_hold) s.maxhold = d.max_hold;
         (d.frames || []).forEach(f => { s.seq = f.seq; s.rows.unshift(f.power); });
-        if (s.rows.length > 260) s.rows.length = 260;
+        if (s.rows.length > 600) s.rows.length = 600;
         if (_wifiState.view === 'waterfall') _wifiDrawWaterfall();
     }).catch(() => {});
 }


### PR DESCRIPTION
The waterfall cells looked chunky, especially stretched full-screen, because each frame was only 256 frequency columns and the browser kept 260 rows.

Double the frequency resolution to 512 columns and keep 600 rows of history so the heatmap stays crisp at any size. A 512-column 2.4 GHz frame is ~195 kHz per column, finer than the old 250 kHz sweep bin — which would leave some columns unfed and painting a floor streak — so drop the FFT bin width to 150 kHz (~667 raw bins into 512 buckets) to keep every column backed by real data. Sweeps stay well within the steady 10 rows/s cadence. Self-test still 18/18; docs updated.