### PR TITLE
Sub-GHz SDR tab: doc + front-end (RTL-SDR ISM/waterfall)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,3 +280,9 @@ ups_config.json
 
 # Environment or system logs
 *.log
+
+# Self-signed TLS material (generated at runtime — never commit private keys)
+certs/
+*.key
+*.crt
+*.pem

--- a/docs/sdr-subghz.md
+++ b/docs/sdr-subghz.md
@@ -1,0 +1,76 @@
+# Sub-GHz SDR (RTL-SDR)
+
+Ragnar's **SDR** tab turns a cheap **RTL-SDR** dongle into two receive-only
+sub-GHz tools. It's the low-band counterpart to the HackRF
+[True-RF Waterfall](wifi-analyzer.md#true-rf-waterfall-hackrf-sdr): the RTL-SDR
+**cannot** see the 2.4/5/6 GHz Wi-Fi bands (it tops out ~1.7 GHz), but the range
+it *can* reach — the 433 / 868 / 915 MHz ISM bands — is where most of the
+non-Wi-Fi world lives.
+
+Everything here is **receive-only** — nothing ever transmits.
+
+## The two tools
+
+| Tool | Backed by | What it does |
+|---|---|---|
+| **📡 ISM Devices** | `rtl_433 -F json` | A live table of every device it decodes — TPMS tyre-pressure sensors, weather stations, door/window & PIR contacts, remotes/keyfobs, utility meters, doorbells — with model, id, RSSI, hit count, last-seen, and the decoded fields. |
+| **📈 Sub-GHz Waterfall** | `rtl_power` | A scrolling power-vs-frequency heatmap (same look as the HackRF Waterfall) over 433 / 868 / 915 MHz or a wide **300–960 MHz** sweep. Raw energy only — no decode — for spotting activity, carriers and jammers below 1.7 GHz. |
+
+## One dongle, one claim
+
+An RTL-SDR is a single USB device only one program can open at a time. So the
+two tools are **mutually exclusive** — starting one stops the other — and the
+tab reflects that automatically. The same rule is why a device probe
+(`rtl_test`) is never run while a capture is streaming: opening the dongle a
+second time would knock the capture offline (the lesson learned from the HackRF
+view). While anything is running, `/status` reports availability from a cached
+probe instead of touching the bus.
+
+## Hardware
+
+Any **RTL2832U**-based dongle (RTL-SDR Blog V3/V4, generic R820T2/R860). The
+dongle draws real USB current — a **powered USB hub** is recommended on the Pi
+(see the undervoltage note in the HackRF section). Leaving the tab, or switching
+modes, stops the capture and frees the dongle.
+
+**The tab's buttons stay greyed until Ragnar detects a dongle.** It polls
+`/api/net/rtl/status` and un-greys once `rtl_test -t` answers.
+
+Install the tools (done by `install_ragnar.sh`, ensured by `update_ragnar.sh`):
+
+```bash
+sudo apt install rtl-sdr rtl-433
+```
+
+If the dongle isn't found, blacklist the DVB-T kernel driver that otherwise
+grabs it (`dvb_usb_rtl28xxu`), replug, and confirm with `rtl_test -t`.
+
+## API
+
+| Route | Purpose |
+|---|---|
+| `GET  /api/net/rtl/status` | Dongle detection (gates the tab) + capture state for both modes |
+| `POST /api/net/rtl/ism/start` `{band}` | Start the ISM scanner (433/868/915) |
+| `POST /api/net/rtl/ism/stop` | Stop the ISM scanner |
+| `GET  /api/net/rtl/ism/devices` | The live decoded-device table |
+| `POST /api/net/rtl/power/start` `{band}` | Start the sub-GHz sweep (433/868/915/subghz) |
+| `POST /api/net/rtl/power/stop` | Stop the sweep |
+| `GET  /api/net/rtl/power/frames?since=` | New waterfall frames + max-hold since a seq |
+| `GET  /api/net/rtl/selftest` | Offline parser / frame-assembly self-test |
+
+## CLI
+
+`rtl_sdr.py` runs standalone for quick checks (no web server needed):
+
+```bash
+python3 rtl_sdr.py detect
+python3 rtl_sdr.py ism   --band 433 --seconds 20
+python3 rtl_sdr.py power --band subghz --seconds 20
+python3 rtl_sdr.py selftest
+```
+
+## Legality
+
+Listening is passive, but decoding third-party device telemetry (TPMS, meters,
+sensors) can be regulated where you live. Use it on your own devices and within
+local law.

--- a/web/scripts/ragnar_rtlsdr.js
+++ b/web/scripts/ragnar_rtlsdr.js
@@ -1,0 +1,279 @@
+// ragnar_rtlsdr.js — Sub-GHz SDR tab (RTL-SDR): ISM device scanner + waterfall.
+// Talks to /api/net/rtl/*. One dongle, so ISM and Waterfall are mutually
+// exclusive; the backend enforces it, the UI just reflects it.
+'use strict';
+
+const _rtl = {
+    mode: 'ism',
+    available: false,
+    detect: null,
+    statusPoll: null,
+    ism:   { running: false, poll: null },
+    power: { running: false, poll: null, seq: 0, rows: [], floor: -120, bandHz: null, maxhold: null, error: null },
+};
+
+// ---- lifecycle -------------------------------------------------------------
+function rtlsdrEnter() {
+    rtlRefreshStatus();
+    if (!_rtl.statusPoll) _rtl.statusPoll = setInterval(rtlRefreshStatus, 15000);
+    rtlSetMode(_rtl.mode, true);
+}
+
+function rtlsdrLeave() {
+    if (_rtl.statusPoll) { clearInterval(_rtl.statusPoll); _rtl.statusPoll = null; }
+    if (_rtl.ism.poll) { clearInterval(_rtl.ism.poll); _rtl.ism.poll = null; }
+    if (_rtl.power.poll) { clearInterval(_rtl.power.poll); _rtl.power.poll = null; }
+    if (_rtl.ism.running) { fetch('/api/net/rtl/ism/stop', { method: 'POST' }).catch(() => {}); _rtl.ism.running = false; }
+    if (_rtl.power.running) { fetch('/api/net/rtl/power/stop', { method: 'POST' }).catch(() => {}); _rtl.power.running = false; }
+}
+window.addEventListener('beforeunload', () => { if (_rtl.ism.running || _rtl.power.running) rtlsdrLeave(); });
+
+function rtlRefreshStatus() {
+    fetch('/api/net/rtl/status').then(r => r.json()).then(st => {
+        const det = st.detect || {};
+        _rtl.detect = det;
+        _rtl.available = !!det.available;
+        _rtl.ism.running = !!(st.ism && st.ism.running);
+        _rtl.power.running = !!(st.power && st.power.running);
+        const el = document.getElementById('rtl-detect');
+        if (el) {
+            if (det.available) {
+                const who = det.tuner ? (det.tuner + ' tuner') : (det.device || 'RTL-SDR');
+                el.innerHTML = '<span class="text-emerald-400">●</span> ' + rtlEsc(who) + ' ready';
+            } else {
+                el.innerHTML = '<span class="text-slate-500">○</span> ' + rtlEsc(det.error || 'No RTL-SDR detected');
+            }
+        }
+        rtlSyncButtons();
+    }).catch(() => {});
+}
+
+function rtlSyncButtons() {
+    const dis = !_rtl.available;
+    ['rtl-ism-toggle', 'rtl-power-toggle'].forEach(id => {
+        const b = document.getElementById(id);
+        if (b) { b.disabled = dis; b.classList.toggle('opacity-40', dis); b.classList.toggle('cursor-not-allowed', dis); }
+    });
+    rtlSetToggle('rtl-ism-toggle', _rtl.ism.running);
+    rtlSetToggle('rtl-power-toggle', _rtl.power.running);
+}
+
+function rtlSetToggle(id, running) {
+    const b = document.getElementById(id);
+    if (!b) return;
+    b.textContent = running ? 'Stop' : 'Start';
+    b.classList.toggle('bg-emerald-600', !running);
+    b.classList.toggle('hover:bg-emerald-500', !running);
+    b.classList.toggle('bg-rose-600', running);
+    b.classList.toggle('hover:bg-rose-500', running);
+}
+
+// ---- mode switch -----------------------------------------------------------
+function rtlSetMode(mode, force) {
+    if (mode === _rtl.mode && !force) return;
+    // Switching modes frees the dongle: stop whatever is running.
+    if (_rtl.ism.running) rtlIsmStop();
+    if (_rtl.power.running) rtlPowerStop();
+    _rtl.mode = mode;
+    document.getElementById('rtl-view-ism').classList.toggle('hidden', mode !== 'ism');
+    document.getElementById('rtl-view-power').classList.toggle('hidden', mode !== 'power');
+    [['rtl-mode-ism', 'ism'], ['rtl-mode-power', 'power']].forEach(([id, m]) => {
+        const b = document.getElementById(id);
+        if (!b) return;
+        const on = m === mode;
+        b.classList.toggle('bg-Ragnar-600', on);
+        b.classList.toggle('text-white', on);
+        b.classList.toggle('text-slate-300', !on);
+        b.classList.toggle('hover:bg-slate-700', !on);
+    });
+    if (mode === 'ism') rtlRenderDevices({ devices: [], count: 0, events: 0 });
+    else rtlDrawWaterfall();
+    rtlSyncButtons();
+}
+
+// ---- ISM scanner -----------------------------------------------------------
+function rtlIsmToggle() { _rtl.ism.running ? rtlIsmStop() : rtlIsmStart(); }
+
+function rtlIsmStart() {
+    if (!_rtl.available) return;
+    const band = (document.getElementById('rtl-ism-band') || {}).value || '433';
+    fetch('/api/net/rtl/ism/start', { method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ band }) }).then(r => r.json()).then(res => {
+        if (res && res.error) { rtlIsmStat('⚠ ' + res.error); return; }
+        _rtl.ism.running = true; rtlSetToggle('rtl-ism-toggle', true);
+        if (_rtl.ism.poll) clearInterval(_rtl.ism.poll);
+        _rtl.ism.poll = setInterval(rtlIsmPoll, 1500);
+        rtlIsmPoll();
+    }).catch(() => rtlIsmStat('⚠ start failed'));
+}
+
+function rtlIsmStop() {
+    if (_rtl.ism.poll) { clearInterval(_rtl.ism.poll); _rtl.ism.poll = null; }
+    _rtl.ism.running = false; rtlSetToggle('rtl-ism-toggle', false);
+    fetch('/api/net/rtl/ism/stop', { method: 'POST' }).catch(() => {});
+}
+
+function rtlIsmPoll() {
+    fetch('/api/net/rtl/ism/devices').then(r => r.json()).then(d => {
+        if (d.error) rtlIsmStat('⚠ ' + d.error);
+        else rtlIsmStat(d.count + ' device' + (d.count === 1 ? '' : 's') + ' · ' + d.events + ' events');
+        rtlRenderDevices(d);
+    }).catch(() => {});
+}
+
+function rtlIsmStat(t) { const el = document.getElementById('rtl-ism-stat'); if (el) el.textContent = t; }
+
+function rtlRenderDevices(d) {
+    const tb = document.getElementById('rtl-ism-tbody');
+    const empty = document.getElementById('rtl-ism-empty');
+    if (!tb) return;
+    const rows = d.devices || [];
+    if (!rows.length) {
+        tb.innerHTML = '';
+        if (empty) empty.textContent = _rtl.ism.running ? 'Listening… decoded devices will appear here.'
+            : 'Start the scanner to list nearby 433/868/915 MHz devices.';
+        return;
+    }
+    if (empty) empty.textContent = '';
+    const now = Date.now() / 1000;
+    tb.innerHTML = rows.map(r => {
+        const fields = Object.entries(r.fields || {}).map(([k, v]) => rtlEsc(k) + '=' + rtlEsc(String(v))).join(', ');
+        const freq = r.freq_mhz ? (r.freq_mhz.toFixed(3) + ' MHz') : '—';
+        const rssi = (r.rssi === null || r.rssi === undefined) ? '—' : (Math.round(r.rssi * 10) / 10 + ' dB');
+        const ago = r.last_ts ? Math.max(0, Math.round(now - r.last_ts)) + 's' : '—';
+        return `<tr class="hover:bg-slate-800/40">
+            <td class="px-3 py-2 text-white">${rtlEsc(r.model || '')}</td>
+            <td class="px-3 py-2 text-slate-300">${r.id === null || r.id === undefined ? (rtlEsc(String(r.channel ?? '—'))) : rtlEsc(String(r.id))}</td>
+            <td class="px-3 py-2 text-right text-slate-400">${freq}</td>
+            <td class="px-3 py-2 text-right text-slate-400">${rssi}</td>
+            <td class="px-3 py-2 text-right text-slate-400">${r.count || 0}</td>
+            <td class="px-3 py-2 text-right text-slate-400">${ago}</td>
+            <td class="px-3 py-2 text-slate-400 text-xs">${fields}</td>
+        </tr>`;
+    }).join('');
+}
+
+// ---- Sub-GHz waterfall -----------------------------------------------------
+function rtlPowerToggle() { _rtl.power.running ? rtlPowerStop() : rtlPowerStart(); }
+
+function rtlPowerStart() {
+    if (!_rtl.available) return;
+    const band = (document.getElementById('rtl-power-band') || {}).value || '433';
+    _rtl.power.seq = 0; _rtl.power.rows = []; _rtl.power.maxhold = null; _rtl.power.error = null;
+    fetch('/api/net/rtl/power/start', { method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ band }) }).then(r => r.json()).then(res => {
+        if (res && res.error) { rtlPowerStat('⚠ ' + res.error); return; }
+        _rtl.power.running = true; rtlSetToggle('rtl-power-toggle', true);
+        if (_rtl.power.poll) clearInterval(_rtl.power.poll);
+        _rtl.power.poll = setInterval(rtlPowerPoll, 500);
+    }).catch(() => rtlPowerStat('⚠ start failed'));
+}
+
+function rtlPowerStop() {
+    if (_rtl.power.poll) { clearInterval(_rtl.power.poll); _rtl.power.poll = null; }
+    _rtl.power.running = false; rtlSetToggle('rtl-power-toggle', false);
+    fetch('/api/net/rtl/power/stop', { method: 'POST' }).catch(() => {});
+}
+
+function rtlPowerPoll() {
+    const s = _rtl.power;
+    fetch('/api/net/rtl/power/frames?since=' + s.seq).then(r => r.json()).then(d => {
+        s.error = d.error || null;
+        if (d.band_hz) s.bandHz = d.band_hz;
+        if (typeof d.floor_dbm === 'number') s.floor = d.floor_dbm;
+        if (d.max_hold) s.maxhold = d.max_hold;
+        (d.frames || []).forEach(f => { s.seq = f.seq; s.rows.unshift(f.power); });
+        if (s.rows.length > 600) s.rows.length = 600;
+        const fb = s.rows.length ? '' : (s.error ? ('⚠ ' + s.error) : 'sweeping…');
+        rtlPowerStat(fb);
+        rtlDrawWaterfall();
+    }).catch(() => {});
+}
+
+function rtlPowerStat(t) { const el = document.getElementById('rtl-power-stat'); if (el) el.textContent = t; }
+
+// dBm -> colour: dark → blue → cyan → green → yellow → red.
+function rtlColor(dbm, floor) {
+    const top = -20, lo = (typeof floor === 'number' ? floor : -110);
+    let t = (dbm - lo) / (top - lo); t = Math.max(0, Math.min(1, t));
+    const stops = [[8, 12, 30], [30, 60, 170], [30, 190, 200], [40, 200, 70], [235, 220, 40], [235, 60, 40]];
+    const seg = t * (stops.length - 1), i = Math.floor(seg), f = seg - i;
+    const a = stops[i], b = stops[Math.min(stops.length - 1, i + 1)];
+    return `rgb(${Math.round(a[0] + (b[0] - a[0]) * f)},${Math.round(a[1] + (b[1] - a[1]) * f)},${Math.round(a[2] + (b[2] - a[2]) * f)})`;
+}
+
+function rtlDrawWaterfall() {
+    const s = _rtl.power;
+    const canvas = document.getElementById('rtl-waterfall');
+    if (!canvas) return;
+    const dpr = window.devicePixelRatio || 1;
+    const W = canvas.clientWidth, H = canvas.clientHeight || 360;
+    if (W < 20 || H < 20) return;
+    canvas.width = W * dpr; canvas.height = H * dpr;
+    const ctx = canvas.getContext('2d'); ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, W, H);
+    const padL = 52, padR = 12, padT = 12, padB = 22;
+    const plotW = W - padL - padR;
+    const specH = Math.max(70, Math.round(H * 0.26)), gap = 8;
+    const wfTop = padT + specH + gap, wfH = H - padB - wfTop;
+    const loHz = s.bandHz ? s.bandHz[0] : 433050000;
+    const hiHz = s.bandHz ? s.bandHz[1] : 434790000;
+
+    if (!_rtl.available || s.error || !s.rows.length) {
+        ctx.fillStyle = '#0b1220'; ctx.fillRect(padL, wfTop, plotW, wfH);
+        ctx.fillStyle = '#64748b'; ctx.font = '13px sans-serif'; ctx.textAlign = 'center';
+        const msg = !_rtl.available ? '📻 Connect an RTL-SDR to see the sub-GHz waterfall'
+            : s.error ? ('⚠ ' + s.error) : 'Starting rtl_power sweep…';
+        ctx.fillText(msg, W / 2, wfTop + wfH / 2);
+        return;
+    }
+
+    const nb = s.rows[0].length;
+    const colW = plotW / nb;
+    const rowH = Math.max(1, wfH / Math.min(s.rows.length, Math.floor(wfH)));
+    for (let r = 0; r < s.rows.length; r++) {
+        const y = wfTop + r * rowH;
+        if (y > wfTop + wfH) break;
+        const row = s.rows[r];
+        for (let bi = 0; bi < nb; bi++) {
+            ctx.fillStyle = rtlColor(row[bi], s.floor);
+            ctx.fillRect(padL + bi * colW, y, Math.ceil(colW), Math.ceil(rowH));
+        }
+    }
+
+    // spectrum line: current + max-hold
+    ctx.fillStyle = '#0b1220'; ctx.fillRect(padL, padT, plotW, specH);
+    const sTop = -20, sBot = s.floor;
+    const yFor = (db) => padT + (sTop - Math.max(sBot, Math.min(sTop, db))) / (sTop - sBot) * specH;
+    const xForBin = (bi) => padL + (bi + 0.5) / nb * plotW;
+    ctx.strokeStyle = '#1e293b'; ctx.fillStyle = '#475569'; ctx.font = '9px sans-serif'; ctx.textAlign = 'right';
+    for (let v = sTop; v >= sBot; v -= 20) {
+        const y = yFor(v); ctx.beginPath(); ctx.moveTo(padL, y); ctx.lineTo(W - padR, y); ctx.stroke();
+        ctx.fillText(v + '', padL - 3, y + 3);
+    }
+    const trace = (arr, stroke, wdt) => {
+        if (!arr) return;
+        ctx.strokeStyle = stroke; ctx.lineWidth = wdt; ctx.beginPath();
+        for (let bi = 0; bi < arr.length; bi++) { const x = xForBin(bi), y = yFor(arr[bi]); bi ? ctx.lineTo(x, y) : ctx.moveTo(x, y); }
+        ctx.stroke();
+    };
+    trace(s.maxhold, 'rgba(148,163,184,0.7)', 1);
+    trace(s.rows[0], '#22d3ee', 1.5);
+
+    // frequency axis (MHz)
+    ctx.fillStyle = '#64748b'; ctx.font = '9px sans-serif'; ctx.textAlign = 'center';
+    const ticks = 6;
+    for (let i = 0; i <= ticks; i++) {
+        const fx = padL + (i / ticks) * plotW;
+        const mhz = (loHz + (i / ticks) * (hiHz - loHz)) / 1e6;
+        ctx.fillText(mhz.toFixed(mhz < 1000 ? 1 : 0), fx, H - 8);
+    }
+}
+
+// small HTML escaper for table cells
+function rtlEsc(s) {
+    return String(s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+window.rtlsdrEnter = rtlsdrEnter;
+window.rtlsdrLeave = rtlsdrLeave;


### PR DESCRIPTION
Commit the remaining Sub-GHz SDR pieces that pair with the RTL-SDR backend already in main (rtl_sdr.py + /api/net/rtl/* routes):
- docs/sdr-subghz.md — documents the RTL-SDR ISM scanner + sub-GHz waterfall.
- web/scripts/ragnar_rtlsdr.js — the Sub-GHz tab front-end (talks to the existing /api/net/rtl/* endpoints). Not yet wired into a dashboard tab, so it's inert until an HTML tab references it.