### PR TITLE
Feature/vendor guards arista juniper cisco

### DIFF
--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -70,6 +70,9 @@ It is split into three sub-tabs: **Diagnostics**, **Switch & L2/L3**, and
 | [OSPF Security Scanner](#ospf-security-scanner) | Switch & L2/L3 | `GET /api/net/ospf-watch`, `POST /api/net/ospf-baseline` |
 | [BGP Path Watch](#bgp-path-watch) | Switch & L2/L3 | `GET /api/net/bgp-watch`, `POST /api/net/bgp-baseline` |
 | [BGP Collector & Path Asymmetry](#bgp-collector--path-asymmetry-control-plane--data-plane) | Switch & L2/L3 | `GET/POST /api/net/bgp-collector`, `/api/net/owd-reflector`, `POST /api/net/path-asymmetry` |
+| [Cisco Guard](#cisco-guard) | Switch & L2/L3 | `GET /api/net/cisco-guard` |
+| [Juniper Guard](#juniper-guard) | Switch & L2/L3 | `GET /api/net/juniper-guard` |
+| [Arista Guard](#arista-guard) | Switch & L2/L3 | `GET /api/net/arista-guard` |
 | [Locate Port](#locate-port) | Switch & L2/L3 | `POST /api/net/locate-port` |
 | [PCAP Analyzer](#pcap-analyzer) | Switch & L2/L3 | `POST /api/net/pcap` |
 | [Interfaces](#interface-list) | Interfaces | `GET /api/net/interfaces` |
@@ -500,7 +503,8 @@ check, the [DHCP Guardian](#dhcp-guardian) rogue-server check, and the instant
 **Extended monitoring** (on by default alongside the monitor) additionally
 **rotates the whole passive-scanner suite** through the background poller —
 STP · DTP · CDP · VTP · IGMP · IPv6 first-hop · NDP · FHRP · OSPF · EIGRP · IS-IS · BGP · SMB ·
-Relay/Coercion · NTP · ICMP · SNMP · Cert · TLS · LDAP. Because each of those
+Relay/Coercion · NTP · ICMP · SNMP · Cert · TLS · LDAP · Cisco/Juniper/Arista Guards.
+Because each of those
 does a short `tcpdump` capture, they're run a **round-robin batch at a time**
 (default 3 per cycle, configurable) so a cycle stays ~1 minute; a full sweep
 completes over several cycles, and each scanner self-noops cheaply when its
@@ -1929,6 +1933,74 @@ change — the asymmetry is below BGP, e.g. a congested or re-routed transit leg
 - CLI: `python3 path_asymmetry.py reflector [port]` runs a standalone reflector;
   `bgp_speaker.py` and `path_asymmetry.py` each expose `selftest()`, aggregated into
   the Detector Self-Test panel (`GET /api/net/routing-selftest`).
+
+### Vendor CVE Guards (Cisco · Juniper · Arista)
+
+Three passive, **detection-only** vendor guards watch a network segment and report
+**three classes** of evidence about a tracked set of router/switch CVEs — never
+transmitting, probing, or authenticating:
+
+- **Posture** — a version/platform fingerprint screened against the CVE catalog.
+  Always a *"verify THIS device"* note, never a vulnerable/not-vulnerable verdict:
+  a banner can be stale or spoofed, and a train absent from an advisory is *inferred
+  from silence, not confirmed patched*.
+- **Exposure** — the enabling condition for a CVE is visibly present on the wire
+  (cleartext SNMP, a default community, an HTTP UI or Telnet to infrastructure, a
+  reachable management listener). Actionable **without** knowing the version.
+- **Attack** — an exploitation primitive observed in transit.
+
+Findings roll up to one verdict per scan: **clean** < **observed** (a vendor device
+seen, no CVE-relevant finding) < **posture** < **exposure** < **attack**. `observed`
+and `clean` rank benign in the Network Integrity Monitor; **attack** ranks critical.
+Each guard captures one short passive `tcpdump` window (`-x`, so the L4 payload bytes
+are reconstructed from the hex dump for byte-level checks). There is **no TCP
+reassembly**, so a segmented HTTP/Telnet attack is best-effort — a hit is
+high-confidence, a miss inconclusive — and thresholds are **structural anomaly
+bounds** set well above legitimate traffic, not published vendor constants. Every
+guard exposes a `selftest()` (synthetic records + a Scapy pcap→`tcpdump`→parse
+end-to-end leg) aggregated into the Detector Self-Test panel.
+
+#### Cisco Guard
+Cisco IOS / IOS-XE / NX-OS routers, switches and edge/core devices. Firewalls
+(ASA/Firepower/FTD/FMC) are **screened out of scope** (`CG-009`), not misclassified.
+Capture surface: SNMP (161/162), Telnet (23), HTTP UIs (80/8080/8443), IKEv2
+(500/4500). Detects, among others: **`CG-101` cleartext SNMP** and **`CG-102`
+default community** (the credential half of the actively-exploited **CVE-2025-20352**
+SNMP overflow); **`CG-201`/`CG-202`** the SNMP **OID-arc-flood / oversized-field**
+overflow shape (BER-parsed); **`CG-103`** HTTP web-UI cleartext; **`CG-104`** Telnet
+to infrastructure and **`CG-270`** an NX-OS Telnet **shell-escape** (the in-the-wild
+**CVE-2024-20399** Velvet-Ant shape); **`CG-220`** a VLAN tag-stack anomaly
+(**CVE-2024-20434** Catalyst-9000 DoS); plus IOS-XE / NX-OS version-in-range postures.
+- Endpoint: `GET /api/net/cisco-guard` `{interface, seconds}` · binary: `tcpdump`
+- CLI: `python3 network_diagnostics.py cisco-guard [--iface I] [--seconds N] [--json]`
+
+#### Juniper Guard
+Juniper J-Web (SRX/EX), Session Smart Router, Junos Space and Junos-Evolved. Fully
+dissects cleartext HTTP to **J-Web** (80/8080) and the Junos-Evolved **On-Box Anomaly
+Detection API** (8160), and reads the TLS ClientHello **SNI** (443/8443). Detects the
+byte-exact **CVE-2023-36844..36847** J-Web attack shapes — **`JNPR-011` PHPRC** and
+**`JNPR-012` LD_PRELOAD** environment-variable injection, **`JNPR-010`**
+unauthenticated file upload, and **`JNPR-014`** the two correlated from one source as
+an **RCE chain** — plus **`JNPR-050`/`JNPR-051`** the **CVE-2026-21902** anomaly-API
+RCE and **`JNPR-030`** Junos-Space stored-XSS (**CVE-2025-59978**) injection attempts.
+Passive version extraction is a known dead end for this vendor, so version postures
+are **not** claimed.
+- Endpoint: `GET /api/net/juniper-guard` `{interface, seconds}` · binary: `tcpdump`
+- CLI: `python3 network_diagnostics.py juniper-guard [--iface I] [--seconds N] [--json]`
+
+#### Arista Guard
+Arista **EOS** switches, routers and edge/core devices. Non-EOS Arista products
+(CloudVision / VeloCloud / DANZ / Awake) are **screened out of scope** (`AG-009`).
+Reads the EOS version/platform from **LLDP** (`AG-001`/`AG-005`), parses **RADIUS**
+(1812/1813/1645/1646) for the **BlastRADIUS** (**CVE-2024-3596**) conditions —
+**`AG-101`** cleartext, **`AG-102`** a missing Message-Authenticator, **`AG-202`** an
+unauthenticated response, and **`AG-201`** an oversized attribute (the forgery shape)
+— screens **SSH banners** (22) for the **regreSSHion** window (**`AG-104`**,
+CVE-2024-6387/6409), and flags management listeners **`AG-103`** gNMI/gNOI
+(6030/9339/50051), **`AG-108`** CVX (9979), **`AG-106`** VXLAN decap (4789/8472), plus
+**`AG-205`** a VLAN tag-stack CPU-punt anomaly (**CVE-2024-5872**).
+- Endpoint: `GET /api/net/arista-guard` `{interface, seconds}` · binary: `tcpdump`
+- CLI: `python3 network_diagnostics.py arista-guard [--iface I] [--seconds N] [--json]`
 
 ### Locate Port
 Physically find **which switch port** the device is plugged into — the software

--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -698,6 +698,20 @@ per-packet Unix timestamp via `-tt`) is parsed and classified:
   or amplification abuse.
 - **Anomaly** — an implausible **root dispersion**, a **leap-alarm** (unsynchronized)
   source, or a **reference-ID loop** (refid equals the source's own address).
+- **Autokey** — an **Autokey** (RFC 5906) **extension field** on the wire. Autokey is
+  deprecated and is the network-reachable attack surface for **CVE-2014-9295** (the
+  `ntpd` `crypto_recv()` stack-overflow → **RCE** as the ntpd user) and its siblings
+  (CVE-2014-9750, CVE-2016-1547). The capture adds `-x`, so the NTP payload bytes are
+  reconstructed and the extension field is parsed directly (independent of the
+  dissector). Fires on **any** NTP packet — server replies *and* inbound client/peer
+  packets — because the overflow is delivered *to* the victim. Ordinary symmetric-key
+  authentication (a 4/20/24-octet MAC) is **not** Autokey and never trips it — the
+  28-octet RFC 7822 extension-field floor separates the two.
+- **Autokey exploit** — a **malformed** Autokey EF: the declared length or the
+  internal **value length** (`crypto_recv()`'s copy length) runs **past the packet**,
+  is **misaligned**, or is structurally impossible. That value-length overflow is the
+  specific signature of **CVE-2014-9295 / CVE-2014-9750** and escalates to a
+  **critical** verdict (ranked as such by the Network Integrity Monitor).
 
 The **first scan learns** the trusted time source(s) + their stratum into
 `data/ntp_watch.json`; after a legitimate NTP change, click **Trust current** to

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -14992,6 +14992,1065 @@ def _ldap_selftest():
             'scapy': {'ran': True, 'pass': r['success']}}
 
 
+# ==========================================================================
+# Vendor CVE Guards — passive Cisco / Juniper / Arista router+switch monitors
+# ==========================================================================
+# Ported from the standalone ciscoguard / juniperwatch / aristaguard modules into
+# the in-app tcpdump-based watch pattern. Each guard passively captures the
+# vendor's management/attack surface for a few seconds and reports three classes of
+# evidence about a tracked CVE set:
+#   * POSTURE  — a version/platform fingerprint screened against the CVE catalog.
+#                Always a "verify THIS device" note, never a vulnerable/not verdict.
+#   * EXPOSURE — the enabling condition for a CVE is visibly present on the wire
+#                (cleartext SNMP, default community, HTTP/Telnet to infrastructure,
+#                a reachable management listener). Actionable without the version.
+#   * ATTACK   — an exploitation primitive observed in transit.
+# Everything is detection-only: the guards never transmit, probe or authenticate.
+# Findings roll up to one verdict per scan: clean < observed < posture < exposure
+# < attack. 'observed' (a vendor device seen, no CVE-relevant finding) and 'clean'
+# rank benign in the Network Integrity Monitor; 'attack' ranks critical.
+_GUARD_SEVERITY_RANK = {'INFO': 0, 'LOW': 1, 'MEDIUM': 2, 'HIGH': 3, 'CRITICAL': 4}
+_GUARD_FLOW_RE = re.compile(
+    r'(\d+\.\d+\.\d+\.\d+)\.(\d+)\s*>\s*(\d+\.\d+\.\d+\.\d+)\.(\d+):')
+_GUARD_PROTO_RE = re.compile(r'proto (\w+) \((\d+)\)')
+_GUARD_HEX_RE = _NTP_HEX_RE  # `\t0x0010:  4500 004c ...` — shared with NTP
+
+
+def _guard_ip_payload(block_lines):
+    """Reconstruct the L4 payload bytes from a tcpdump `-x`/`-X` hex-dump block.
+    tcpdump prints packet bytes from the IP header on (link layer stripped); we
+    reassemble the hex, walk the IPv4/IPv6 + TCP/UDP headers, and return
+    (ip_ver, proto_num, l4_payload_bytes) or (None, None, None)."""
+    hexchars = []
+    for ln in block_lines:
+        m = _GUARD_HEX_RE.match(ln)
+        if m:
+            hexchars.append(re.sub(r'[^0-9a-fA-F]', '', m.group(1)))
+    if not hexchars:
+        return (None, None, None)
+    try:
+        data = bytes.fromhex(''.join(hexchars))
+    except ValueError:
+        return (None, None, None)
+    if len(data) < 20:
+        return (None, None, None)
+    ver = data[0] >> 4
+    if ver == 4:
+        ihl = (data[0] & 0x0F) * 4
+        if ihl < 20 or len(data) < ihl:
+            return (None, None, None)
+        proto = data[9]
+        l4 = data[ihl:]
+    elif ver == 6:
+        if len(data) < 40:
+            return (None, None, None)
+        proto = data[6]
+        l4 = data[40:]
+    else:
+        return (None, None, None)
+    if proto == 6:      # TCP
+        if len(l4) < 20:
+            return (ver, proto, b'')
+        thl = ((l4[12] >> 4) & 0x0F) * 4
+        return (ver, proto, l4[thl:] if len(l4) >= thl else b'')
+    if proto == 17:     # UDP
+        return (ver, proto, l4[8:] if len(l4) >= 8 else b'')
+    return (ver, proto, l4)
+
+
+def _guard_packets(text):
+    """Parse `tcpdump -nn -tt -v -X <bpf>` output into per-packet records. Each
+    record: {ts, src, sport, dst, dport, proto, ipver, payload (L4 bytes),
+    dissect (block text), vlan_tags (outer-tag count)}."""
+    records = []
+    blocks, cur = [], []
+    for raw in text.splitlines():
+        if _NTP_HDR_RE.match(raw):
+            if cur:
+                blocks.append(cur)
+            cur = [raw]
+        elif cur:
+            cur.append(raw)
+    if cur:
+        blocks.append(cur)
+
+    for block in blocks:
+        head = _NTP_HDR_RE.match(block[0])
+        try:
+            ts = float(head.group(1))
+        except (TypeError, ValueError):
+            continue
+        btext = '\n'.join(block)
+        pm = _GUARD_PROTO_RE.search(btext)
+        proto = pm.group(1) if pm else ''
+        fm = _GUARD_FLOW_RE.search(btext)
+        rec = {'ts': ts, 'proto': proto, 'dissect': btext,
+               'src': None, 'sport': None, 'dst': None, 'dport': None,
+               'ipver': None, 'payload': b'',
+               'vlan_tags': len(re.findall(r'\bvlan\s+\d+', btext))}
+        if fm:
+            rec['src'], rec['sport'] = fm.group(1), int(fm.group(2))
+            rec['dst'], rec['dport'] = fm.group(3), int(fm.group(4))
+        ipver, protonum, payload = _guard_ip_payload(block)
+        rec['ipver'] = ipver
+        if payload is not None:
+            rec['payload'] = payload
+        records.append(rec)
+    return records
+
+
+def _guard_verdict(findings):
+    """Roll a finding list up to one verdict: clean < observed < posture <
+    exposure < attack."""
+    if not findings:
+        return 'clean'
+    klasses = {f['klass'] for f in findings}
+    if 'ATTACK' in klasses:
+        return 'attack'
+    if 'EXPOSURE' in klasses:
+        return 'exposure'
+    # POSTURE only: a version/platform that screens into a CVE range (>= MEDIUM) is
+    # a 'posture' note; a bare INFO device/platform sighting is just 'observed'.
+    if any(_GUARD_SEVERITY_RANK.get(f['severity'], 0) >= 2 for f in findings):
+        return 'posture'
+    return 'observed'
+
+
+def _guard_finish(module, iface, seconds, findings, records, catalog=None):
+    """Common guard result payload builder + events persistence hook value."""
+    findings = sorted(findings, key=lambda f: -_GUARD_SEVERITY_RANK.get(
+        f['severity'], 0))
+    verdict = _guard_verdict(findings)
+    counts = {}
+    for f in findings:
+        counts[f['klass']] = counts.get(f['klass'], 0) + 1
+    cves = sorted({c for f in findings for c in f.get('cves', [])})
+    return {
+        'success': True, 'module': module, 'interface': iface,
+        'seconds': seconds, 'verdict': verdict,
+        'packet_count': len(records),
+        'finding_count': len(findings),
+        'class_counts': counts,
+        'cves': cves,
+        'findings': findings,
+    }
+
+
+# --- Shared minimal SNMP BER walker (defensive; never raises) ----------------
+def _ber_len(buf, i):
+    """Read a BER length at buf[i]. Returns (length, next_index) or (None, i)."""
+    if i >= len(buf):
+        return (None, i)
+    b = buf[i]
+    i += 1
+    if b < 0x80:
+        return (b, i)
+    n = b & 0x7F
+    if n == 0 or i + n > len(buf):
+        return (None, i)
+    val = int.from_bytes(buf[i:i + n], 'big')
+    return (val, i + n)
+
+
+def _ber_oid_arcs(oid_bytes):
+    """Count encoded sub-identifiers in a BER OID value. (True arcs are this + 1,
+    because BER packs the first two arcs into one sub-identifier — the arc-flood
+    threshold is applied to this encoded count, matching the standalone.)"""
+    n = 0
+    for b in oid_bytes:
+        if not (b & 0x80):
+            n += 1
+    return n
+
+
+def _snmp_ber_parse(payload):
+    """Extract SNMP facts from a raw UDP payload without pyasn1. Returns a dict:
+    {version (0=v1,1=v2c,3=v3), community, max_oid_arcs, max_field_len,
+    varbind_count} or None if it is not a plausible SNMP message. Defensive: any
+    structural break returns what was parsed so far."""
+    try:
+        if len(payload) < 2 or payload[0] != 0x30:  # outer SEQUENCE
+            return None
+        total, i = _ber_len(payload, 1)
+        if total is None:
+            return None
+        out = {'version': None, 'community': None, 'max_oid_arcs': 0,
+               'max_field_len': 0, 'varbind_count': 0}
+        # version INTEGER
+        if i >= len(payload) or payload[i] != 0x02:
+            return None
+        vlen, j = _ber_len(payload, i + 1)
+        if vlen is None or j + vlen > len(payload):
+            return None
+        out['version'] = int.from_bytes(payload[j:j + vlen], 'big') if vlen else 0
+        i = j + vlen
+        if out['version'] == 3:
+            # v3 header shape differs; we only need to know it IS v3 (encrypted-ish).
+            return out
+        # community OCTET STRING
+        if i < len(payload) and payload[i] == 0x04:
+            clen, j = _ber_len(payload, i + 1)
+            if clen is not None and j + clen <= len(payload):
+                out['community'] = payload[j:j + clen]
+                out['max_field_len'] = max(out['max_field_len'], clen)
+                i = j + clen
+        # Walk the rest of the buffer for OID (0x06) and long values, counting the
+        # deepest OID and the largest field — enough for the arc-flood / oversized
+        # attack heuristics without a full PDU state machine.
+        k = i
+        while k < len(payload):
+            tag = payload[k]
+            ln, m = _ber_len(payload, k + 1)
+            if ln is None or m + ln > len(payload) + 0:
+                break
+            if tag == 0x06:  # OID
+                out['max_oid_arcs'] = max(out['max_oid_arcs'],
+                                          _ber_oid_arcs(payload[m:m + ln]))
+            if tag == 0x04:  # OCTET STRING value
+                out['max_field_len'] = max(out['max_field_len'], ln)
+            if tag == 0x30 and 0xA0 <= (payload[m] if m < len(payload) else 0):
+                pass
+            # Descend into SEQUENCE / context PDUs; step over primitives.
+            if tag in (0x30, 0x31) or 0xA0 <= tag <= 0xBF:
+                k = m  # descend
+            else:
+                if tag in (0x30, 0x31):
+                    out['varbind_count'] += 1
+                k = m + ln
+        # Count varbinds: the varbind-list is a SEQUENCE of SEQUENCEs; approximate
+        # by counting 0x30 tags after the PDU header.
+        out['varbind_count'] = payload.count(0x30)
+        return out
+    except Exception:
+        return None
+
+
+_CISCO_DEFAULT_COMMUNITIES = frozenset((
+    b'admin', b'cisco', b'community', b'default', b'manager', b'monitor',
+    b'private', b'public', b'read', b'secret', b'snmp', b'write'))
+# CG-201/202 structural anomaly bounds (well above any real NMS; see README).
+_CISCO_SNMP_MAX_OID_ARCS = 128
+_CISCO_SNMP_MAX_FIELD_LEN = 8192
+_CISCO_SNMP_MAX_COMMUNITY = 64
+_CISCO_MAX_VLAN_TAGS = 2
+# Out-of-scope Cisco security appliances (screened out, not misclassified).
+_CISCO_OUT_OF_SCOPE_RE = re.compile(
+    r'\b(ASA|Firepower|FTD|FMC|FXOS|Secure Firewall|Adaptive Security)\b', re.I)
+_CISCO_IOSXE_VER_RE = re.compile(r'(?:IOS[- ]XE|IOS Software).{0,40}?'
+                                 r'Version\s+(\d+\.\d+(?:\.\d+)?[a-z]?)', re.I)
+_CISCO_NXOS_VER_RE = re.compile(r'NX-OS.{0,40}?[Vv]ersion\s+(\d+\.\d+\([^)]+\))', re.I)
+# Telnet CLI shell-escape / command-injection metacharacters (CVE-2024-20399 shape).
+_CISCO_SHELL_ESCAPE_RE = re.compile(rb'[;`|]|\$\(|&&|\|\||>\s*/|run\s+bash|feature\s')
+
+_CISCO_GUARD_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                 'data', 'cisco_guard.json')
+_cisco_guard_lock = threading.Lock()
+_GUARD_EVENTS_CAP = 200
+
+
+def _guard_events_load(path):
+    try:
+        with open(path) as f:
+            d = json.load(f)
+            return d if isinstance(d, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _guard_events_save(path, d):
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp = path + '.tmp'
+        with open(tmp, 'w') as f:
+            json.dump(d, f, indent=2)
+        os.replace(tmp, path)
+    except OSError:
+        pass
+
+
+def _guard_record_event(path, lock, result):
+    if result.get('verdict') in ('clean', 'observed'):
+        return
+    with lock:
+        d = _guard_events_load(path)
+        evs = d.get('events') or []
+        evs.append({'ts': int(time.time()), 'verdict': result['verdict'],
+                    'cves': result.get('cves', [])[:8],
+                    'codes': sorted({f['code'] for f in result.get('findings', [])})[:12]})
+        d['events'] = evs[-_GUARD_EVENTS_CAP:]
+        _guard_events_save(path, d)
+
+
+def _cisco_screen_version(iosxe=None, nxos=None):
+    """Return the list of CVEs whose fixed release the observed train sits below.
+    Conservative: a train we don't have a table for is reported as unscreenable
+    rather than clean (the caller decides how to surface that)."""
+    hits = []
+    # IOS XE trains carrying the tracked SNMP / CWE-family CVEs (advisory-sourced,
+    # screened as < fixed). Kept compact: the point is "verify THIS device", so a
+    # coarse major.minor band below the fixed release is the trigger.
+    if iosxe:
+        try:
+            maj = tuple(int(x) for x in re.split(r'[.\s]', iosxe)[:2])
+        except (ValueError, IndexError):
+            maj = None
+        if maj and maj < (17, 15):   # SNMP CVE-2025-20352 fixed in 17.15.x line
+            hits.append('CVE-2025-20352')
+    if nxos:
+        hits.append('CVE-2025-20241')  # tracked NX-OS trains — verify on box
+    return hits
+
+
+def do_cisco_guard(interface=None, seconds=20, learn=True, quick=False):
+    """Passive Cisco router/switch/edge CVE guard (detection-only). Captures the
+    Cisco management + attack surface (SNMP, Telnet, HTTP UIs, IKEv2) for a few
+    seconds and reports POSTURE / EXPOSURE / ATTACK findings against a tracked CVE
+    set. Ported from the standalone ciscoguard. Never transmits."""
+    iface = interface if _valid_iface(interface or '') else _capture_iface()
+    if not iface:
+        return {'success': False, 'error': 'no interface to capture on'}
+    if iface not in _list_iface_names(include_virtual=True):
+        return {'success': False, 'error': f'unknown interface: {iface}'}
+    seconds = _clamp_int(seconds, 20, 5, 40)
+    bpf = ('udp port 161 or udp port 162 or tcp port 23 or tcp port 80 or '
+           'tcp port 8080 or tcp port 8443 or udp port 500 or udp port 4500')
+    if not _have('tcpdump'):
+        return {'success': False, 'interface': iface,
+                'error': 'tcpdump is not installed. Click Install to add it.',
+                'missing_tool': 'tcpdump'}
+    res = _run(['timeout', str(seconds), 'tcpdump', '-i', iface, '-nn', '-tt',
+                '-v', '-x', '-s', '1600', '-c', '20000', bpf],
+               timeout=seconds + 8)
+    out = res['out']
+    if not out and res['err'] and any(k in res['err'].lower() for k in (
+            'permission', "couldn't", 'no such device', 'syntax error')):
+        return {'success': False, 'interface': iface, 'error': res['err'].strip()[:200]}
+    records = _guard_packets(out)
+    result = _cisco_analyze(records)
+    result['interface'] = iface
+    result['seconds'] = seconds
+    if not quick:
+        _guard_record_event(_CISCO_GUARD_PATH, _cisco_guard_lock, result)
+    return result
+
+
+def _cisco_analyze(records):
+    """Pure classifier over parsed guard packets → Cisco findings + verdict.
+    Separated from capture so the self-test can drive it with synthetic packets."""
+    findings = []
+    seen_codes = set()
+
+    def add(code, name, sev, klass, src, cves, detail):
+        key = (code, src)
+        if key in seen_codes:
+            return
+        seen_codes.add(key)
+        findings.append({'code': code, 'name': name, 'severity': sev,
+                         'klass': klass, 'src': src, 'cves': cves, 'detail': detail})
+
+    iosxe_ver = nxos_ver = None
+    for r in records:
+        text = r['dissect']
+        src, dst = r['src'], r['dst']
+        # --- POSTURE: version / platform fingerprints (SNMP sysDescr, HTTP Server) ---
+        m = _CISCO_IOSXE_VER_RE.search(text)
+        if m:
+            iosxe_ver = m.group(1)
+            add('CG-002', 'IOS_XE_VERSION_OBSERVED', 'INFO', 'POSTURE', src, [],
+                {'version': iosxe_ver})
+        m = _CISCO_NXOS_VER_RE.search(text)
+        if m:
+            nxos_ver = m.group(1)
+            add('CG-003', 'NXOS_VERSION_OBSERVED', 'INFO', 'POSTURE', src, [],
+                {'version': nxos_ver})
+        if _CISCO_OUT_OF_SCOPE_RE.search(text):
+            add('CG-009', 'PLATFORM_OUT_OF_SCOPE_SCREENED', 'INFO', 'POSTURE', src,
+                [], {'note': 'Cisco security appliance — cover with firewall tooling'})
+        elif re.search(r'\bcisco\b', text, re.I):
+            add('CG-001', 'CISCO_DEVICE_OBSERVED', 'INFO', 'POSTURE', src, [], {})
+
+        # --- SNMP (UDP 161/162): exposure + attack ---
+        if r['proto'] == 'UDP' and (r['dport'] in (161, 162) or r['sport'] in (161, 162)):
+            snmp = _snmp_ber_parse(r['payload']) if r['payload'] else None
+            if snmp and snmp['version'] in (0, 1):  # v1 / v2c cleartext
+                add('CG-101', 'SNMP_CLEARTEXT_ON_WIRE', 'HIGH', 'EXPOSURE', src,
+                    ['CVE-2025-20352', 'CVE-2025-20312'],
+                    {'snmp_version': 'v1' if snmp['version'] == 0 else 'v2c'})
+                comm = snmp.get('community')
+                if comm and comm.lower() in _CISCO_DEFAULT_COMMUNITIES:
+                    add('CG-102', 'SNMP_DEFAULT_COMMUNITY', 'CRITICAL', 'EXPOSURE',
+                        src, ['CVE-2025-20352'],
+                        {'community': comm.decode('latin-1', 'replace')})
+                if snmp['max_oid_arcs'] > _CISCO_SNMP_MAX_OID_ARCS:
+                    add('CG-201', 'SNMP_OID_ARC_FLOOD', 'CRITICAL', 'ATTACK', src,
+                        ['CVE-2025-20352', 'CVE-2025-20312'],
+                        {'oid_arcs': snmp['max_oid_arcs'],
+                         'threshold': _CISCO_SNMP_MAX_OID_ARCS})
+                if (snmp['max_field_len'] > _CISCO_SNMP_MAX_FIELD_LEN
+                        or (comm and len(comm) > _CISCO_SNMP_MAX_COMMUNITY)):
+                    add('CG-202', 'SNMP_OVERSIZED_FIELD', 'CRITICAL', 'ATTACK', src,
+                        ['CVE-2025-20352'],
+                        {'max_field_len': snmp['max_field_len'],
+                         'community_len': len(comm) if comm else 0})
+
+        # --- HTTP device web UI (cleartext) ---
+        if r['proto'] == 'TCP' and r['dport'] in (80, 8080):
+            if re.search(rb'^(GET|POST|PUT|HEAD)\s', r['payload'][:8]):
+                add('CG-103', 'HTTP_WEB_UI_CLEARTEXT', 'HIGH', 'EXPOSURE', src,
+                    ['CVE-2023-20159', 'CVE-2023-20160', 'CVE-2023-20161',
+                     'CVE-2023-20189', 'CVE-2025-20164'], {'dst': dst, 'port': r['dport']})
+                # Oversized request line = SMB-switch overflow shape (no reassembly).
+                line = r['payload'].split(b'\r\n', 1)[0]
+                if len(line) > 4096:
+                    add('CG-260', 'WEB_UI_OVERSIZED_FIELD', 'MEDIUM', 'ATTACK', src,
+                        ['CVE-2023-20159', 'CVE-2023-20160', 'CVE-2023-20161',
+                         'CVE-2023-20189'], {'request_line_len': len(line)})
+
+        # --- Telnet to infrastructure ---
+        if r['proto'] == 'TCP' and (r['dport'] == 23 or r['sport'] == 23):
+            add('CG-104', 'TELNET_TO_INFRASTRUCTURE', 'HIGH', 'EXPOSURE', src,
+                ['CVE-2024-20399'], {'dst': dst})
+            if _CISCO_SHELL_ESCAPE_RE.search(r['payload']):
+                add('CG-270', 'TELNET_SHELL_ESCAPE_ATTEMPT', 'CRITICAL', 'ATTACK',
+                    src, ['CVE-2024-20399'], {'note': 'shell-escape metacharacters'})
+
+        # --- IKEv2 enabled on segment (exposure precondition) ---
+        if r['proto'] == 'UDP' and (r['dport'] in (500, 4500) or r['sport'] in (500, 4500)):
+            add('CG-108', 'IKEV2_ENABLED_ON_SEGMENT', 'LOW', 'EXPOSURE', src,
+                ['CVE-2024-20307', 'CVE-2024-20308'], {})
+
+        # --- VLAN tag-stack anomaly (Catalyst 9000 control-plane DoS shape) ---
+        if r['vlan_tags'] > _CISCO_MAX_VLAN_TAGS:
+            add('CG-220', 'VLAN_TAG_STACK_ANOMALY', 'HIGH', 'ATTACK', src or dst,
+                ['CVE-2024-20434'], {'vlan_tags': r['vlan_tags'],
+                                     'threshold': _CISCO_MAX_VLAN_TAGS})
+
+    # POSTURE version screening → CG-004 / CG-005.
+    screened = _cisco_screen_version(iosxe_ver, nxos_ver)
+    if iosxe_ver and 'CVE-2025-20352' in screened:
+        add('CG-004', 'IOS_XE_VERSION_IN_CVE_RANGE', 'MEDIUM', 'POSTURE', None,
+            ['CVE-2025-20352'], {'version': iosxe_ver,
+                                 'note': 'verify THIS device against the advisory'})
+    if nxos_ver:
+        add('CG-005', 'NXOS_VERSION_IN_CVE_RANGE', 'MEDIUM', 'POSTURE', None,
+            ['CVE-2025-20241', 'CVE-2024-20399'], {'version': nxos_ver,
+             'note': 'verify THIS device; CVE-2024-20399 is an in-the-wild 0-day'})
+
+    return _guard_finish('cisco_guard', None, None, findings, records)
+
+
+# ==========================================================================
+# Juniper Guard — passive J-Web / SSR / Junos Space / Junos-Evolved CVE monitor
+# ==========================================================================
+_JUNIPER_GUARD_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                   'data', 'juniper_guard.json')
+_juniper_guard_lock = threading.Lock()
+# J-Web cleartext HTTP ports and the Junos-Evolved On-Box Anomaly Detection API.
+_JUNIPER_HTTP_PORTS = (80, 8080)
+_JUNIPER_ANOMALY_PORTS = (8160,)
+_JUNIPER_TLS_PORTS = (443, 8443)
+# watchTowr CVE-2023-36844/45 J-Web PHP environment-variable injection signatures.
+_JUNIPER_PHPRC_RE = re.compile(rb'PHPRC', re.I)
+_JUNIPER_LDPRELOAD_RE = re.compile(rb'LD_PRELOAD', re.I)
+_JUNIPER_ENV_SUSPECT_RE = re.compile(
+    rb'auto_prepend_file|allow_url_include|auto_append_file', re.I)
+# CVE-2023-36846/47 unauthenticated file-upload endpoints (multipart POST).
+_JUNIPER_UPLOAD_RE = re.compile(
+    rb'webauth_operation\.php|logging_browse\.php|installAppPackage\.php'
+    rb'|/jsdm/ajax/|Content-Disposition:\s*form-data;[^\r\n]*filename=', re.I)
+_JUNIPER_XSS_RE = re.compile(rb'<script[\s>]|javascript:|onerror\s*=', re.I)
+
+
+def _tls_sni(payload):
+    """Extract the SNI hostname from a TLS ClientHello payload, or None. Minimal
+    parser: content-type 22 (handshake), handshake type 1 (ClientHello), walk to
+    the server_name extension (type 0)."""
+    try:
+        p = payload
+        if len(p) < 45 or p[0] != 0x16 or p[5] != 0x01:  # handshake / ClientHello
+            return None
+        i = 43                       # skip record(5)+hs(4)+ver(2)+random(32)
+        sid = p[i]; i += 1 + sid     # session id
+        cs = int.from_bytes(p[i:i + 2], 'big'); i += 2 + cs   # cipher suites
+        cm = p[i]; i += 1 + cm       # compression methods
+        if i + 2 > len(p):
+            return None
+        ext_total = int.from_bytes(p[i:i + 2], 'big'); i += 2
+        end = min(len(p), i + ext_total)
+        while i + 4 <= end:
+            etype = int.from_bytes(p[i:i + 2], 'big')
+            elen = int.from_bytes(p[i + 2:i + 4], 'big')
+            j = i + 4
+            if etype == 0x0000 and j + 5 <= len(p):   # server_name
+                nlen = int.from_bytes(p[j + 3:j + 5], 'big')
+                name = p[j + 5:j + 5 + nlen]
+                return name.decode('latin-1', 'replace') or None
+            i = j + elen
+    except Exception:
+        return None
+    return None
+
+
+def do_juniper_guard(interface=None, seconds=20, learn=True, quick=False):
+    """Passive Juniper J-Web / SSR / Junos Space / Junos-Evolved CVE guard
+    (detection-only). Dissects cleartext HTTP to J-Web and the On-Box Anomaly API,
+    and reads TLS ClientHello SNI, reporting EXPOSURE / ATTACK findings. Ported
+    from the standalone juniperwatch. Never transmits."""
+    iface = interface if _valid_iface(interface or '') else _capture_iface()
+    if not iface:
+        return {'success': False, 'error': 'no interface to capture on'}
+    if iface not in _list_iface_names(include_virtual=True):
+        return {'success': False, 'error': f'unknown interface: {iface}'}
+    seconds = _clamp_int(seconds, 20, 5, 40)
+    bpf = ('tcp port 80 or tcp port 8080 or tcp port 8160 or tcp port 443 or '
+           'tcp port 8443')
+    if not _have('tcpdump'):
+        return {'success': False, 'interface': iface,
+                'error': 'tcpdump is not installed. Click Install to add it.',
+                'missing_tool': 'tcpdump'}
+    res = _run(['timeout', str(seconds), 'tcpdump', '-i', iface, '-nn', '-tt',
+                '-v', '-x', '-s', '1600', '-c', '20000', bpf],
+               timeout=seconds + 8)
+    out = res['out']
+    if not out and res['err'] and any(k in res['err'].lower() for k in (
+            'permission', "couldn't", 'no such device', 'syntax error')):
+        return {'success': False, 'interface': iface, 'error': res['err'].strip()[:200]}
+    records = _guard_packets(out)
+    result = _juniper_analyze(records)
+    result['interface'] = iface
+    result['seconds'] = seconds
+    if not quick:
+        _guard_record_event(_JUNIPER_GUARD_PATH, _juniper_guard_lock, result)
+    return result
+
+
+def _juniper_analyze(records):
+    """Pure classifier over parsed guard packets → Juniper findings + verdict."""
+    findings = []
+    seen = set()
+    upload_srcs, envinj_srcs, anomaly_srcs = set(), set(), set()
+
+    def add(code, name, sev, klass, src, cves, detail):
+        key = (code, src)
+        if key in seen:
+            return
+        seen.add(key)
+        findings.append({'code': code, 'name': name, 'severity': sev,
+                         'klass': klass, 'src': src, 'cves': cves, 'detail': detail})
+
+    for r in records:
+        pl, src, dst = r['payload'], r['src'], r['dst']
+        is_http = r['proto'] == 'TCP' and r['dport'] in _JUNIPER_HTTP_PORTS
+        is_anom = r['proto'] == 'TCP' and r['dport'] in _JUNIPER_ANOMALY_PORTS
+        is_tls = r['proto'] == 'TCP' and r['dport'] in _JUNIPER_TLS_PORTS
+
+        if is_tls:
+            sni = _tls_sni(pl)
+            if sni:
+                add('JNPR-006', 'TLS_SNI_HOSTNAME_OBSERVED', 'INFO', 'POSTURE',
+                    src, [], {'sni': sni, 'dst': dst})
+
+        if is_http and re.match(rb'^(GET|POST|PUT|HEAD)\s', pl[:8]):
+            add('JNPR-001', 'JWEB_CLEARTEXT_EXPOSED', 'MEDIUM', 'EXPOSURE', src,
+                [], {'dst': dst, 'port': r['dport']})
+            if _JUNIPER_UPLOAD_RE.search(pl):
+                upload_srcs.add(src)
+                add('JNPR-010', 'JWEB_UNAUTH_FILE_UPLOAD', 'HIGH', 'ATTACK', src,
+                    ['CVE-2023-36846', 'CVE-2023-36847'], {'dst': dst})
+            if _JUNIPER_PHPRC_RE.search(pl):
+                envinj_srcs.add(src)
+                add('JNPR-011', 'JWEB_ENV_INJECTION_PHPRC', 'CRITICAL', 'ATTACK',
+                    src, ['CVE-2023-36844', 'CVE-2023-36845'], {'dst': dst})
+            if _JUNIPER_LDPRELOAD_RE.search(pl):
+                envinj_srcs.add(src)
+                add('JNPR-012', 'JWEB_ENV_INJECTION_LDPRELOAD', 'CRITICAL', 'ATTACK',
+                    src, ['CVE-2023-36844', 'CVE-2023-36845'], {'dst': dst})
+            if _JUNIPER_ENV_SUSPECT_RE.search(pl):
+                add('JNPR-013', 'JWEB_ENV_INJECTION_SUSPECT', 'MEDIUM', 'ATTACK',
+                    src, ['CVE-2023-36844', 'CVE-2023-36845'],
+                    {'dst': dst, 'note': 'heuristic PHP-ini injection field'})
+            if _JUNIPER_XSS_RE.search(pl):
+                add('JNPR-030', 'SPACE_SCRIPT_INJECTION_ATTEMPT', 'HIGH', 'ATTACK',
+                    src, ['CVE-2025-59978'], {'dst': dst})
+
+        if is_anom and re.match(rb'^(GET|POST|PUT|HEAD)\s', pl[:8]):
+            anomaly_srcs.add(src)
+            add('JNPR-050', 'ANOMALY_API_EXPOSED', 'MEDIUM', 'EXPOSURE', src,
+                ['CVE-2026-21902'], {'dst': dst, 'port': r['dport']})
+            if re.search(rb'command|register|exec|/api/', pl, re.I):
+                add('JNPR-051', 'ANOMALY_API_DANGEROUS_COMMAND_REGISTERED', 'HIGH',
+                    'ATTACK', src, ['CVE-2026-21902'], {'dst': dst})
+
+    # Correlated RCE chains within the capture window.
+    for s in upload_srcs & envinj_srcs:
+        add('JNPR-014', 'JWEB_RCE_CHAIN_CORRELATED', 'CRITICAL', 'ATTACK', s,
+            ['CVE-2023-36844', 'CVE-2023-36845', 'CVE-2023-36846', 'CVE-2023-36847'],
+            {'note': 'file upload + env injection correlated from same source'})
+    return _guard_finish('juniper_guard', None, None, findings, records)
+
+
+# ==========================================================================
+# Arista Guard — passive EOS switch/router CVE monitor
+# ==========================================================================
+_ARISTA_GUARD_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                  'data', 'arista_guard.json')
+_arista_guard_lock = threading.Lock()
+_ARISTA_RADIUS_AUTH_PORTS = (1812, 1645)
+_ARISTA_RADIUS_ACCT_PORTS = (1813, 1646)
+_ARISTA_GNMI_PORTS = (6030, 9339, 50051)
+_ARISTA_CVX_PORTS = (9979,)
+_ARISTA_VXLAN_PORTS = (4789, 8472)
+_ARISTA_MAX_VLAN_TAGS = 2
+_ARISTA_RADIUS_ATTR_LEN_MAX = 128     # BlastRADIUS structural anomaly bound
+# Non-EOS Arista products actively screened out (AG-009).
+_ARISTA_OOS_RE = re.compile(
+    r'VeloCloud|CloudVision|NG Firewall|Edge Threat|DANZ|Converged Cloud'
+    r'|Awake NDR', re.I)
+_ARISTA_EOS_VER_RE = re.compile(r'\bEOS[- ](?:version\s+)?(\d+\.\d+\.\d+[A-Z0-9.]*)', re.I)
+_ARISTA_SSH_BANNER_RE = re.compile(rb'SSH-2\.0-OpenSSH_(\d+)\.(\d+)(?:p(\d+))?')
+
+
+def _arista_ssh_vulnerable(major, minor, patch):
+    """regreSSHion (CVE-2024-6387/6409) window: OpenSSH < 4.4p1, or 8.5p1 up to
+    (not including) 9.8p1."""
+    v = (major, minor, patch or 0)
+    if v < (4, 4, 1):
+        return True
+    return (8, 5, 1) <= v < (9, 8, 1)
+
+
+def _radius_parse(payload):
+    """Minimal RADIUS parser. Returns {code, has_msg_auth, max_attr_len} or None.
+    RADIUS: code(1) id(1) length(2) authenticator(16) then TLV attributes."""
+    try:
+        if len(payload) < 20:
+            return None
+        code = payload[0]
+        if code not in (1, 2, 3, 4, 5, 11):   # plausible RADIUS codes
+            return None
+        length = int.from_bytes(payload[2:4], 'big')
+        if not (20 <= length <= 4096):
+            return None
+        out = {'code': code, 'has_msg_auth': False, 'max_attr_len': 0}
+        i = 20
+        while i + 2 <= len(payload) and i < length:
+            atype = payload[i]
+            alen = payload[i + 1]
+            if alen < 2 or i + alen > len(payload):
+                break
+            if atype == 80:                    # Message-Authenticator
+                out['has_msg_auth'] = True
+            out['max_attr_len'] = max(out['max_attr_len'], alen)
+            i += alen
+        return out
+    except Exception:
+        return None
+
+
+def do_arista_guard(interface=None, seconds=20, learn=True, quick=False):
+    """Passive Arista EOS switch/router CVE guard (detection-only). Reads LLDP
+    version/platform, RADIUS (BlastRADIUS CVE-2024-3596), SSH banners (regreSSHion),
+    and management listeners (gNMI/CVX/VXLAN), reporting POSTURE / EXPOSURE / ATTACK
+    findings. Ported from the standalone aristaguard. Never transmits."""
+    iface = interface if _valid_iface(interface or '') else _capture_iface()
+    if not iface:
+        return {'success': False, 'error': 'no interface to capture on'}
+    if iface not in _list_iface_names(include_virtual=True):
+        return {'success': False, 'error': f'unknown interface: {iface}'}
+    seconds = _clamp_int(seconds, 20, 5, 40)
+    bpf = ('udp port 1812 or udp port 1813 or udp port 1645 or udp port 1646 or '
+           'tcp port 22 or tcp port 6030 or tcp port 9339 or tcp port 50051 or '
+           'tcp port 9979 or udp port 4789 or udp port 8472 or '
+           'ether proto 0x88cc')     # LLDP
+    if not _have('tcpdump'):
+        return {'success': False, 'interface': iface,
+                'error': 'tcpdump is not installed. Click Install to add it.',
+                'missing_tool': 'tcpdump'}
+    res = _run(['timeout', str(seconds), 'tcpdump', '-i', iface, '-nn', '-tt',
+                '-v', '-x', '-s', '1600', '-c', '20000', bpf],
+               timeout=seconds + 8)
+    out = res['out']
+    if not out and res['err'] and any(k in res['err'].lower() for k in (
+            'permission', "couldn't", 'no such device', 'syntax error')):
+        return {'success': False, 'interface': iface, 'error': res['err'].strip()[:200]}
+    records = _guard_packets(out)
+    result = _arista_analyze(records)
+    result['interface'] = iface
+    result['seconds'] = seconds
+    if not quick:
+        _guard_record_event(_ARISTA_GUARD_PATH, _arista_guard_lock, result)
+    return result
+
+
+def _arista_analyze(records):
+    """Pure classifier over parsed guard packets → Arista findings + verdict."""
+    findings = []
+    seen = set()
+    eos_ver = None
+
+    def add(code, name, sev, klass, src, cves, detail):
+        key = (code, src)
+        if key in seen:
+            return
+        seen.add(key)
+        findings.append({'code': code, 'name': name, 'severity': sev,
+                         'klass': klass, 'src': src, 'cves': cves, 'detail': detail})
+
+    for r in records:
+        pl, text, src, dst = r['payload'], r['dissect'], r['src'], r['dst']
+
+        # --- POSTURE: LLDP EOS version / platform, out-of-scope screen ---
+        if _ARISTA_OOS_RE.search(text):
+            add('AG-009', 'OUT_OF_SCOPE_PLATFORM', 'INFO', 'POSTURE', src, [],
+                {'note': 'non-EOS Arista product — needs its own coverage'})
+        else:
+            m = _ARISTA_EOS_VER_RE.search(text)
+            if m:
+                eos_ver = m.group(1)
+                add('AG-001', 'EOS_VERSION_OBSERVED', 'INFO', 'POSTURE', src, [],
+                    {'version': eos_ver})
+            elif re.search(r'\bArista\b', text, re.I):
+                add('AG-005', 'EOS_PLATFORM_OBSERVED', 'INFO', 'POSTURE', src, [], {})
+
+        # --- RADIUS (BlastRADIUS CVE-2024-3596) ---
+        is_radius = r['proto'] == 'UDP' and (
+            r['dport'] in _ARISTA_RADIUS_AUTH_PORTS + _ARISTA_RADIUS_ACCT_PORTS
+            or r['sport'] in _ARISTA_RADIUS_AUTH_PORTS + _ARISTA_RADIUS_ACCT_PORTS)
+        if is_radius:
+            rad = _radius_parse(pl) if pl else None
+            add('AG-101', 'RADIUS_CLEARTEXT_OBSERVED', 'MEDIUM', 'EXPOSURE', src,
+                ['CVE-2024-3596'], {'dst': dst})
+            if rad:
+                if rad['code'] == 1 and not rad['has_msg_auth']:    # Access-Request
+                    add('AG-102', 'RADIUS_NO_MESSAGE_AUTHENTICATOR', 'HIGH',
+                        'EXPOSURE', src, ['CVE-2024-3596'],
+                        {'note': 'Access-Request without attribute 80'})
+                if rad['code'] in (2, 3, 11) and not rad['has_msg_auth']:  # responses
+                    add('AG-202', 'RADIUS_RESPONSE_UNAUTHENTICATED', 'HIGH', 'ATTACK',
+                        src, ['CVE-2024-3596'],
+                        {'note': 'response protected only by the MD5 authenticator'})
+                if rad['max_attr_len'] > _ARISTA_RADIUS_ATTR_LEN_MAX:
+                    add('AG-201', 'RADIUS_FORGERY_ATTEMPT', 'CRITICAL', 'ATTACK', src,
+                        ['CVE-2024-3596'], {'max_attr_len': rad['max_attr_len'],
+                         'threshold': _ARISTA_RADIUS_ATTR_LEN_MAX,
+                         'note': 'oversized attribute — BlastRADIUS collision shape'})
+
+        # --- SSH banner (regreSSHion CVE-2024-6387/6409) ---
+        if r['proto'] == 'TCP' and (r['dport'] == 22 or r['sport'] == 22):
+            m = _ARISTA_SSH_BANNER_RE.search(pl)
+            if m:
+                mj, mn = int(m.group(1)), int(m.group(2))
+                pt = int(m.group(3)) if m.group(3) else 0
+                if _arista_ssh_vulnerable(mj, mn, pt):
+                    add('AG-104', 'SSH_VULNERABLE_BANNER', 'HIGH', 'EXPOSURE', src,
+                        ['CVE-2024-6387', 'CVE-2024-6409'],
+                        {'banner': f'OpenSSH_{mj}.{mn}' + (f'p{pt}' if pt else '')})
+
+        # --- Management-plane listeners (exposure preconditions) ---
+        if r['proto'] == 'TCP' and r['dport'] in _ARISTA_GNMI_PORTS:
+            add('AG-103', 'GNMI_GNOI_LISTENER_OBSERVED', 'MEDIUM', 'EXPOSURE', src,
+                ['CVE-2025-1259', 'CVE-2025-1260', 'CVE-2025-0936'],
+                {'dst': dst, 'port': r['dport']})
+        if r['proto'] == 'TCP' and r['dport'] in _ARISTA_CVX_PORTS:
+            add('AG-108', 'CVX_SESSION_OBSERVED', 'MEDIUM', 'EXPOSURE', src,
+                ['CVE-2025-5089'], {'dst': dst})
+        if r['proto'] == 'UDP' and (r['dport'] in _ARISTA_VXLAN_PORTS
+                                    or r['sport'] in _ARISTA_VXLAN_PORTS):
+            add('AG-106', 'VXLAN_DECAP_ENDPOINT_OBSERVED', 'LOW', 'EXPOSURE',
+                dst or src, ['CVE-2026-7473'], {'endpoint': dst})
+
+        # --- VLAN tag anomaly (CVE-2024-5872 CPU punt shape) ---
+        if r['vlan_tags'] > _ARISTA_MAX_VLAN_TAGS:
+            add('AG-205', 'VLAN_TAG_ANOMALY_CPU_PUNT', 'MEDIUM', 'ATTACK', src or dst,
+                ['CVE-2024-5872'], {'vlan_tags': r['vlan_tags'],
+                                    'threshold': _ARISTA_MAX_VLAN_TAGS})
+
+    return _guard_finish('arista_guard', None, None, findings, records)
+
+
+def _guard_rec(proto=None, src='10.0.0.9', sport=40000, dst='10.0.0.1',
+               dport=None, payload=b'', dissect='', vlan_tags=0):
+    """Build a synthetic guard packet record for the analyzer self-tests."""
+    return {'ts': 1780000000.0, 'proto': proto, 'src': src, 'sport': sport,
+            'dst': dst, 'dport': dport, 'ipver': 4, 'payload': payload,
+            'dissect': dissect, 'vlan_tags': vlan_tags}
+
+
+def _ber_encode_len(n):
+    """Encode a BER length (short form < 128, else long form)."""
+    if n < 0x80:
+        return bytes([n])
+    b = n.to_bytes((n.bit_length() + 7) // 8, 'big')
+    return bytes([0x80 | len(b)]) + b
+
+
+def _ber_tlv(tag, value):
+    """Encode one BER TLV with a correct short/long-form length."""
+    return bytes([tag]) + _ber_encode_len(len(value)) + value
+
+
+def _snmp_v2c_get(community=b'public', oid_arcs=6, oversized_community=False):
+    """Craft a minimal BER-encoded SNMPv2c GetRequest payload for the self-test.
+    Uses proper long-form lengths so oversized OID/community fixtures stay valid
+    BER (the parser handles long-form via _ber_len)."""
+    if oversized_community:
+        community = b'A' * 100
+    # OID value: 1.3.6.1.2.1... then extra single-byte arcs to reach oid_arcs subids.
+    oid_val = bytes([0x2b, 0x06, 0x01, 0x02, 0x01]) + bytes([0x01]) * max(0, oid_arcs - 5)
+    oid = _ber_tlv(0x06, oid_val)
+    vb = _ber_tlv(0x30, oid + _ber_tlv(0x05, b''))                # varbind: OID + NULL
+    vbl = _ber_tlv(0x30, vb)
+    pdu = _ber_tlv(0xA0, _ber_tlv(0x02, bytes([0x01]))           # request-id
+                   + _ber_tlv(0x02, bytes([0x00]))               # error-status
+                   + _ber_tlv(0x02, bytes([0x00]))               # error-index
+                   + vbl)
+    body = (_ber_tlv(0x02, bytes([0x01]))                        # version v2c
+            + _ber_tlv(0x04, community)                          # community
+            + pdu)
+    return _ber_tlv(0x30, body)
+
+
+def _cisco_selftest():
+    """Self-test the Cisco guard detectors with synthetic records + a scapy
+    end-to-end leg. No root, no live traffic, no persistence."""
+    scenarios = []
+
+    def check(name, recs, expect_verdict, expect_codes=()):
+        res = _cisco_analyze(recs)
+        codes = {f['code'] for f in res['findings']}
+        ok = res['verdict'] == expect_verdict and all(c in codes for c in expect_codes)
+        scenarios.append({'name': name, 'expect': f'{expect_verdict}/{list(expect_codes)}',
+                          'got': f"{res['verdict']}/{sorted(codes)}", 'pass': ok})
+        return res
+
+    # BER parse: SNMPv2c GetRequest, default community.
+    snmp = _snmp_ber_parse(_snmp_v2c_get(b'public'))
+    ber_ok = bool(snmp) and snmp['version'] == 1 and snmp['community'] == b'public'
+    scenarios.append({'name': 'cisco-snmp-ber', 'expect': 'v2c+public',
+                      'got': str(snmp), 'pass': ber_ok})
+
+    # clean: quiet segment.
+    check('cisco-clean', [], 'clean')
+    # observed: a Cisco device sighting, no CVE-relevant finding.
+    check('cisco-observed', [_guard_rec(dissect='Cisco IOS Software ...')],
+          'observed', ['CG-001'])
+    # posture: an IOS XE version that screens into the CVE range.
+    check('cisco-posture', [_guard_rec(
+        dissect='Cisco IOS-XE Software, Version 17.6.3')], 'posture', ['CG-004'])
+    # exposure: cleartext SNMPv2c with a default community.
+    check('cisco-snmp-default', [_guard_rec(
+        proto='UDP', dport=161, payload=_snmp_v2c_get(b'public'))],
+        'exposure', ['CG-101', 'CG-102'])
+    # exposure: telnet to infrastructure.
+    check('cisco-telnet', [_guard_rec(proto='TCP', dport=23, payload=b'\xff\xfd\x18')],
+          'exposure', ['CG-104'])
+    # attack: SNMP OID arc flood.
+    check('cisco-oid-flood', [_guard_rec(
+        proto='UDP', dport=161, payload=_snmp_v2c_get(b'public', oid_arcs=200))],
+        'attack', ['CG-201'])
+    # attack: telnet shell-escape metacharacters (CVE-2024-20399 shape).
+    check('cisco-telnet-escape', [_guard_rec(
+        proto='TCP', dport=23, payload=b'admin\r\nrun bash; cat /etc/passwd\r\n')],
+        'attack', ['CG-270'])
+    # attack: VLAN tag-stack anomaly (Catalyst 9000 DoS shape).
+    check('cisco-vlan-stack', [_guard_rec(
+        proto='UDP', dport=161, vlan_tags=3, payload=_snmp_v2c_get(b'public'))],
+        'attack', ['CG-220'])
+    # out-of-scope firewall is screened, not misclassified as a router.
+    check('cisco-oos', [_guard_rec(dissect='Cisco Adaptive Security Appliance (ASA)')],
+          'observed', ['CG-009'])
+
+    # --- Scapy end-to-end: craft SNMP default-community -> pcap -> tcpdump -X. ---
+    scapy_result = {'ran': False, 'reason': 'scapy or tcpdump unavailable'}
+    try:
+        import tempfile
+        from scapy.all import Ether, IP, UDP, TCP, Raw, wrpcap
+        if _have('tcpdump'):
+            pkts = [
+                (Ether() / IP(src='10.0.0.5', dst='10.0.0.1')
+                 / UDP(sport=40000, dport=161) / Raw(_snmp_v2c_get(b'public'))),
+                (Ether() / IP(src='10.0.0.6', dst='10.0.0.1')
+                 / TCP(sport=41000, dport=23, flags='PA')
+                 / Raw(b'enable\r\nrun bash; id\r\n')),
+            ]
+            with tempfile.NamedTemporaryFile(suffix='.pcap', delete=False) as tf:
+                pcap_path = tf.name
+            wrpcap(pcap_path, pkts)
+            res = _run(['tcpdump', '-nn', '-tt', '-v', '-x', '-r', pcap_path],
+                       timeout=10)
+            recs = _guard_packets(res['out'])
+            out = _cisco_analyze(recs)
+            codes = {f['code'] for f in out['findings']}
+            ok = ('CG-102' in codes and 'CG-270' in codes and out['verdict'] == 'attack')
+            scapy_result = {'ran': True, 'pass': ok, 'verdict': out['verdict'],
+                            'codes': sorted(codes),
+                            'packets': len(recs)}
+            try:
+                os.remove(pcap_path)
+            except OSError:
+                pass
+    except Exception as e:
+        scapy_result = {'ran': False, 'reason': f'{type(e).__name__}: {e}'}
+
+    passed = all(s['pass'] for s in scenarios) and (
+        not scapy_result.get('ran') or scapy_result.get('pass'))
+    return {'success': passed, 'scenarios': scenarios, 'scapy': scapy_result}
+
+
+def _juniper_selftest():
+    """Self-test the Juniper guard detectors with synthetic records + a scapy
+    end-to-end leg (crafted J-Web HTTP -> pcap -> tcpdump -X -> parse)."""
+    scenarios = []
+
+    def check(name, recs, expect_verdict, expect_codes=()):
+        res = _juniper_analyze(recs)
+        codes = {f['code'] for f in res['findings']}
+        ok = res['verdict'] == expect_verdict and all(c in codes for c in expect_codes)
+        scenarios.append({'name': name, 'expect': f'{expect_verdict}/{list(expect_codes)}',
+                          'got': f"{res['verdict']}/{sorted(codes)}", 'pass': ok})
+        return res
+
+    def http(port, body):
+        return _guard_rec(proto='TCP', dport=port, payload=body)
+
+    check('juniper-clean', [], 'clean')
+    check('juniper-cleartext', [http(80, b'GET /login HTTP/1.1\r\nHost: jweb\r\n\r\n')],
+          'exposure', ['JNPR-001'])
+    check('juniper-phprc', [http(80,
+        b'POST /?PHPRC=/tmp/x HTTP/1.1\r\nHost: jweb\r\n\r\nPHPRC=/tmp/php.ini')],
+        'attack', ['JNPR-011'])
+    check('juniper-ldpreload', [http(8080,
+        b'POST / HTTP/1.1\r\n\r\nLD_PRELOAD=/tmp/evil.so')], 'attack', ['JNPR-012'])
+    check('juniper-upload', [http(80,
+        b'POST /webauth_operation.php HTTP/1.1\r\nContent-Type: multipart/form-data\r\n\r\n')],
+        'attack', ['JNPR-010'])
+    # RCE chain: upload + env injection from the same source -> JNPR-014.
+    check('juniper-rce-chain', [
+        _guard_rec(proto='TCP', src='9.9.9.9', dport=80,
+                   payload=b'POST /webauth_operation.php HTTP/1.1\r\n\r\nfilename=x'),
+        _guard_rec(proto='TCP', src='9.9.9.9', dport=80,
+                   payload=b'POST /?PHPRC=/tmp HTTP/1.1\r\n\r\nPHPRC=x')],
+        'attack', ['JNPR-014'])
+    check('juniper-anomaly-api', [http(8160,
+        b'POST /api/command/register HTTP/1.1\r\n\r\n{}')], 'attack', ['JNPR-050', 'JNPR-051'])
+
+    scapy_result = {'ran': False, 'reason': 'scapy or tcpdump unavailable'}
+    try:
+        import tempfile
+        from scapy.all import Ether, IP, TCP, Raw, wrpcap
+        if _have('tcpdump'):
+            body = (b'POST /webauth_operation.php?PHPRC=/tmp/x HTTP/1.1\r\n'
+                    b'Host: jweb\r\nContent-Type: multipart/form-data; '
+                    b'boundary=b\r\n\r\nPHPRC=/tmp/php.ini filename="a"')
+            pkt = (Ether() / IP(src='10.0.0.7', dst='10.0.0.1')
+                   / TCP(sport=42000, dport=80, flags='PA') / Raw(body))
+            with tempfile.NamedTemporaryFile(suffix='.pcap', delete=False) as tf:
+                pcap_path = tf.name
+            wrpcap(pcap_path, [pkt])
+            res = _run(['tcpdump', '-nn', '-tt', '-v', '-x', '-r', pcap_path], timeout=10)
+            out = _juniper_analyze(_guard_packets(res['out']))
+            codes = {f['code'] for f in out['findings']}
+            ok = 'JNPR-011' in codes and 'JNPR-010' in codes and out['verdict'] == 'attack'
+            scapy_result = {'ran': True, 'pass': ok, 'verdict': out['verdict'],
+                            'codes': sorted(codes)}
+            try:
+                os.remove(pcap_path)
+            except OSError:
+                pass
+    except Exception as e:
+        scapy_result = {'ran': False, 'reason': f'{type(e).__name__}: {e}'}
+
+    passed = all(s['pass'] for s in scenarios) and (
+        not scapy_result.get('ran') or scapy_result.get('pass'))
+    return {'success': passed, 'scenarios': scenarios, 'scapy': scapy_result}
+
+
+def _radius_packet(code=1, attrs=None):
+    """Craft a RADIUS packet for the self-test. attrs: list of (type, value)."""
+    body = b''
+    for atype, val in (attrs or []):
+        body += bytes([atype, len(val) + 2]) + val
+    length = 20 + len(body)
+    return bytes([code, 1]) + length.to_bytes(2, 'big') + bytes(16) + body
+
+
+def _arista_selftest():
+    """Self-test the Arista guard detectors with synthetic records + a scapy
+    end-to-end leg (crafted RADIUS + SSH banner -> pcap -> tcpdump -X -> parse)."""
+    scenarios = []
+
+    def check(name, recs, expect_verdict, expect_codes=()):
+        res = _arista_analyze(recs)
+        codes = {f['code'] for f in res['findings']}
+        ok = res['verdict'] == expect_verdict and all(c in codes for c in expect_codes)
+        scenarios.append({'name': name, 'expect': f'{expect_verdict}/{list(expect_codes)}',
+                          'got': f"{res['verdict']}/{sorted(codes)}", 'pass': ok})
+        return res
+
+    check('arista-clean', [], 'clean')
+    check('arista-observed', [_guard_rec(dissect='Arista Networks EOS-4.29.2F running')],
+          'observed', ['AG-001'])
+    check('arista-oos', [_guard_rec(dissect='Arista CloudVision Portal 2024.1.0')],
+          'observed', ['AG-009'])
+    # RADIUS Access-Request without Message-Authenticator -> AG-101 + AG-102.
+    check('arista-radius-noauth', [_guard_rec(proto='UDP', dport=1812,
+        payload=_radius_packet(1, [(1, b'admin')]))], 'exposure', ['AG-101', 'AG-102'])
+    # RADIUS oversized attribute (BlastRADIUS) -> AG-201 attack.
+    check('arista-radius-forgery', [_guard_rec(proto='UDP', dport=1812,
+        payload=_radius_packet(1, [(24, b'X' * 200)]))], 'attack', ['AG-201'])
+    # RADIUS response without Message-Authenticator -> AG-202 attack.
+    check('arista-radius-resp', [_guard_rec(proto='UDP', sport=1812, dport=41000,
+        payload=_radius_packet(2, [(1, b'ok')]))], 'attack', ['AG-202'])
+    # Vulnerable SSH banner (regreSSHion window) -> AG-104.
+    check('arista-ssh-vuln', [_guard_rec(proto='TCP', sport=22, dport=40000,
+        payload=b'SSH-2.0-OpenSSH_9.6p1 Debian\r\n')], 'exposure', ['AG-104'])
+    # Patched SSH banner -> no AG-104.
+    r = _arista_analyze([_guard_rec(proto='TCP', sport=22, dport=40000,
+        payload=b'SSH-2.0-OpenSSH_9.8p1\r\n')])
+    scenarios.append({'name': 'arista-ssh-patched', 'expect': 'clean/no-AG-104',
+                      'got': r['verdict'],
+                      'pass': all(f['code'] != 'AG-104' for f in r['findings'])})
+    # gNMI listener -> AG-103 exposure.
+    check('arista-gnmi', [_guard_rec(proto='TCP', dport=6030, payload=b'')],
+          'exposure', ['AG-103'])
+    # VLAN tag anomaly -> AG-205 attack.
+    check('arista-vlan', [_guard_rec(proto='UDP', dport=1812, vlan_tags=3,
+        payload=_radius_packet(1, [(80, bytes(16))]))], 'attack', ['AG-205'])
+
+    scapy_result = {'ran': False, 'reason': 'scapy or tcpdump unavailable'}
+    try:
+        import tempfile
+        from scapy.all import Ether, IP, UDP, TCP, Raw, wrpcap
+        if _have('tcpdump'):
+            pkts = [
+                (Ether() / IP(src='10.0.0.8', dst='10.0.0.1')
+                 / UDP(sport=41000, dport=1812)
+                 / Raw(_radius_packet(1, [(1, b'admin'), (24, b'Y' * 200)]))),
+                (Ether() / IP(src='10.0.0.9', dst='10.0.0.2')
+                 / TCP(sport=22, dport=43000, flags='PA')
+                 / Raw(b'SSH-2.0-OpenSSH_9.6p1\r\n')),
+            ]
+            with tempfile.NamedTemporaryFile(suffix='.pcap', delete=False) as tf:
+                pcap_path = tf.name
+            wrpcap(pcap_path, pkts)
+            res = _run(['tcpdump', '-nn', '-tt', '-v', '-x', '-r', pcap_path], timeout=10)
+            out = _arista_analyze(_guard_packets(res['out']))
+            codes = {f['code'] for f in out['findings']}
+            ok = ('AG-201' in codes and 'AG-104' in codes and out['verdict'] == 'attack')
+            scapy_result = {'ran': True, 'pass': ok, 'verdict': out['verdict'],
+                            'codes': sorted(codes)}
+            try:
+                os.remove(pcap_path)
+            except OSError:
+                pass
+    except Exception as e:
+        scapy_result = {'ran': False, 'reason': f'{type(e).__name__}: {e}'}
+
+    passed = all(s['pass'] for s in scenarios) and (
+        not scapy_result.get('ran') or scapy_result.get('pass'))
+    return {'success': passed, 'scenarios': scenarios, 'scapy': scapy_result}
+
+
 def do_routing_selftest():
     """Run the IGMP / OSPF / BGP detector self-tests and report a combined result
     plus whether Scapy is available for the end-to-end packet-crafting leg. Drives
@@ -15009,6 +16068,8 @@ def do_routing_selftest():
               'ospf': _ospf_selftest(), 'bgp': _bgp_selftest(),
               'arp': _arp_selftest(), 'dns': _dns_selftest(),
               'mac': _mac_selftest(), 'dhcp': _dhcp_selftest(),
+              'cisco_guard': _cisco_selftest(), 'juniper_guard': _juniper_selftest(),
+              'arista_guard': _arista_selftest(),
               'bgp_speaker': bgp_speaker.selftest(), 'path_asymmetry': path_asymmetry.selftest()}
     return {
         'success': all(s['success'] for s in suites.values()),
@@ -16580,6 +17641,33 @@ def register_network_diagnostics(app, logger=None):
         _log(f"net/fhrp-watch iface={iface or 'default-route'} secs={secs}")
         return jsonify(do_fhrp_watch(interface=iface, seconds=secs))
 
+    @app.route('/api/net/cisco-guard', methods=['GET'])
+    def net_cisco_guard():
+        iface = (request.args.get('interface') or '').strip() or None
+        if iface is not None and not _valid_iface(iface):
+            return _bad('Invalid interface')
+        secs = _clamp_int(request.args.get('seconds'), 20, 5, 40)
+        _log(f"net/cisco-guard iface={iface or 'default-route'} secs={secs}")
+        return jsonify(do_cisco_guard(interface=iface, seconds=secs))
+
+    @app.route('/api/net/juniper-guard', methods=['GET'])
+    def net_juniper_guard():
+        iface = (request.args.get('interface') or '').strip() or None
+        if iface is not None and not _valid_iface(iface):
+            return _bad('Invalid interface')
+        secs = _clamp_int(request.args.get('seconds'), 20, 5, 40)
+        _log(f"net/juniper-guard iface={iface or 'default-route'} secs={secs}")
+        return jsonify(do_juniper_guard(interface=iface, seconds=secs))
+
+    @app.route('/api/net/arista-guard', methods=['GET'])
+    def net_arista_guard():
+        iface = (request.args.get('interface') or '').strip() or None
+        if iface is not None and not _valid_iface(iface):
+            return _bad('Invalid interface')
+        secs = _clamp_int(request.args.get('seconds'), 20, 5, 40)
+        _log(f"net/arista-guard iface={iface or 'default-route'} secs={secs}")
+        return jsonify(do_arista_guard(interface=iface, seconds=secs))
+
     @app.route('/api/net/fhrp-baseline', methods=['GET', 'POST'])
     def net_fhrp_baseline():
         action = 'get'
@@ -17406,6 +18494,18 @@ def _cli(argv=None):
     fhst = sub.add_parser('fhrp-selftest', help='self-test the FHRP detectors (no root)')
     fhst.add_argument('--json', action='store_true', help='emit JSON')
 
+    for _gname, _ghelp in (('cisco', 'Cisco router/switch/edge'),
+                           ('juniper', 'Juniper J-Web/SSR/Junos-Space'),
+                           ('arista', 'Arista EOS switch/router')):
+        gp = sub.add_parser('%s-guard' % _gname,
+                            help='passive %s CVE guard (posture/exposure/attack)' % _ghelp)
+        gp.add_argument('--iface', '-i', default=None, help='interface (default: route)')
+        gp.add_argument('--seconds', '-s', type=int, default=20, help='capture window (5-40)')
+        gp.add_argument('--json', action='store_true', help='emit JSON')
+        gs = sub.add_parser('%s-guard-selftest' % _gname,
+                            help='self-test the %s guard detectors (no root)' % _gname)
+        gs.add_argument('--json', action='store_true', help='emit JSON')
+
     o = sub.add_parser('ospf-watch', help='passive OSPF security scan')
     o.add_argument('--iface', '-i', default=None, help='interface (default: route)')
     o.add_argument('--seconds', '-s', type=int, default=15, help='capture window (5-40)')
@@ -18212,6 +19312,53 @@ def _cli(argv=None):
             else:
                 print(f"  [skip] scapy-e2e: {sc.get('reason')}")
             print(f"FHRP self-test: {'OK' if r['success'] else 'FAILED'}")
+        return 0 if r['success'] else 1
+
+    _GUARD_CLI = {
+        'cisco-guard': (do_cisco_guard, 'Cisco'),
+        'juniper-guard': (do_juniper_guard, 'Juniper'),
+        'arista-guard': (do_arista_guard, 'Arista'),
+    }
+    if args.cmd in _GUARD_CLI:
+        fn, label = _GUARD_CLI[args.cmd]
+        r = fn(interface=args.iface, seconds=args.seconds)
+        if args.json:
+            print(json.dumps(r, indent=2))
+        elif not r.get('success'):
+            print(f"error: {r.get('error')}")
+        else:
+            print(f"{label} Guard [{r['interface']}] {r['seconds']}s: "
+                  f"{r['verdict'].upper()}  ({r['packet_count']} pkts, "
+                  f"{r['finding_count']} finding(s))")
+            for f in r.get('findings', []):
+                cves = (' ' + ','.join(f['cves'])) if f.get('cves') else ''
+                print(f"  [{f['severity']}] {f['code']} {f['name']} "
+                      f"({f['klass']}){' src=' + f['src'] if f.get('src') else ''}{cves}")
+            if r.get('cves'):
+                print(f"  CVEs in scope: {', '.join(r['cves'])}")
+        return 0 if r.get('success') else 1
+
+    _GUARD_SELFTEST_CLI = {
+        'cisco-guard-selftest': (_cisco_selftest, 'Cisco'),
+        'juniper-guard-selftest': (_juniper_selftest, 'Juniper'),
+        'arista-guard-selftest': (_arista_selftest, 'Arista'),
+    }
+    if args.cmd in _GUARD_SELFTEST_CLI:
+        fn, label = _GUARD_SELFTEST_CLI[args.cmd]
+        r = fn()
+        if args.json:
+            print(json.dumps(r, indent=2))
+        else:
+            for s in r['scenarios']:
+                print(f"  [{'PASS' if s['pass'] else 'FAIL'}] {s['name']}: "
+                      f"expect={s['expect']} got={s['got']}")
+            sc = r['scapy']
+            if sc.get('ran'):
+                print(f"  [{'PASS' if sc.get('pass') else 'FAIL'}] scapy-e2e: "
+                      f"verdict={sc.get('verdict')} codes={sc.get('codes')}")
+            else:
+                print(f"  [skip] scapy-e2e: {sc.get('reason')}")
+            print(f"{label} Guard self-test: {'OK' if r['success'] else 'FAILED'}")
         return 0 if r['success'] else 1
 
     if args.cmd == 'ospf-watch':

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -20,6 +20,7 @@ import json
 import re
 import secrets
 import shutil
+import struct
 import subprocess
 import ipaddress
 import os
@@ -5988,6 +5989,11 @@ def _raguard_selftest():
 #     or amplification abuse.
 #   * anomaly        — implausible root dispersion, a leap-alarm (unsynced) source,
 #     or a reference-ID loop.
+#   * autokey        — an Autokey (RFC 5906) extension field on the wire. Autokey is
+#     deprecated and is the network-reachable attack surface for CVE-2014-9295 (the
+#     ntpd crypto_recv() stack overflow → RCE) and its siblings. A *malformed* EF —
+#     declared/value length running past the packet, misaligned, or structurally
+#     impossible — is the specific exploit signature and escalates to critical.
 _NTP_WATCH_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                'data', 'ntp_watch.json')
 _ntp_watch_lock = threading.Lock()
@@ -6011,10 +6017,116 @@ _NTP_CONTROL_MODES = ('Control Message', 'Private', 'Reserved')
 _NTP_KOD_CODES = frozenset(('DENY', 'RSTR', 'RATE', 'ACST', 'AUTH', 'AUTO', 'BCST',
                             'CRYP', 'DROP', 'MCST', 'NKEY', 'RMOT', 'INIT', 'STEP'))
 
+# --- Autokey / extension-field layout (RFC 5906 Autokey, RFC 7822 EF format) ---
+# The standard NTP header is 48 octets. Anything after it is zero or more extension
+# fields followed by an optional MAC. A MAC is 0 (none), 4 (crypto-NAK), 20
+# (keyid+MD5) or 24 (keyid+SHA-1) octets; a valid extension field is >= 28 octets
+# (RFC 7822). That size split is exactly how we tell an Autokey EF apart from
+# ordinary symmetric-key authentication, so plain keyed NTP never trips the detector.
+_NTP_HEADER_LEN = 48
+_NTP_EF_MIN_LEN = 28              # RFC 7822 minimum extension-field length
+_NTP_EF_LEN_FLOOR = 8            # absolute floor: type(2)+len(2)+4 body
+_NTP_MAC_SIZES = frozenset((0, 4, 20, 24))   # none / crypto-NAK / MD5 / SHA-1
+_NTP_EF_OFF_LEN = 2              # u16 total EF length (incl. header + padding)
+_NTP_EF_OFF_VALLEN = 16         # u32 value length — the crypto_recv() copy length
+_NTP_EF_VALUE_START = 20        # first octet of the value payload
+# Autokey opcodes (RFC 5906 §11) — low 6 bits of the field type.
+_NTP_AUTOKEY_OPCODES = {1: 'ASSOC', 2: 'CERT', 3: 'COOKIE', 4: 'AUTO', 5: 'LEAP',
+                        6: 'SIGN', 7: 'IFF', 8: 'GQ', 9: 'MV'}
+
 _NTP_HDR_RE = re.compile(r'^(\d+\.\d+)\s+IP6?\b')
 _NTP_SRC_RE = re.compile(
     r'(\d+\.\d+\.\d+\.\d+)\.(\d+)\s*>\s*(\d+\.\d+\.\d+\.\d+)\.(\d+):\s*'
-    r'NTPv(\d+),\s*([^,]+?),\s*length')
+    r'NTPv(\d+),\s*([^,]+?),\s*length\s+(\d+)')
+# tcpdump -x hex-dump line: `\t0x0010:  4500 004c 0000 4000 ...`
+_NTP_HEX_RE = re.compile(r'^\s*0x[0-9a-fA-F]+:\s+((?:[0-9a-fA-F]{2,4}\s*)+)')
+
+
+def _parse_autokey_ef(payload):
+    """Inspect raw NTP payload bytes for an Autokey (crypto) extension field.
+
+    Detects the network-reachable attack surface of CVE-2014-9295 — the ntpd
+    ``crypto_recv()`` stack buffer overflow reached via a crafted Autokey
+    extension field — plus the closely related CVE-2014-9750 value-length flaw.
+    Works directly on the wire bytes so it is independent of any dissector
+    recognising Autokey opcodes. Returns (present, info, reasons); a non-empty
+    ``reasons`` list means the EF is malformed in the way an exploit packet is.
+    Ported from the standalone ntpwatch _parse_autokey_ef."""
+    try:
+        if payload is None or len(payload) < _NTP_HEADER_LEN:
+            return (False, None, [])
+        remaining = len(payload) - _NTP_HEADER_LEN
+        # Trailing region is a MAC (or nothing) -> symmetric-key auth, not Autokey.
+        if remaining in _NTP_MAC_SIZES:
+            return (False, None, [])
+        # Too large for a MAC but too small for a valid EF -> broken EF.
+        if remaining < _NTP_EF_MIN_LEN:
+            return (True, {'ef_len': None, 'region': remaining},
+                    ['ef_region_undersized'])
+        ef = payload[_NTP_HEADER_LEN:]
+        ef_type = struct.unpack_from('!H', ef, 0)[0]
+        ef_len = struct.unpack_from('!H', ef, _NTP_EF_OFF_LEN)[0]
+        opcode = ef_type & 0x3F
+        info = {'ef_type': ef_type, 'opcode': opcode,
+                'opcode_name': _NTP_AUTOKEY_OPCODES.get(opcode, 'UNKNOWN'),
+                'flags': (ef_type >> 8) & 0xFF, 'ef_len': ef_len, 'region': remaining}
+        reasons = []
+        # crypto_recv() / crypto overflow signatures.
+        if ef_len == 0:
+            reasons.append('ef_len_zero')
+        elif ef_len < _NTP_EF_LEN_FLOOR:
+            reasons.append('ef_len_below_floor')
+        if ef_len % 4 != 0:
+            reasons.append('ef_len_misaligned')
+        if ef_len > len(ef):
+            reasons.append('ef_len_exceeds_packet')
+        # Value-length overflow: the copy length crypto_recv() trusts. A value that
+        # cannot fit the declared EF (or the wire bytes) is the exploit signature.
+        if len(ef) >= _NTP_EF_VALUE_START:
+            vallen = struct.unpack_from('!I', ef, _NTP_EF_OFF_VALLEN)[0]
+            info['value_len'] = vallen
+            wire_budget = len(ef) - _NTP_EF_VALUE_START
+            if vallen > wire_budget or (ef_len >= _NTP_EF_VALUE_START
+                                        and vallen > ef_len - _NTP_EF_VALUE_START):
+                reasons.append('value_length_overflow')
+        return (True, info, reasons)
+    except Exception:
+        return (True, {'ef_len': None, 'region': None}, ['ef_parse_error'])
+
+
+def _ntp_payload_from_block(block_lines):
+    """Reconstruct the NTP payload bytes from a tcpdump `-x` hex dump block.
+    tcpdump -x prints packet bytes from the IP header on (link layer stripped);
+    we reassemble the hex, walk the IPv4/IPv6 + UDP headers, and return the UDP
+    payload (the NTP message). Returns bytes or None if not reconstructable."""
+    hexchars = []
+    for ln in block_lines:
+        m = _NTP_HEX_RE.match(ln)
+        if m:
+            hexchars.append(re.sub(r'[^0-9a-fA-F]', '', m.group(1)))
+    if not hexchars:
+        return None
+    try:
+        data = bytes.fromhex(''.join(hexchars))
+    except ValueError:
+        return None
+    if len(data) < 1:
+        return None
+    ver = data[0] >> 4
+    if ver == 4:
+        if len(data) < 20:
+            return None
+        ihl = (data[0] & 0x0F) * 4
+        if ihl < 20 or data[9] != 17 or len(data) < ihl + 8:  # proto 17 = UDP
+            return None
+        udp_off = ihl
+    elif ver == 6:
+        if len(data) < 48 or data[6] != 17:  # next-header 17 = UDP (no ext hdrs)
+            return None
+        udp_off = 40
+    else:
+        return None
+    return data[udp_off + 8:]  # skip the 8-byte UDP header
 
 
 def _parse_ntp_capture(output):
@@ -6055,8 +6167,28 @@ def _parse_ntp_capture(output):
         rec = {'rx_epoch': rx_epoch, 'src': sm.group(1), 'sport': int(sm.group(2)),
                'dst': sm.group(3), 'dport': int(sm.group(4)),
                'ver': int(sm.group(5)), 'mode': sm.group(6).strip(),
+               'ntp_len': int(sm.group(7)),
                'stratum': None, 'sdesc': '', 'refid': '', 'disp': 0.0,
-               'leap': None, 'xmit_unix': None, 'offset': None}
+               'leap': None, 'xmit_unix': None, 'offset': None,
+               'autokey': False, 'autokey_info': None, 'autokey_reasons': []}
+
+        # Autokey / extension-field inspection. Prefer the exact wire bytes from the
+        # -x hex dump (lets us catch a malformed EF = the CVE-2014-9295 exploit
+        # signature); fall back to the tcpdump-reported length so EF *presence* is
+        # still surfaced even when the hex was truncated by the capture snaplen.
+        payload = _ntp_payload_from_block(block)
+        if payload is not None:
+            present, info, ak_reasons = _parse_autokey_ef(payload)
+            rec['autokey'] = present
+            rec['autokey_info'] = info
+            rec['autokey_reasons'] = ak_reasons
+        elif rec['ntp_len'] is not None:
+            trailer = rec['ntp_len'] - _NTP_HEADER_LEN
+            if trailer > 0 and trailer not in _NTP_MAC_SIZES:
+                rec['autokey'] = True
+                if trailer < _NTP_EF_MIN_LEN:
+                    rec['autokey_reasons'] = ['ef_region_undersized']
+                    rec['autokey_info'] = {'ef_len': None, 'region': trailer}
 
         st = re.search(r'Stratum\s+(\d+)\s*\(([^)]*)\)', text)
         if st:
@@ -6183,8 +6315,8 @@ def _ntp_analyze(records, seconds, baseline, learn=True, threshold=None):
         known = dict(baseline['servers'])
         had_baseline = True
 
-    PRIORITY = ['time-injection', 'rogue-server', 'kod', 'stratum-spoof',
-                'broadcast', 'recon', 'anomaly', 'clean']
+    PRIORITY = ['autokey-exploit', 'time-injection', 'rogue-server', 'kod',
+                'stratum-spoof', 'broadcast', 'recon', 'autokey', 'anomaly', 'clean']
     verdict = 'clean'
     reasons = []
 
@@ -6282,6 +6414,29 @@ def _ntp_analyze(records, seconds, baseline, learn=True, threshold=None):
             f"— reconnaissance or amplification abuse; disable 'monitor' and restrict "
             f"mode 6/7")
 
+    # --- autokey: RFC 5906 Autokey extension field (CVE-2014-9295 surface) ---
+    # Fires on ANY NTP packet (server replies AND inbound client/peer packets),
+    # because the crypto_recv() overflow is delivered *to* the victim ntpd. A
+    # malformed EF is the exploit signature and escalates to autokey-exploit.
+    ak_seen = [r for r in records if r.get('autokey')]
+    ak_bad = [r for r in ak_seen if r.get('autokey_reasons')]
+    if ak_bad:
+        for r in ak_bad[:6]:
+            bump('autokey-exploit')
+            why = ', '.join(r['autokey_reasons'])
+            reasons.append(
+                f"Malformed Autokey extension field from {r['src']} ({why}) — the "
+                f"ntpd crypto_recv() stack-overflow signature (CVE-2014-9295 / "
+                f"CVE-2014-9750): remote code execution as the ntpd user")
+    if ak_seen and not ak_bad:
+        srcs = sorted({r['src'] for r in ak_seen})
+        bump('autokey')
+        reasons.append(
+            f"NTP Autokey (RFC 5906) extension field on the wire from "
+            f"{', '.join(srcs[:8])} — Autokey is deprecated and is the attack "
+            f"surface for CVE-2014-9295 and its siblings; disable it and use NTS "
+            f"or symmetric keys")
+
     # --- anomaly: unusable / forged time source ---
     for src in sorted(servers):
         s = servers[src]
@@ -6302,12 +6457,17 @@ def _ntp_analyze(records, seconds, baseline, learn=True, threshold=None):
                 f"loop / forged sync chain")
 
     advisories = []
-    if servers or control_recs:
+    if servers or control_recs or ak_seen:
         advisories.append(
             "Pin clients to known NTP servers (prefer authenticated NTS or symmetric "
             "keys), restrict inbound/outbound UDP 123 to expected hosts, and disable "
             "mode 6/7 (monlist) on servers. On precision-critical segments "
             "(lab/medical/finance/industrial) alert on any new time source or skew.")
+    if ak_seen:
+        advisories.append(
+            "Autokey (RFC 5906) is deprecated and carries the CVE-2014-9295 "
+            "crypto_recv() RCE surface. Disable Autokey on ntpd, upgrade to ntp "
+            ">= 4.2.8, and migrate authentication to NTS (RFC 8915) or symmetric keys.")
 
     def _pub(s):
         off = offsets_by_server.get(s['src'])
@@ -6319,7 +6479,7 @@ def _ntp_analyze(records, seconds, baseline, learn=True, threshold=None):
 
     if reasons:
         summary = reasons
-    elif not (servers or control_recs):
+    elif not (servers or control_recs or ak_seen):
         summary = ['No NTP traffic seen — segment quiet on UDP/123']
     else:
         summary = ['All time sources match the trusted baseline and agree on time']
@@ -6333,6 +6493,8 @@ def _ntp_analyze(records, seconds, baseline, learn=True, threshold=None):
         'packet_count': len(records),
         'client_count': len(client_recs),
         'control_count': len(control_recs),
+        'autokey_count': len(ak_seen),
+        'autokey_malformed': len(ak_bad),
         'rate': round(len(records) / seconds, 2),
         'servers': [_pub(servers[s]) for s in sorted(servers)],
         'advisories': advisories,
@@ -6345,7 +6507,8 @@ def _ntp_capture(interface, seconds):
     if not _have('tcpdump'):
         return '', 'tcpdump is not installed. Click Install to add it.'
     res = _run(['timeout', str(seconds), 'tcpdump', '-i', interface,
-                '-nn', '-tt', '-v', '-s', '512', '-c', '20000', 'udp port 123'],
+                '-nn', '-tt', '-v', '-x', '-s', '512', '-c', '20000',
+                'udp port 123'],
                timeout=seconds + 8)
     out = res['out']
     if not out and res['err'] and ('permission' in res['err'].lower()
@@ -6481,10 +6644,37 @@ def _ntp_selftest():
     scenarios.append({'name': 'ntp-parse', 'expect': 'stratum2+refid+offset~0',
                       'got': str(pr[0] if pr else None)[:90], 'pass': p_ok})
 
+    # --- Autokey extension-field detector (byte-level, deterministic, no deps) ---
+    def _ak_ef(ef_len, vallen, total=28):
+        """Craft an NTP payload: 48-octet header + one extension field."""
+        ef = bytearray(total)
+        struct.pack_into('!H', ef, 0, 0x0002)          # ef_type: CERT opcode
+        struct.pack_into('!H', ef, _NTP_EF_OFF_LEN, ef_len)
+        struct.pack_into('!I', ef, _NTP_EF_OFF_VALLEN, vallen)
+        return bytes(48) + bytes(ef)
+
+    def ak_case(name, payload, expect_present, expect_bad):
+        present, _info, why = _parse_autokey_ef(payload)
+        ok = (present == expect_present) and (bool(why) == expect_bad)
+        scenarios.append({'name': name, 'expect': f'present={expect_present},bad={expect_bad}',
+                          'got': f'present={present},reasons={why}', 'pass': ok})
+
+    # Well-formed 28-octet Autokey EF (value fits) -> present, not malformed.
+    ak_case('ntp-autokey-wellformed', _ak_ef(28, 8), True, False)
+    # value_length_overflow -> present AND malformed (the CVE-2014-9295 signature).
+    ak_case('ntp-autokey-vallen-overflow', _ak_ef(28, 9999), True, True)
+    # ef_len runs past the packet -> malformed.
+    ak_case('ntp-autokey-eflen-overrun', _ak_ef(400, 8), True, True)
+    # Plain 20-octet MD5 MAC -> NOT Autokey (must not false-positive keyed NTP).
+    ak_case('ntp-autokey-mac-md5', bytes(48) + bytes(20), False, False)
+    # Bare 48-octet packet -> nothing trailing.
+    ak_case('ntp-autokey-none', bytes(48), False, False)
+    # Region too big for a MAC but too small for a valid EF -> broken EF.
+    ak_case('ntp-autokey-undersized', bytes(48) + bytes(12), True, True)
+
     # Optional Scapy end-to-end: craft a real NTP reply -> pcap -> tcpdump -> parse.
     scapy_result = {'ran': False, 'reason': 'scapy or tcpdump unavailable'}
     try:
-        import struct
         import tempfile
         import time as _time
         from scapy.all import Ether, IP, UDP, Raw, wrpcap
@@ -6495,22 +6685,40 @@ def _ntp_selftest():
             def _ts(u):
                 s = int(u)
                 return struct.pack('!II', s, int((u - s) * (1 << 32)))
-            payload = (struct.pack('!BBBb', 0x24, 2, 10, -23)  # LI0 VN4 Mode4, str2
-                       + struct.pack('!ii', 0, 1310)           # root delay/disp
-                       + bytes((17, 253, 14, 125))             # refid
-                       + _ts(ntp - 3) + _ts(ntp - 1) + _ts(ntp) + _ts(ntp))
-            pkt = (Ether() / IP(src='192.0.2.123', dst='192.0.2.9')
-                   / UDP(sport=123, dport=123) / Raw(payload))
+            header = (struct.pack('!BBBb', 0x24, 2, 10, -23)  # LI0 VN4 Mode4, str2
+                      + struct.pack('!ii', 0, 1310)           # root delay/disp
+                      + bytes((17, 253, 14, 125))             # refid
+                      + _ts(ntp - 3) + _ts(ntp - 1) + _ts(ntp) + _ts(ntp))
+            # A crafted client packet carrying a malformed Autokey EF (the
+            # CVE-2014-9295 crypto_recv() overflow shape: value length past the EF).
+            bad_ef = bytearray(28)
+            struct.pack_into('!H', bad_ef, 0, 0x0002)
+            struct.pack_into('!H', bad_ef, _NTP_EF_OFF_LEN, 28)
+            struct.pack_into('!I', bad_ef, _NTP_EF_OFF_VALLEN, 0xFFFF)
+            ak_header = struct.pack('!BBBb', 0x1B, 4, 10, -23) + header[4:]  # Mode3 client
+            pkts = [
+                (Ether() / IP(src='192.0.2.123', dst='192.0.2.9')
+                 / UDP(sport=123, dport=123) / Raw(header)),
+                (Ether() / IP(src='192.0.2.66', dst='192.0.2.9')
+                 / UDP(sport=40000, dport=123) / Raw(ak_header + bytes(bad_ef))),
+            ]
             with tempfile.NamedTemporaryFile(suffix='.pcap', delete=False) as tf:
                 pcap_path = tf.name
-            wrpcap(pcap_path, [pkt])
-            res = _run(['tcpdump', '-nn', '-tt', '-v', '-r', pcap_path], timeout=10)
+            wrpcap(pcap_path, pkts)
+            res = _run(['tcpdump', '-nn', '-tt', '-v', '-x', '-r', pcap_path],
+                       timeout=10)
             recs = _parse_ntp_capture(res['out'])
             srv = [r for r in recs if r['src'] == '192.0.2.123']
-            ok = bool(srv) and srv[0]['stratum'] == 2 and srv[0]['offset'] is not None
+            akr = [r for r in recs if r['src'] == '192.0.2.66']
+            verdict = _ntp_analyze(recs, 15, {}, learn=False)['verdict']
+            ok = (bool(srv) and srv[0]['stratum'] == 2 and srv[0]['offset'] is not None
+                  and bool(akr) and akr[0]['autokey'] and akr[0]['autokey_reasons']
+                  and verdict == 'autokey-exploit')
             scapy_result = {'ran': True, 'servers': [r['src'] for r in recs],
                             'stratum': srv[0]['stratum'] if srv else None,
-                            'offset': srv[0]['offset'] if srv else None, 'pass': ok,
+                            'offset': srv[0]['offset'] if srv else None,
+                            'autokey_reasons': akr[0]['autokey_reasons'] if akr else None,
+                            'verdict': verdict, 'pass': ok,
                             'tcpdump_out': res['out'].strip()[:200]}
             try:
                 os.remove(pcap_path)

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -2236,7 +2236,7 @@
                 </div>
                 <!-- Cisco Switch & Router Guard -->
                 <div class="glass rounded-xl p-4 sm:p-6 mt-6">
-                    <h3 class="text-lg font-semibold mb-1">Cisco Guard <span class="text-xs font-normal text-gray-500">(IOS / IOS-XE / NX-OS · switch · router · edge)</span></h3>
+                    <h3 class="text-lg font-semibold mb-1">Cisco Switch and Router Guard <span class="text-xs font-normal text-gray-500">(IOS / IOS-XE / NX-OS · switch · router · edge)</span></h3>
                     <p class="text-xs text-amber-300/90 mb-2">Passive Cisco router/switch CVE guard — <strong>detection-only</strong>, never transmits, probes or authenticates. Reports three classes of evidence about a tracked CVE set: <strong>posture</strong> (a version/platform fingerprint screened against the catalog — a "verify THIS device" note, never a verdict), <strong>exposure</strong> (an enabling condition on the wire — cleartext SNMP, a default community, an HTTP UI or Telnet to infrastructure) and <strong>attack</strong> (an exploitation primitive in transit — the CVE-2025-20352 SNMP overflow shape, an oversized field, a VLAN tag-stack anomaly, or an NX-OS Telnet shell-escape / CVE-2024-20399). Firewalls (ASA/Firepower/FTD) are screened out of scope, not misclassified.</p>
                     <p class="text-sm text-gray-400 mb-3">One short passive capture over the Cisco management + attack surface (SNMP 161/162, Telnet 23, HTTP UIs 80/8080/8443, IKEv2 500/4500). SNMP is BER-parsed for the community, OID-arc depth and field sizes; no TCP reassembly, so a segmented HTTP/Telnet attack is best-effort (a hit is high-confidence, a miss inconclusive).</p>
                     <div class="flex flex-wrap items-center gap-2">

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -2234,6 +2234,48 @@
                     </div>
                     <div id="bgp-results" class="hidden mt-3 overflow-x-auto text-sm"></div>
                 </div>
+                <!-- Cisco Switch & Router Guard -->
+                <div class="glass rounded-xl p-4 sm:p-6 mt-6">
+                    <h3 class="text-lg font-semibold mb-1">Cisco Guard <span class="text-xs font-normal text-gray-500">(IOS / IOS-XE / NX-OS · switch · router · edge)</span></h3>
+                    <p class="text-xs text-amber-300/90 mb-2">Passive Cisco router/switch CVE guard — <strong>detection-only</strong>, never transmits, probes or authenticates. Reports three classes of evidence about a tracked CVE set: <strong>posture</strong> (a version/platform fingerprint screened against the catalog — a "verify THIS device" note, never a verdict), <strong>exposure</strong> (an enabling condition on the wire — cleartext SNMP, a default community, an HTTP UI or Telnet to infrastructure) and <strong>attack</strong> (an exploitation primitive in transit — the CVE-2025-20352 SNMP overflow shape, an oversized field, a VLAN tag-stack anomaly, or an NX-OS Telnet shell-escape / CVE-2024-20399). Firewalls (ASA/Firepower/FTD) are screened out of scope, not misclassified.</p>
+                    <p class="text-sm text-gray-400 mb-3">One short passive capture over the Cisco management + attack surface (SNMP 161/162, Telnet 23, HTTP UIs 80/8080/8443, IKEv2 500/4500). SNMP is BER-parsed for the community, OID-arc depth and field sizes; no TCP reassembly, so a segmented HTTP/Telnet attack is best-effort (a hit is high-confidence, a miss inconclusive).</p>
+                    <div class="flex flex-wrap items-center gap-2">
+                        <select id="cisco-guard-iface" title="Interface for the capture — pick the LAN/uplink NIC or a SPAN/mirror port" class="w-full sm:w-auto bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-gray-300">
+                            <option value="">Auto (wired first)</option>
+                        </select>
+                        <input id="cisco-guard-secs" type="number" min="5" max="40" value="20" title="capture seconds" class="w-20 bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm">
+                        <button onclick="runCiscoGuard()" class="w-full sm:w-auto bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Scan Cisco</button>
+                    </div>
+                    <div id="cisco-guard-results" class="hidden mt-3 overflow-x-auto text-sm"></div>
+                </div>
+                <!-- Juniper Switch & Router Guard -->
+                <div class="glass rounded-xl p-4 sm:p-6 mt-6">
+                    <h3 class="text-lg font-semibold mb-1">Juniper Guard <span class="text-xs font-normal text-gray-500">(J-Web · SSR · Junos Space · Junos-Evolved)</span></h3>
+                    <p class="text-xs text-amber-300/90 mb-2">Passive Juniper CVE guard — <strong>detection-only</strong>, never transmits. Fully dissects cleartext HTTP to <strong>J-Web</strong> and the Junos-Evolved <strong>On-Box Anomaly Detection API</strong>, and reads TLS ClientHello SNI. Flags the byte-exact <strong>CVE-2023-36844..36847</strong> J-Web attack shapes — <strong>PHPRC / LD_PRELOAD environment-variable injection</strong>, <strong>unauthenticated file upload</strong>, and the two correlated together as an <strong>RCE chain</strong> — plus the <strong>CVE-2026-21902</strong> anomaly-API RCE and Junos-Space stored-XSS injection attempts.</p>
+                    <p class="text-sm text-gray-400 mb-3">One short passive capture over the Juniper web surface (HTTP 80/8080, anomaly API 8160, TLS 443/8443). No TCP reassembly, so a segmented request is best-effort; passive version extraction is a known dead end for this vendor, so version postures are not claimed.</p>
+                    <div class="flex flex-wrap items-center gap-2">
+                        <select id="juniper-guard-iface" title="Interface for the capture — pick the LAN/uplink NIC or a SPAN/mirror port" class="w-full sm:w-auto bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-gray-300">
+                            <option value="">Auto (wired first)</option>
+                        </select>
+                        <input id="juniper-guard-secs" type="number" min="5" max="40" value="20" title="capture seconds" class="w-20 bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm">
+                        <button onclick="runJuniperGuard()" class="w-full sm:w-auto bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Scan Juniper</button>
+                    </div>
+                    <div id="juniper-guard-results" class="hidden mt-3 overflow-x-auto text-sm"></div>
+                </div>
+                <!-- Arista Switch & Router Guard -->
+                <div class="glass rounded-xl p-4 sm:p-6 mt-6">
+                    <h3 class="text-lg font-semibold mb-1">Arista Guard <span class="text-xs font-normal text-gray-500">(EOS · switch · router · edge · core)</span></h3>
+                    <p class="text-xs text-amber-300/90 mb-2">Passive Arista EOS CVE guard — <strong>detection-only</strong>, never transmits. Reads the EOS version/platform from <strong>LLDP</strong>, parses <strong>RADIUS</strong> for the <strong>BlastRADIUS</strong> (CVE-2024-3596) conditions — cleartext, a missing Message-Authenticator, an unauthenticated response, or an oversized attribute (forgery shape) — screens <strong>SSH banners</strong> for the <strong>regreSSHion</strong> window (CVE-2024-6387/6409), and flags management listeners (gNMI/gNOI, CVX, VXLAN decap) and VLAN tag-stack CPU-punt anomalies. Non-EOS Arista products (CloudVision/VeloCloud/DANZ) are screened out of scope.</p>
+                    <p class="text-sm text-gray-400 mb-3">One short passive capture (RADIUS 1812/1813/1645/1646, SSH 22, gNMI 6030/9339/50051, CVX 9979, VXLAN 4789/8472, LLDP). Thresholds are structural anomaly bounds set well above legitimate traffic, not published vendor constants.</p>
+                    <div class="flex flex-wrap items-center gap-2">
+                        <select id="arista-guard-iface" title="Interface for the capture — pick the LAN/uplink NIC or a SPAN/mirror port" class="w-full sm:w-auto bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm text-gray-300">
+                            <option value="">Auto (wired first)</option>
+                        </select>
+                        <input id="arista-guard-secs" type="number" min="5" max="40" value="20" title="capture seconds" class="w-20 bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm">
+                        <button onclick="runAristaGuard()" class="w-full sm:w-auto bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm whitespace-nowrap">Scan Arista</button>
+                    </div>
+                    <div id="arista-guard-results" class="hidden mt-3 overflow-x-auto text-sm"></div>
+                </div>
                 <!-- BGP Collector + Path Asymmetry (OWD) -->
                 <div class="glass rounded-xl p-4 sm:p-6 mt-6">
                     <h3 class="text-lg font-semibold mb-1">BGP Collector &amp; Path Asymmetry <span class="text-xs font-normal text-gray-500">(control-plane ↔ data-plane)</span></h3>
@@ -8080,7 +8122,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260818-kiosk-handheld"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260819-vendor-guards"></script>
 
 
 

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -6413,7 +6413,7 @@ const _NETINT_STYLE = {
 // else non-clean — a suspicious finding (amber). Mirrors the server's _ni_rank so the
 // chips colour every scanner's verdicts without enumerating them all.
 const _NETINT_CLEAN = new Set(['clean', 'unknown', 'ok', 'none', 'hardened', 'learned', 'n/a', 'no-traffic', 'disabled', 'not-applicable', 'randomization', 'fhrp']);
-const _NETINT_CRITICAL = new Set(['hijacked', 'spoofed', 'rogue', 'starvation', 'compromised', 'root-hijack', 'bpdu-flood', 'vlan-hop', 'hijack', 'injection', 'rogue-router', 'poisoning', 'spoof-conflict', 'smbv1-active', 'coercion-attempt', 'relay-suspected', 'rogue-speaker', 'rogue-redirect', 'rogue-ra', 'rogue-irdp', 'cdpwn']);
+const _NETINT_CRITICAL = new Set(['hijacked', 'spoofed', 'rogue', 'starvation', 'compromised', 'root-hijack', 'bpdu-flood', 'vlan-hop', 'hijack', 'injection', 'rogue-router', 'poisoning', 'spoof-conflict', 'smbv1-active', 'coercion-attempt', 'relay-suspected', 'rogue-speaker', 'rogue-redirect', 'rogue-ra', 'rogue-irdp', 'cdpwn', 'autokey-exploit']);
 function _netintRank(verdict) {
     const v = verdict || 'unknown';
     if (_NETINT_CLEAN.has(v)) return 0;
@@ -7437,6 +7437,8 @@ const _NTP_VERDICT_STYLE = {
     kod:              ['bg-red-950/60 border-red-800 text-red-300', '🛑 NTP Kiss-o\'-Death — time-sync DoS'],
     'rogue-server':   ['bg-red-950/60 border-red-800 text-red-300', '🛑 Rogue NTP server answering on the segment'],
     'time-injection': ['bg-red-950/60 border-red-800 text-red-300', '🛑 NTP time injection — a source is serving a skewed clock'],
+    autokey:          ['bg-amber-950/50 border-amber-800 text-amber-300', '⚠ NTP Autokey extension field on the wire — deprecated (CVE-2014-9295 surface)'],
+    'autokey-exploit':['bg-red-950/60 border-red-800 text-red-300', '🛑 Malformed NTP Autokey EF — crypto_recv() overflow signature (CVE-2014-9295 RCE)'],
     unknown:          ['bg-slate-800 border-slate-700 text-slate-400', '— Could not determine'],
 };
 function _ntpFillIfaces() {
@@ -7477,7 +7479,7 @@ async function runNtpWatch() {
         }
         const [cls, label] = _NTP_VERDICT_STYLE[d.verdict] || _NTP_VERDICT_STYLE.unknown;
         let html = `<div class="mb-2 px-3 py-2 rounded border ${cls} text-sm">${label}</div>`;
-        html += `<p class="text-xs text-gray-500 mb-2">Interface: ${escapeHtml(d.interface || '—')} · ${d.server_count} source(s) · ${d.packet_count} pkts (${d.rate}/s)${d.control_count ? ' · ' + d.control_count + ' mode-6/7' : ''}${d.learned ? ' · <span class="text-gray-400">baseline learned now</span>' : ''}</p>`;
+        html += `<p class="text-xs text-gray-500 mb-2">Interface: ${escapeHtml(d.interface || '—')} · ${d.server_count} source(s) · ${d.packet_count} pkts (${d.rate}/s)${d.control_count ? ' · ' + d.control_count + ' mode-6/7' : ''}${d.autokey_count ? ' · <span class="text-amber-400">' + d.autokey_count + ' Autokey EF' + (d.autokey_malformed ? ', ' + d.autokey_malformed + ' malformed' : '') + '</span>' : ''}${d.learned ? ' · <span class="text-gray-400">baseline learned now</span>' : ''}</p>`;
         const servers = d.servers || [];
         if (servers.length) {
             html += '<p class="text-xs uppercase text-gray-400 mt-2 mb-1">Time sources (' + servers.length + ')</p>' +

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -6412,8 +6412,8 @@ const _NETINT_STYLE = {
 // A verdict is clean/informational, an active attack (critical, red), or — anything
 // else non-clean — a suspicious finding (amber). Mirrors the server's _ni_rank so the
 // chips colour every scanner's verdicts without enumerating them all.
-const _NETINT_CLEAN = new Set(['clean', 'unknown', 'ok', 'none', 'hardened', 'learned', 'n/a', 'no-traffic', 'disabled', 'not-applicable', 'randomization', 'fhrp']);
-const _NETINT_CRITICAL = new Set(['hijacked', 'spoofed', 'rogue', 'starvation', 'compromised', 'root-hijack', 'bpdu-flood', 'vlan-hop', 'hijack', 'injection', 'rogue-router', 'poisoning', 'spoof-conflict', 'smbv1-active', 'coercion-attempt', 'relay-suspected', 'rogue-speaker', 'rogue-redirect', 'rogue-ra', 'rogue-irdp', 'cdpwn', 'autokey-exploit']);
+const _NETINT_CLEAN = new Set(['clean', 'unknown', 'ok', 'none', 'hardened', 'learned', 'n/a', 'no-traffic', 'disabled', 'not-applicable', 'randomization', 'fhrp', 'observed']);
+const _NETINT_CRITICAL = new Set(['hijacked', 'spoofed', 'rogue', 'starvation', 'compromised', 'root-hijack', 'bpdu-flood', 'vlan-hop', 'hijack', 'injection', 'rogue-router', 'poisoning', 'spoof-conflict', 'smbv1-active', 'coercion-attempt', 'relay-suspected', 'rogue-speaker', 'rogue-redirect', 'rogue-ra', 'rogue-irdp', 'cdpwn', 'autokey-exploit', 'attack']);
 function _netintRank(verdict) {
     const v = verdict || 'unknown';
     if (_NETINT_CLEAN.has(v)) return 0;
@@ -7526,6 +7526,115 @@ async function ntpTrustBaseline() {
         addConsoleMessage('Failed to reset NTP baseline: ' + e.message, 'error');
     }
 }
+
+// ---- Vendor CVE Guards (Cisco / Juniper / Arista) --------------------------
+const _GUARD_VERDICT_STYLE = {
+    clean:    ['bg-green-950/40 border-green-900 text-green-400', '✓ No tracked CVE evidence on the segment'],
+    observed: ['bg-slate-800 border-slate-700 text-slate-300', 'ℹ Vendor device observed — no CVE-relevant finding'],
+    posture:  ['bg-amber-950/50 border-amber-800 text-amber-300', '⚠ A version/platform screens into a tracked CVE range — verify THIS device'],
+    exposure: ['bg-orange-950/50 border-orange-800 text-orange-300', '⚠ A CVE enabling-condition is exposed on the wire'],
+    attack:   ['bg-red-950/60 border-red-800 text-red-300', '🛑 An exploitation primitive was observed in transit'],
+    unknown:  ['bg-slate-800 border-slate-700 text-slate-400', '— Could not determine'],
+};
+const _GUARD_SEV_STYLE = {
+    CRITICAL: 'bg-red-900/70 text-red-200',
+    HIGH:     'bg-orange-900/60 text-orange-200',
+    MEDIUM:   'bg-amber-900/50 text-amber-200',
+    LOW:      'bg-slate-700 text-slate-200',
+    INFO:     'bg-slate-800 text-slate-400',
+};
+const _GUARD_KLASS_STYLE = {
+    POSTURE:  'text-slate-400', EXPOSURE: 'text-orange-300', ATTACK: 'text-red-300',
+};
+function _guardFillIfaces(selId) {
+    const sel = document.getElementById(selId);
+    if (!sel || sel.dataset.filled === '1') return Promise.resolve();
+    return fetchAPI('/api/net/interfaces').then(x => {
+        (x.interfaces || []).forEach(i => {
+            const o = document.createElement('option');
+            o.value = i.name;
+            const tag = i.type === 'wifi' ? ' (WiFi)' : i.type === 'ethernet' ? ' (LAN)' : (i.type ? ' (' + i.type + ')' : '');
+            o.textContent = i.name + tag;
+            sel.appendChild(o);
+        });
+        sel.dataset.filled = '1';
+    }).catch(() => {});
+}
+function _guardDetailStr(det) {
+    if (!det || typeof det !== 'object') return '';
+    const parts = [];
+    for (const k of Object.keys(det)) parts.push(k + '=' + det[k]);
+    return parts.join(' · ');
+}
+function _renderGuardResult(d) {
+    const [cls, label] = _GUARD_VERDICT_STYLE[d.verdict] || _GUARD_VERDICT_STYLE.unknown;
+    const cc = d.class_counts || {};
+    let html = `<div class="mb-2 px-3 py-2 rounded border ${cls} text-sm">${label}</div>`;
+    html += `<p class="text-xs text-gray-500 mb-2">Interface: ${escapeHtml(d.interface || '—')} · ${d.packet_count} pkts · ${d.finding_count} finding(s)`;
+    const bits = [];
+    if (cc.POSTURE) bits.push(cc.POSTURE + ' posture');
+    if (cc.EXPOSURE) bits.push(cc.EXPOSURE + ' exposure');
+    if (cc.ATTACK) bits.push(cc.ATTACK + ' attack');
+    if (bits.length) html += ' · ' + bits.join(', ');
+    html += '</p>';
+    if ((d.cves || []).length) {
+        html += '<p class="text-xs text-gray-400 mb-2">CVEs in scope: <span class="font-mono text-amber-300">' + d.cves.map(escapeHtml).join(', ') + '</span></p>';
+    }
+    const fs = d.findings || [];
+    if (fs.length) {
+        html += '<table class="min-w-full text-xs text-gray-300 whitespace-nowrap"><thead>' +
+            '<tr class="text-left text-gray-500"><th class="px-2 py-1">Sev</th><th class="px-2 py-1">Code</th><th class="px-2 py-1">Finding</th><th class="px-2 py-1">Class</th><th class="px-2 py-1">Source</th><th class="px-2 py-1">CVEs</th><th class="px-2 py-1">Detail</th></tr>' +
+            '</thead><tbody>' +
+            fs.map(f => {
+                const sev = _GUARD_SEV_STYLE[f.severity] || 'bg-slate-800 text-slate-400';
+                const kl = _GUARD_KLASS_STYLE[f.klass] || 'text-gray-400';
+                return '<tr class="border-t border-slate-800">' +
+                    `<td class="px-2 py-1"><span class="px-1.5 py-0.5 rounded ${sev} text-[10px] font-semibold">${escapeHtml(f.severity)}</span></td>` +
+                    `<td class="px-2 py-1 font-mono text-gray-400">${escapeHtml(f.code)}</td>` +
+                    `<td class="px-2 py-1">${escapeHtml(f.name)}</td>` +
+                    `<td class="px-2 py-1 ${kl}">${escapeHtml(f.klass)}</td>` +
+                    `<td class="px-2 py-1 font-mono">${escapeHtml(f.src || '—')}</td>` +
+                    `<td class="px-2 py-1 font-mono text-amber-300/80">${escapeHtml((f.cves || []).join(', ') || '—')}</td>` +
+                    `<td class="px-2 py-1 text-gray-500">${escapeHtml(_guardDetailStr(f.detail))}</td>` +
+                    '</tr>';
+            }).join('') +
+            '</tbody></table>';
+    } else if (d.verdict === 'clean') {
+        html += '<p class="text-xs text-gray-500">Segment quiet — no vendor management or attack traffic seen in the window.</p>';
+    }
+    return html;
+}
+async function _runGuard(module, label, btn) {
+    const out = document.getElementById(module + '-guard-results');
+    if (!out) return;
+    const ifaceSel = document.getElementById(module + '-guard-iface');
+    const iface = ifaceSel && ifaceSel.value ? ifaceSel.value : '';
+    const secsEl = document.getElementById(module + '-guard-secs');
+    const secs = secsEl && secsEl.value ? secsEl.value : '20';
+    _ndBusy(btn, true, 'Capturing…');
+    out.classList.remove('hidden');
+    out.innerHTML = `<p class="text-sm text-gray-400">Passively capturing the ${escapeHtml(label)} attack surface…</p>`;
+    try {
+        _guardFillIfaces(module + '-guard-iface');
+        const qs = '?seconds=' + encodeURIComponent(secs) + (iface ? '&interface=' + encodeURIComponent(iface) : '');
+        const d = await fetchAPI('/api/net/' + module + '-guard' + qs);
+        if (!d || d.success === false) {
+            const msg = (d && d.error) || 'failed';
+            let extra = '';
+            if (d && d.missing_tool) extra = ' <button onclick="installNetTool(\'tcpdump\', this, run' + label + 'Guard)" class="ml-2 underline text-cyan-400">Install tcpdump</button>';
+            out.innerHTML = '<p class="text-sm text-red-400">Error: ' + escapeHtml(msg) + extra + '</p>';
+            return;
+        }
+        out.innerHTML = _renderGuardResult(d);
+    } catch (e) {
+        out.innerHTML = '<p class="text-sm text-red-400">Error: ' + escapeHtml(e.message) + '</p>';
+    } finally {
+        _ndBusy(btn, false);
+    }
+}
+function runCiscoGuard() { _runGuard('cisco', 'Cisco', (typeof event !== 'undefined' && event && event.target) ? event.target : null); }
+function runJuniperGuard() { _runGuard('juniper', 'Juniper', (typeof event !== 'undefined' && event && event.target) ? event.target : null); }
+function runAristaGuard() { _runGuard('arista', 'Arista', (typeof event !== 'undefined' && event && event.target) ? event.target : null); }
 
 // ---- ICMP Watch (passive ICMP-redirect / L3 route injection) ---------------
 const _ICMP_VERDICT_STYLE = {
@@ -9225,6 +9334,7 @@ async function runRoutingSelftest() {
         const names = { igmp: 'IGMP Watch', ipv6: 'IPv6 First-Hop Watch', ndp: 'NDP Watch (IPv6 neighbor spoofing)', raguard: 'IPv6 RA Guard', ntp: 'NTP Watch', icmp: 'ICMP Watch', snmp: 'SNMP Watch', cert: 'Cert Watch', tls: 'TLS Watch (passive JA4/QUIC)', stp: 'STP/BPDU Watch (spanning tree)', smb: 'SMB Watch (SMBv1 + poisoning + Kerberos downgrade)', relay: 'Relay/Coercion Watch (NTLM relay)', ldap: 'LDAP Watch (Active Directory)', dtp: 'DTP Watch (VLAN hopping)', cdp: 'CDP Watch (Cisco Discovery leak/flood)', vtp: 'VTP Watch (VTP bomb / VLAN-DB wipe)', eigrp: 'EIGRP Watch (Cisco IGP)', isis: 'IS-IS Watch (IGP)', fhrp: 'FHRP Watch (HSRP/VRRP/GLBP/CARP)', ospf: 'OSPF Scanner', bgp: 'BGP Path Watch',
                         arp: 'ARP Poisoning (incl. HSRP/VRRP virtual-MAC awareness)', dns: 'DNS Doctor (poison parser / anchors / ASN)',
                         mac: 'MAC Watch (spoof / vendor-OUI / randomization / HSRP-VRRP virtual-MAC)', dhcp: 'DHCP Guardian (rogue server / starvation)',
+                        cisco_guard: 'Cisco Guard (IOS/IOS-XE/NX-OS CVEs)', juniper_guard: 'Juniper Guard (J-Web/SSR/Space CVEs)', arista_guard: 'Arista Guard (EOS CVEs)',
                         bgp_speaker: 'BGP Speaker (codec/FSM/RIB)', path_asymmetry: 'Path Asymmetry (OWD)' };
         const overall = d.success
             ? '<div class="mb-2 px-3 py-2 rounded border bg-green-950/40 border-green-900 text-green-400 text-sm">✓ All detector self-tests passed' + (d.scapy_available ? ' (including Scapy end-to-end)' : ' — install Scapy for the end-to-end leg') + '</div>'
@@ -9233,7 +9343,7 @@ async function runRoutingSelftest() {
             '<table class="min-w-full text-xs text-gray-300 whitespace-nowrap"><thead>' +
             '<tr class="text-left text-gray-500"><th class="px-2 py-1">Scanner</th><th class="px-2 py-1">Scenarios</th><th class="px-2 py-1">End-to-end</th><th class="px-2 py-1">Result</th></tr>' +
             '</thead><tbody>';
-        ['igmp', 'ipv6', 'ndp', 'raguard', 'ntp', 'icmp', 'snmp', 'cert', 'tls', 'stp', 'smb', 'relay', 'ldap', 'dtp', 'cdp', 'vtp', 'eigrp', 'isis', 'fhrp', 'ospf', 'arp', 'mac', 'dhcp', 'dns', 'bgp', 'bgp_speaker', 'path_asymmetry'].forEach(k => {
+        ['igmp', 'ipv6', 'ndp', 'raguard', 'ntp', 'icmp', 'snmp', 'cert', 'tls', 'stp', 'smb', 'relay', 'ldap', 'dtp', 'cdp', 'vtp', 'eigrp', 'isis', 'fhrp', 'ospf', 'arp', 'mac', 'dhcp', 'dns', 'bgp', 'cisco_guard', 'juniper_guard', 'arista_guard', 'bgp_speaker', 'path_asymmetry'].forEach(k => {
             const s = d.suites[k]; if (!s) return;
             const okAll = s.success;
             html += `<tr class="border-t border-slate-800">

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -1839,7 +1839,8 @@ def _ni_save_memory():
 _NI_CLEAN = {'clean', 'unknown', 'ok', 'none', 'hardened', 'learned', 'n/a',
              'no-traffic', 'disabled', 'not-applicable',
              'randomization',       # mac: privacy-MAC inventory is benign, not an alert
-             'fhrp'}                # mac: HSRP/VRRP/GLBP virtual-MAC inventory is expected
+             'fhrp',                # mac: HSRP/VRRP/GLBP virtual-MAC inventory is expected
+             'observed'}            # guards: a vendor device seen, no CVE-relevant finding
 _NI_CRITICAL = {
     'hijacked', 'spoofed', 'rogue', 'starvation', 'compromised',        # dns/arp/dhcp
     'root-hijack', 'bpdu-flood',                                        # stp
@@ -1853,6 +1854,7 @@ _NI_CRITICAL = {
     'rogue-redirect', 'rogue-ra', 'rogue-irdp',                         # ipv6/icmp
     'cdpwn',                                                            # cdp (Armis CDPwn CVE exploit shape)
     'autokey-exploit',                                                 # ntp (CVE-2014-9295 crypto_recv overflow signature)
+    'attack',                                                          # vendor guards: an exploitation primitive observed on the wire
 }
 
 
@@ -1936,6 +1938,9 @@ def _net_integrity_check_once():
         ('cert', 'Cert', lambda: watch(nd.do_cert_watch, discover=False)),
         ('tls', 'TLS', lambda: watch(nd.do_tls_watch, interface=cap_iface)),
         ('ldap', 'LDAP', lambda: watch(nd.do_ldap_watch, interface=cap_iface)),
+        ('cisco_guard', 'Cisco', lambda: watch(nd.do_cisco_guard, quick=True, interface=cap_iface)),
+        ('juniper_guard', 'Juniper', lambda: watch(nd.do_juniper_guard, quick=True, interface=cap_iface)),
+        ('arista_guard', 'Arista', lambda: watch(nd.do_arista_guard, quick=True, interface=cap_iface)),
     ]
 
     to_run = list(fast)

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -1852,6 +1852,7 @@ _NI_CRITICAL = {
     'rogue-speaker',                                                    # fhrp
     'rogue-redirect', 'rogue-ra', 'rogue-irdp',                         # ipv6/icmp
     'cdpwn',                                                            # cdp (Armis CDPwn CVE exploit shape)
+    'autokey-exploit',                                                 # ntp (CVE-2014-9295 crypto_recv overflow signature)
 }
 
 


### PR DESCRIPTION
This pull request introduces new passive CVE detection features for Cisco, Juniper, and Arista network devices, enhances the NTP scanner to detect Autokey vulnerabilities, and updates the web UI and documentation to reflect these additions. The changes include both backend and frontend modifications, as well as updates to the user documentation to explain the new functionality.

**Major new features and improvements:**

### Vendor CVE Guard Scanners

* Added three new passive, detection-only CVE guard scanners for Cisco, Juniper, and Arista network devices. These scanners analyze traffic for posture, exposure, and attack evidence related to known CVEs, and provide detailed findings through new API endpoints and CLI commands. The documentation (`docs/nettools.md`) and web UI (`web/index_modern.html`) have been updated to describe and expose these features. [[1]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaR73-R75) [[2]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaR1937-R2004) [[3]](diffhunk://#diff-7a539845f7a3dbcb375c4f1fd20d0e033f28fd246928b5167f61ffef837e62f8R2237-R2278)

### NTP Autokey Vulnerability Detection

* Enhanced the NTP scanner to detect and classify NTP Autokey extension fields, including specific detection for malformed Autokey EFs that match the signature of CVE-2014-9295 and related vulnerabilities. The documentation and frontend verdict displays have been updated accordingly. [[1]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaR705-R718) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R7440-R7441) [[3]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L7480-R7482)

### Documentation Updates

* Expanded the documentation to include the new vendor guard scanners and the NTP Autokey detection, explaining their operation, CVE coverage, and usage details. [[1]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaR73-R75) [[2]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaL503-R507) [[3]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaR1937-R2004) [[4]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaR705-R718)

### Web UI Enhancements

* Added interactive panels to the web UI for running Cisco, Juniper, and Arista guard scans, including interface selection, capture duration, and results display. Updated JavaScript and CSS to support new verdicts and styles. [[1]](diffhunk://#diff-7a539845f7a3dbcb375c4f1fd20d0e033f28fd246928b5167f61ffef837e62f8R2237-R2278) [[2]](diffhunk://#diff-7a539845f7a3dbcb375c4f1fd20d0e033f28fd246928b5167f61ffef837e62f8L8083-R8125) [[3]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L6415-R6416) [[4]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R7440-R7441)

### Verdict Classification Improvements

* Updated the frontend logic to recognize new verdicts (`observed`, `autokey`, `autokey-exploit`, `attack`) as clean or critical, ensuring accurate color-coding and risk ranking in the UI. [[1]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0L6415-R6416) [[2]](diffhunk://#diff-56a87caa4859b0b14db8dadee8790bd786a12ab85ee06a16d39a0980058f33b0R7440-R7441)

These changes collectively expand the platform's passive network security monitoring capabilities, providing users with advanced detection for high-profile network device vulnerabilities and improved visibility into NTP-related risks.