### PR TITLE
rusense: add Restart button to the Sensing backend card

### DIFF
--- a/docs/rusense.md
+++ b/docs/rusense.md
@@ -115,6 +115,10 @@ cd /home/ragnar/Ragnar
 sudo ./scripts/install_sensing.sh
 ```
 
+The **Sensing backend** card (Config → RuSense) manages this without a shell:
+**Install/Reinstall**, **Build from source**, **Restart** (a quick service bounce —
+e.g. after changing env overrides or to re-bind the UDP receiver), and **Uninstall**.
+
 This installs and starts `ragnar-sensing.service`:
 
 - On **Raspberry Pi (arm64)** it installs the prebuilt binary at `bin/sensing-server`.

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -6873,6 +6873,8 @@
                                             class="px-3 py-1.5 rounded-lg bg-cyan-600 hover:bg-cyan-500 text-white text-xs font-medium">Install</button>
                                         <button id="sensing-rebuild-btn" onclick="installSensingBackend(true)"
                                             class="px-3 py-1.5 rounded-lg bg-slate-600 hover:bg-slate-500 text-white text-xs font-medium">Build from source</button>
+                                        <button id="sensing-restart-btn" onclick="restartSensingBackend()"
+                                            class="hidden px-3 py-1.5 rounded-lg bg-amber-600 hover:bg-amber-500 text-white text-xs font-medium">Restart</button>
                                         <button id="sensing-uninstall-btn" onclick="uninstallSensingBackend()"
                                             class="hidden px-3 py-1.5 rounded-lg bg-red-700 hover:bg-red-600 text-white text-xs font-medium">Uninstall</button>
                                     </div>
@@ -8122,7 +8124,7 @@
 
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260721-skyview-live"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260819-vendor-guards"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260819-sensing-restart"></script>
 
 
 

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -1066,6 +1066,7 @@ function refreshSensingInstallCard() {
             const installBtn = document.getElementById('sensing-install-btn');
             const rebuildBtn = document.getElementById('sensing-rebuild-btn');
             const uninstallBtn = document.getElementById('sensing-uninstall-btn');
+            const restartBtn = document.getElementById('sensing-restart-btn');
             const archNote = document.getElementById('sensing-arch-note');
             // Always visible in the RuSense tab: doubles as a status + management panel
             // (Install when absent, Reinstall / Uninstall when present).
@@ -1087,6 +1088,7 @@ function refreshSensingInstallCard() {
             if (installBtn) { installBtn.disabled = busy; installBtn.textContent = s.installed ? 'Reinstall' : 'Install'; }
             if (rebuildBtn) rebuildBtn.disabled = busy;
             if (uninstallBtn) { uninstallBtn.classList.toggle('hidden', !s.installed); uninstallBtn.disabled = busy; }
+            if (restartBtn) { restartBtn.classList.toggle('hidden', !s.installed); restartBtn.disabled = busy; }
             if (s.installing) startSensingLogPoll();
         })
         .catch(() => {});
@@ -1106,6 +1108,27 @@ function uninstallSensingBackend() {
     if (!confirm('Stop and remove the bundled sensing backend?')) return;
     fetch('/api/sensing/uninstall', { method: 'POST' })
         .then(() => startSensingLogPoll()).catch(() => {});
+}
+
+function restartSensingBackend() {
+    const btn = document.getElementById('sensing-restart-btn');
+    if (btn) { btn.disabled = true; btn.textContent = 'Restarting…'; }
+    fetch('/api/sensing/restart', { method: 'POST' })
+        .then(r => r.json())
+        .then(d => {
+            if (typeof showNotification === 'function') {
+                showNotification(d.success ? (d.message || 'Sensing service restarted')
+                                           : (d.error || 'Restart failed'),
+                                 d.success ? 'success' : 'error');
+            }
+        })
+        .catch(() => {
+            if (typeof showNotification === 'function') showNotification('Restart request failed', 'error');
+        })
+        .finally(() => {
+            if (btn) btn.textContent = 'Restart';
+            refreshSensingInstallCard();
+        });
 }
 
 function startSensingLogPoll() {

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -4745,6 +4745,33 @@ def sensing_uninstall():
     return jsonify({'success': True, 'message': 'Sensing backend uninstall started'})
 
 
+@app.route('/api/sensing/restart', methods=['POST'])
+def sensing_restart():
+    """Restart the bundled sensing service (systemctl restart) without a full reinstall.
+
+    Handy after tuning env/overrides, or to re-bind the UDP CSI receiver — a quick
+    bounce instead of the slower Reinstall path. Refuses while an install is running.
+    """
+    with _sensing_install_lock:
+        if _sensing_installing:
+            return jsonify({'success': False, 'error': 'An install is in progress — try again shortly.'}), 409
+    installed, _ = _sensing_unit_state()
+    if not installed:
+        return jsonify({'success': False, 'error': 'Sensing backend is not installed.'}), 400
+    cmd = (['systemctl', 'restart', SENSING_UNIT] if os.geteuid() == 0
+           else ['sudo', '-n', 'systemctl', 'restart', SENSING_UNIT])
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except Exception as exc:
+        return jsonify({'success': False, 'error': f'restart failed: {exc}'}), 500
+    if proc.returncode != 0:
+        return jsonify({'success': False,
+                        'error': (proc.stderr or proc.stdout or 'systemctl restart failed').strip()}), 500
+    _, active = _sensing_unit_state()
+    return jsonify({'success': True, 'active': active,
+                    'message': 'Sensing service restarted' + ('' if active else ' (not active — check logs)')})
+
+
 @app.route('/api/sensing/install-log', methods=['GET'])
 def sensing_install_log():
     """Return the live install/uninstall log and current service state."""


### PR DESCRIPTION
A quick 'systemctl restart ragnar-sensing.service' bounce from the config UI — useful after tuning env overrides or to re-bind the UDP CSI receiver, without the slower Reinstall path.

- webapp_modern.py: POST /api/sensing/restart (refuses during an install / when not installed; runs restart directly as root, reports new active state).
- index_modern.html + ragnar_modern.js: amber Restart button on the card, shown when installed; bump the JS cache-buster.
- docs/rusense.md: document the card's Install/Restart/Uninstall actions.