### PR TITLE
Feed SSH Watch and Telnet Watch into Watchtower + Network Integrity M…

### DIFF
--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -1561,6 +1561,13 @@ it drives: upgrade sshd to **9.8p1+**, enable **strict KEX** and drop CBC-EtM / 
 Terrapin matters, and remove SSH-1 / weak KEX / host-key / cipher / MAC offers. **API:**
 `GET /api/net/ssh-watch` (`seconds`, `grace_seconds`). **CLI:** `ssh-watch`, `ssh-selftest`.
 
+> **Watchtower feed.** Each non-`info` finding is appended as a JSON-lines record to
+> `/var/log/ragnar/ssh_watch.jsonl` (time-window deduplicated per code + server), so
+> [Watchtower](#watchtower) folds it into the unified alert pane and single Pushover path
+> alongside the standalone watcher daemons — automatically whenever Extended Monitoring is on.
+> Pure inventory/posture (`info`) stays off the alert pane. The observer also joins the
+> **Network Integrity Monitor** rotation, so its verdict shows as an `SSH` chip there.
+
 ### Telnet Watch
 A **passive** Telnet observer — **detection-only, it never transmits**. Telnet is unusually
 suited to deep passive detection because the protocol is **cleartext end to end**, including
@@ -1603,6 +1610,14 @@ dissected with Scapy; the parser/engine is pure Python and self-tests without ro
 engine). Hardening it drives: **disable Telnet** and use SSH; where it must remain, patch
 inetutils (**2.5 `3ubuntu4.1`** is the fixed build) and firewall tcp/23 off the management
 plane. **API:** `GET /api/net/telnet-watch`. **CLI:** `telnet-watch`, `telnet-selftest`.
+
+> **Watchtower feed.** Each non-`info` finding is appended as a JSON-lines record to
+> `/var/log/ragnar/telnet_watch.jsonl` (time-window deduplicated per code + server), so
+> [Watchtower](#watchtower) folds it into the unified alert pane and single Pushover path
+> alongside the standalone watcher daemons — automatically whenever Extended Monitoring is on.
+> A `compromised` finding (argument injection, confirmed overflow) lands as **critical** there.
+> The observer also joins the **Network Integrity Monitor** rotation, so its verdict shows as
+> a `Telnet` chip there.
 
 ### DTP Watch
 A **passive** VLAN-hopping / switch-spoofing scanner for Cisco's **Dynamic Trunking

--- a/docs/watchtower.md
+++ b/docs/watchtower.md
@@ -26,6 +26,14 @@ pane and the same Pushover path as an ARP-poisoning or an evil-twin. Unlike the
 daemons, the guards need no systemd unit — they feed Watchtower automatically
 whenever **Extended Monitoring** is on.
 
+The in-app **L5–L7 observers** [`ssh_watch`](nettools.md#ssh-watch) and
+[`telnet_watch`](nettools.md#telnet-watch) feed the pane the same way, appending
+their **non-`info`** findings to `/var/log/ragnar/ssh_watch.jsonl` and
+`/var/log/ragnar/telnet_watch.jsonl` (deduplicated per code + server). Pure
+inventory/posture stays off the pane; a Terrapin exposure lands as **high** and a
+confirmed Telnet argument injection as **critical**. Both also run in the Network
+Integrity Monitor rotation, so their verdicts surface there as chips as well.
+
 These vendor guards are **LAN-only**: their findings only mean anything on a
 wired switch/router uplink or a SPAN/mirror port, so the background rotation
 runs them **only when a genuine wired LAN interface is up** and always over that

--- a/ssh_watch.py
+++ b/ssh_watch.py
@@ -51,6 +51,7 @@ import json
 import os
 import re
 import sys
+import threading
 import time
 from datetime import datetime, timezone
 
@@ -1277,6 +1278,61 @@ def _ssh_summarize(events, interface, seconds):
             "interface": interface, "seconds": seconds}
 
 
+# --- Watchtower feed: append findings as JSON-lines so the unified alert pane tails them ---
+_WT_LOG_DIR = os.environ.get("RAGNAR_WATCH_LOG_DIR", "/var/log/ragnar")
+_WT_DEDUP_S = 300.0                    # don't re-log the same standing finding within 5 min
+_WT_SKIP_SEV = frozenset(("info",))   # pure posture/inventory stays off the alert pane
+_wt_lock = threading.Lock()
+_wt_seen = {}                         # (code, server) -> last-emitted epoch
+
+
+def _emit_watchtower(result):
+    """Append each non-info SSH finding to <log-dir>/ssh_watch.jsonl in the shape
+    Watchtower.normalize() reads, so the unified alert pane and its single Pushover
+    path fold in the in-app SSH observer alongside the standalone watchers. Time-window
+    deduplicated per (code, server) so the background rotation can't spam a standing
+    condition. Best-effort: the scan never fails because logging did."""
+    if not result.get("success"):
+        return
+    verdict = result.get("verdict", "clean")
+    iface = result.get("interface")
+    now = time.time()
+    iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    lines = []
+    with _wt_lock:
+        for row in result.get("sessions", []):
+            server, client = row.get("server"), row.get("client")
+            for f in row.get("findings", []):
+                sev = f.get("severity")
+                if sev in _WT_SKIP_SEV:
+                    continue
+                code = f.get("code")
+                key = (code, server)
+                last = _wt_seen.get(key)
+                if last is not None and now - last < _WT_DEDUP_S:
+                    continue
+                _wt_seen[key] = now
+                cve = f.get("cve")
+                lines.append(json.dumps({
+                    "module": "ssh_watch", "ts": now, "iso": iso, "iface": iface,
+                    "severity": sev, "code": code, "codes": [code],
+                    "src": server, "target": client,
+                    "cves": [cve] if cve else [],
+                    "summary": f.get("message"), "verdict": verdict}))
+        if len(_wt_seen) > 4096:
+            cutoff = now - _WT_DEDUP_S
+            for k in [k for k, t in _wt_seen.items() if t < cutoff]:
+                _wt_seen.pop(k, None)
+    if not lines:
+        return
+    try:
+        os.makedirs(_WT_LOG_DIR, exist_ok=True)
+        with open(os.path.join(_WT_LOG_DIR, "ssh_watch.jsonl"), "a") as fh:
+            fh.write("\n".join(lines) + "\n")
+    except OSError:
+        pass
+
+
 def do_ssh_watch(interface=None, seconds=12, grace_seconds=120, grace_min=20,
                  no_grace_track=False):
     """Passive SSH observation on `interface` for `seconds`. Reads the cleartext SSH
@@ -1314,7 +1370,9 @@ def do_ssh_watch(interface=None, seconds=12, grace_seconds=120, grace_min=20,
         except OSError:
             pass
     watcher._gc(force=True)      # flush held flows so grace holds within the window score
-    return _ssh_summarize(em.events, interface, seconds)
+    result = _ssh_summarize(em.events, interface, seconds)
+    _emit_watchtower(result)
+    return result
 
 
 # ===========================================================================

--- a/telnet_watch.py
+++ b/telnet_watch.py
@@ -44,7 +44,9 @@ import argparse
 import json
 import os
 import sys
+import threading
 import time
+from datetime import datetime, timezone
 from dataclasses import dataclass, field
 from typing import Callable, Dict, Iterator, List, Optional, Tuple
 
@@ -903,6 +905,63 @@ def _telnet_summarize(records, interface, seconds):
     return {"success": True, "verdict": verdict, "sessions": rows,
             "count": len(rows), "findings_total": len(all_f),
             "interface": interface, "seconds": seconds}
+
+
+# --- Watchtower feed: append findings as JSON-lines so the unified alert pane tails them ---
+_WT_LOG_DIR = os.environ.get("RAGNAR_WATCH_LOG_DIR", "/var/log/ragnar")
+_WT_DEDUP_S = 300.0                    # don't re-log the same standing finding within 5 min
+_WT_SKIP_SEV = frozenset(("info",))   # pure posture/inventory stays off the alert pane
+_wt_lock = threading.Lock()
+_wt_seen = {}                         # (code, server) -> last-emitted epoch
+
+
+def _emit_watchtower(result):
+    """Append each non-info Telnet finding to <log-dir>/telnet_watch.jsonl in the shape
+    Watchtower.normalize() reads, so the unified alert pane and its single Pushover path
+    fold in the in-app Telnet observer alongside the standalone watchers. Time-window
+    deduplicated per (code, server) so the background rotation can't spam a standing
+    condition. Best-effort: the scan never fails because logging did."""
+    if not result.get("success"):
+        return
+    verdict = result.get("verdict", "clean")
+    iface = result.get("interface")
+    now = time.time()
+    iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    lines = []
+    with _wt_lock:
+        for row in result.get("sessions", []):
+            server, client = row.get("server"), row.get("client")
+            for f in row.get("findings", []):
+                sev = f.get("severity")
+                if sev in _WT_SKIP_SEV:
+                    continue
+                code = f.get("code")
+                key = (code, server)
+                last = _wt_seen.get(key)
+                if last is not None and now - last < _WT_DEDUP_S:
+                    continue
+                _wt_seen[key] = now
+                detail = f.get("detail") or {}
+                cves = detail.get("cves") if isinstance(detail, dict) else None
+                lines.append(json.dumps({
+                    "module": "telnet_watch", "ts": now, "iso": iso, "iface": iface,
+                    "severity": sev, "code": code, "codes": [code],
+                    "class": f.get("class"), "confidence": f.get("confidence"),
+                    "src": server, "target": client,
+                    "cves": cves if isinstance(cves, list) else [],
+                    "summary": f.get("desc"), "verdict": verdict}))
+        if len(_wt_seen) > 4096:
+            cutoff = now - _WT_DEDUP_S
+            for k in [k for k, t in _wt_seen.items() if t < cutoff]:
+                _wt_seen.pop(k, None)
+    if not lines:
+        return
+    try:
+        os.makedirs(_WT_LOG_DIR, exist_ok=True)
+        with open(os.path.join(_WT_LOG_DIR, "telnet_watch.jsonl"), "a") as fh:
+            fh.write("\n".join(lines) + "\n")
+    except OSError:
+        pass
 
 
 def do_telnet_watch(interface=None, seconds=12, server_ports=DEFAULT_SERVER_PORTS):

--- a/watchtower.py
+++ b/watchtower.py
@@ -103,6 +103,12 @@ DEFAULT_SOURCES = {
                       'paths': ['/var/log/ragnar/arista_guard.jsonl']},
     'comware_guard': {'label': 'Comware Guard (VRF-hop / MPLS)',
                       'paths': ['/var/log/ragnar/comware_guard.jsonl']},
+    # In-app L5-L7 passive observers (ssh_watch / telnet_watch do_*_watch) emit
+    # their non-info findings here so the unified pane tails them too.
+    'ssh_watch':     {'label': 'SSH Watch (regreSSHion / Terrapin)',
+                      'paths': ['/var/log/ragnar/ssh_watch.jsonl']},
+    'telnet_watch':  {'label': 'Telnet Watch (CVE-2026-24061 / 32746)',
+                      'paths': ['/var/log/ragnar/telnet_watch.jsonl']},
 }
 
 # Directories globbed for `*.jsonl`; the basename becomes the source name. This is

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -8180,7 +8180,7 @@
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260822-mobile-touch"></script>
     <script src="/web/scripts/skyview_vr.js?v=20260822-rich-info-panel"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260822-ssh-telnet-watch"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260822-ssh-telnet-watchtower"></script>
 
 
 

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -6458,7 +6458,7 @@ function renderNetIntegrity(d) {
     // Prefer the full per-check map (extended monitor); fall back to dns/arp/dhcp.
     let entries;
     if (d.checks && Object.keys(d.checks).length) {
-        const order = ['dns', 'arp', 'dhcp', 'raguard', 'stp', 'dtp', 'cdp', 'vtp', 'igmp', 'ipv6', 'ndp', 'fhrp', 'ospf', 'eigrp', 'isis', 'bgp', 'smb', 'relay', 'ntp', 'icmp', 'snmp', 'cert', 'tls', 'ldap'];
+        const order = ['dns', 'arp', 'dhcp', 'raguard', 'stp', 'dtp', 'cdp', 'vtp', 'igmp', 'ipv6', 'ndp', 'fhrp', 'ospf', 'eigrp', 'isis', 'bgp', 'smb', 'relay', 'ntp', 'icmp', 'snmp', 'cert', 'tls', 'ldap', 'ssh', 'telnet'];
         entries = Object.keys(d.checks).sort((a, b) => (order.indexOf(a) + 1 || 99) - (order.indexOf(b) + 1 || 99))
             .map(k => [d.checks[k].label || k.toUpperCase(), d.checks[k].verdict, d.checks[k].reasons || []]);
     } else {


### PR DESCRIPTION
This pull request introduces unified Watchtower alert integration for the in-app SSH and Telnet passive observers. Now, significant findings from `ssh_watch` and `telnet_watch` are automatically appended as deduplicated JSON-lines to their respective log files, enabling the Watchtower alert pane and Pushover notifications to include these results alongside existing external daemons. Documentation and UI are updated to reflect this integration, and both observers now participate in the Network Integrity Monitor rotation.

**Watchtower integration for SSH and Telnet observers:**

* Added logic to `ssh_watch.py` and `telnet_watch.py` to append each non-`info` finding as a deduplicated JSON-lines record to `/var/log/ragnar/ssh_watch.jsonl` and `/var/log/ragnar/telnet_watch.jsonl`, respectively, so Watchtower can ingest and display these findings in the unified alert pane. [[1]](diffhunk://#diff-9e96f0cbdd5c99e8663524a48844493fa9ff17289ca1d9d184536b6c2905c0f5R1281-R1335) [[2]](diffhunk://#diff-9e96f0cbdd5c99e8663524a48844493fa9ff17289ca1d9d184536b6c2905c0f5L1317-R1375) [[3]](diffhunk://#diff-6e8cac814c60c456a2a0073f3537a6f02b27df23099346784cd70acaebf2a5f3R910-R966)
* Updated `watchtower.py` to recognize and label the new log sources for SSH and Telnet Watch, integrating them into the alert pane.

**Documentation updates:**

* Enhanced `docs/nettools.md` and `docs/watchtower.md` to document the new Watchtower feed behavior for SSH and Telnet Watch, including deduplication, alert severity mapping, and Network Integrity Monitor integration. [[1]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaR1564-R1570) [[2]](diffhunk://#diff-13a1743ad5a59c38def7493f779be98b2b1923e8554ace15537f7a01f76704aaR1614-R1621) [[3]](diffhunk://#diff-ba409efb7ec3b663ed9e1be5597711c6209d71227509ee517b4034c985ce1c69R29-R36)

**UI and frontend changes:**

* Updated the Network Integrity Monitor UI in `ragnar_modern.js` to include `ssh` and `telnet` as recognized check types, so their verdicts appear as chips in the rotation.
* Bumped the frontend script version to reflect the new Watchtower integration.