### PR TITLE
RuSense flasher: add fixed CSI channel field to Provision WiFi

### DIFF
--- a/rusense_flasher/index.html
+++ b/rusense_flasher/index.html
@@ -91,11 +91,13 @@
           <input id="prov-ip" type="text" placeholder="Server IP — e.g. 192.168.1.20" autocomplete="off" />
           <input id="prov-port" type="number" value="5005" min="1" max="65535" placeholder="Port" />
           <input id="prov-node" type="number" value="1" min="0" max="255" placeholder="Node ID (0-255, unique per node)" title="Give each node in the mesh a different ID, e.g. 1, 2, 3. Nodes with the same ID collide and only one shows up." />
+          <input id="prov-channel" type="number" min="1" max="14" placeholder="Channel (1-14, blank = auto)" title="Fix every node to the SAME 2.4 GHz channel as your AP. Leave blank to auto-detect from the AP the node associates with. Overrides auto-detect when set." />
           <label class="prov-ext-ant" title="Seeed XIAO ESP32-C6 only: drives the on-board RF switch to the external u.FL/IPEX socket at boot. Ignored on other boards. Only helps with an antenna actually attached.">
             <input id="prov-ext-ant" type="checkbox" />
             <span class="prov-ext-ant-text">Use external u.FL antenna <span class="panel-sub">(Seeed XIAO ESP32-C6 only)</span></span>
           </label>
           <p class="prov-hint">⚠️ Give <strong>each node a unique Node ID</strong> (1, 2, 3…). Two nodes sharing an ID collide, so only one shows up in RuSense.</p>
+          <p class="prov-hint">📶 <strong>Channel:</strong> set the <strong>same fixed 2.4 GHz channel</strong> on every node — match your AP's channel (1, 6 and 11 are the non-overlapping ones). Leave it <strong>blank</strong> to auto-detect from the AP, but a fixed channel keeps the fleet's clocks in sync and stops fusion dropping offline.</p>
           <p class="prov-hint">📡 Point <strong>every node at the same WiFi access point on one fixed 2.4 GHz channel</strong>. If several routers or a mesh/extenders share one SSID, nodes latch onto different APs, their clocks can't sync, and sensing drops offline. Use a single AP (a dedicated 2.4 GHz SSID served by one router is ideal) and disable auto-channel.</p>
         </div>
         <div class="flash-buttons">
@@ -413,7 +415,7 @@
       </div>
     </div>
 
-    <script src="js/nvs_gen.js?v=20260804-ext-antenna"></script>
-    <script type="module" src="js/flasher.js?v=20260804-ext-antenna"></script>
+    <script src="js/nvs_gen.js?v=20260823-channel"></script>
+    <script type="module" src="js/flasher.js?v=20260823-channel"></script>
   </body>
 </html>

--- a/rusense_flasher/js/flasher.js
+++ b/rusense_flasher/js/flasher.js
@@ -232,10 +232,18 @@ window.provisionDevice = async function () {
   }
   const nodeIdRaw = ($("prov-node").value || "").trim();
   const nodeId = nodeIdRaw === "" ? 1 : parseInt(nodeIdRaw, 10);
+  // Optional fixed 2.4 GHz channel. Blank = omit the key so the node auto-detects
+  // from its AP; when set it becomes the firmware's priority-#1 channel override.
+  const channelRaw = (($("prov-channel") && $("prov-channel").value) || "").trim();
+  const channel = channelRaw === "" ? undefined : parseInt(channelRaw, 10);
   if (!ssid)     { alert("Enter your 2.4 GHz WiFi SSID."); return; }
   if (!targetIp) { alert("Enter the RuSense server IP (your Ragnar box's address)."); return; }
   if (!Number.isInteger(nodeId) || nodeId < 0 || nodeId > 255) {
     alert("Node ID must be a whole number 0-255. Give each node in the mesh a different ID.");
+    return;
+  }
+  if (channel !== undefined && (!Number.isInteger(channel) || channel < 1 || channel > 14)) {
+    alert("Channel must be a whole number 1-14 (2.4 GHz), or blank to auto-detect from the AP.");
     return;
   }
   if (typeof window.buildCsiCfgNvs !== "function") { alert("Provisioning module failed to load."); return; }
@@ -253,9 +261,10 @@ window.provisionDevice = async function () {
 
     setStatus("Building provisioning data…");
     const extAntenna = !!($("prov-ext-ant") && $("prov-ext-ant").checked);
-    const nvs = window.buildCsiCfgNvs({ ssid, password, target_ip: targetIp, target_port: targetPort, node_id: nodeId, ext_antenna: extAntenna });
+    const nvs = window.buildCsiCfgNvs({ ssid, password, target_ip: targetIp, target_port: targetPort, node_id: nodeId, channel, ext_antenna: extAntenna });
     log("Antenna   : " + (extAntenna ? "external u.FL (XIAO C6)" : "on-board"));
     log("WiFi SSID : " + ssid);
+    log("Channel   : " + (channel === undefined ? "auto (detect from AP)" : channel));
     log("Server    : " + targetIp + ":" + targetPort);
     if (strippedPort) {
       log("Note      : ':" + strippedPort + "' was stripped from the Server IP — CSI streams to UDP " +

--- a/rusense_flasher/js/nvs_gen.js
+++ b/rusense_flasher/js/nvs_gen.js
@@ -85,7 +85,7 @@ function buildNvsPartition(size, keys) {
 // written right after target_port). node_id gives each node a unique identity;
 // without it every node falls back to the firmware default (1) and they collide
 // -- the server then only ever shows one node at a time.
-function buildCsiCfgNvs({ ssid, password, target_ip, target_port = 5005, node_id, edge_tier = 0, ext_antenna }) {
+function buildCsiCfgNvs({ ssid, password, target_ip, target_port = 5005, node_id, channel, edge_tier = 0, ext_antenna }) {
   const keys = [
     { type: 'namespace', key: 'csi_cfg', value: 1 },
     { type: 'string', key: 'ssid', value: ssid },
@@ -95,6 +95,13 @@ function buildCsiCfgNvs({ ssid, password, target_ip, target_port = 5005, node_id
   ];
   if (node_id !== undefined && node_id !== null) {
     keys.push({ type: 'u8', key: 'node_id', value: node_id & 0xFF });
+  }
+  // ADR-060: fixed CSI channel override (u8 'csi_channel'). At boot the firmware
+  // takes this as priority #1 over connected-AP auto-detect and the Kconfig
+  // default (csi_collector.c). Matches provision.py --channel. Omit the key to
+  // let the node auto-detect its channel from the AP it associates with.
+  if (channel !== undefined && channel !== null) {
+    keys.push({ type: 'u8', key: 'csi_channel', value: channel & 0xFF });
   }
   // XIAO ESP32-C6 antenna select (u8 'ext_ant'): 1 = external u.FL, 0 = on-board.
   // Read by the firmware in app_main before the radio starts. Only meaningful on


### PR DESCRIPTION
The web flasher's Provision WiFi step could set SSID, password, server IP, port, node ID and antenna, but not the CSI channel — so every node fell back to auto-detecting its channel from whatever AP it associated with. On a fleet sharing one SSID across several APs that means nodes can land on different channels, their clocks drift, and multistatic fusion drops offline.

Add an optional Channel (1-14) field that writes the csi_channel u8 NVS key the firmware reads as its priority-#1 channel override (csi_collector.c), matching provision.py --channel. Leaving it blank omits the key so the node keeps auto-detecting.

- nvs_gen.js: buildCsiCfgNvs() takes channel; pushes csi_channel u8 when set
- index.html: Channel input + hint in the prov-fields grid; cache-bust bump
- flasher.js: parse/validate 1-14 (blank = auto), pass through, log the value