### PR TITLE
Feature/rtl sdr

### DIFF
--- a/demos/rf_waterfall.html
+++ b/demos/rf_waterfall.html
@@ -61,7 +61,7 @@
   .spacer{flex:1 1 auto}
   .clock{font-family:var(--mono);font-size:12px;color:var(--muted);letter-spacing:.04em}
   .legend{display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:10px;color:var(--muted)}
-  .legend .grad{width:120px;height:9px;border-radius:3px;background:linear-gradient(90deg,#071a2c,#0e5f78,#22a06a,#f5b942,#fff3d6)}
+  .legend .grad{width:120px;height:9px;border-radius:3px;background:linear-gradient(90deg,#071a2c,#165a82,#2ea096,#7b8cd2,#cec4e6)}
   .stack{display:flex;flex-direction:column;gap:20px}
   .scope{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);overflow:hidden;box-shadow:0 18px 40px -28px rgba(0,0,0,.9)}
   .scope-head{display:flex;flex-wrap:wrap;align-items:center;gap:10px 16px;padding:13px 16px;border-bottom:1px solid var(--line-soft);background:var(--panel-2)}
@@ -167,7 +167,10 @@
 <script>
 (function(){
   "use strict";
-  var STOPS=[[0.00,[7,26,44]],[0.28,[14,95,120]],[0.52,[34,160,106]],[0.78,[245,185,66]],[1.00,[255,243,214]]];
+  // Aurora colormap — cool, no warm tones: navy→blue→teal→periwinkle→lavender.
+  // Kinder on the eyes than the old amber/white hot end; strong bursts glow soft
+  // violet instead of glaring yellow.
+  var STOPS=[[0.00,[7,26,44]],[0.28,[22,90,130]],[0.52,[46,160,150]],[0.78,[123,140,210]],[1.00,[206,196,230]]];
   var CEIL=-20, LUT=new Array(256);
   (function(){for(var i=0;i<256;i++){var t=i/255,a=STOPS[0],b=STOPS[STOPS.length-1];
     for(var s=0;s<STOPS.length-1;s++){if(t>=STOPS[s][0]&&t<=STOPS[s+1][0]){a=STOPS[s];b=STOPS[s+1];break;}}

--- a/demos/rf_waterfall.html
+++ b/demos/rf_waterfall.html
@@ -108,6 +108,9 @@
   .logempty{font-family:var(--mono);font-size:11.5px;color:var(--muted);padding:6px 0 10px}
   /* decode view: hide the sweep surfaces, let the device list breathe */
   .scope.decoding .fall-wrap,.scope.decoding .ruler,.scope.decoding canvas.trace,.scope.decoding .toolbar{display:none}
+  .zwavesel{display:flex;align-items:center;gap:6px}
+  .zwavesel select{font-family:var(--mono);font-size:11.5px;color:var(--cyan);background:var(--panel);border:1px solid rgba(56,189,201,.4);border-radius:6px;padding:5px 8px;cursor:pointer}
+  .zwavesel .zwtag{font-size:9px;letter-spacing:.14em;text-transform:uppercase;color:var(--cyan);font-family:var(--mono)}
   .scope-head .fsbtn{font-family:var(--mono);font-size:11px;color:var(--ink);background:var(--panel);border:1px solid var(--line);padding:5px 11px;border-radius:6px;cursor:pointer;transition:border-color .15s,background .15s,color .15s;white-space:nowrap}
   .scope-head .fsbtn:hover{border-color:rgba(56,189,201,.5);color:var(--cyan);background:rgba(56,189,201,.08)}
   .scope:fullscreen,.scope:-webkit-full-screen{width:100vw;height:100vh;border-radius:0;border:0;background:var(--ground);display:flex;flex-direction:column}
@@ -157,6 +160,7 @@
 
   <footer id="footer"><div id="foot-msg"></div>
     <div style="margin-top:6px"><b>Backends:</b> rtl_sdr.py (rtl_power sweep · rtl_433 decode) · sdr_spectrum.py (hackrf_sweep). Click a signal to pin a marker and retune a narrow zoom sweep there; the sub-GHz panel can switch to rtl_433 to name devices (one dongle, so Waterfall and Decode are mutually exclusive).</div>
+    <div style="margin-top:6px"><b>📡 Z-Wave Spectrum:</b> pick a region to sweep its exact Z-Wave channels and watch the mesh's bursts land on them — device chatter, retries, or a jammer parked on a channel. Z-Wave is a sub-GHz mesh that rtl_433 can't decode, so this is an energy/occupancy view of a band almost nobody scans. Receive-only.</div>
   </footer>
 </div>
 
@@ -199,8 +203,19 @@
       m.emit=function(row){bump(row,lo,hi,2412,9,-58+gauss()*4);bump(row,lo,hi,2437,9,-52+gauss()*5);bump(row,lo,hi,2462,9,-60+gauss()*4);
         if(Math.random()<0.4)bump(row,lo,hi,2402,0.6,-64);if(Math.random()<0.4)bump(row,lo,hi,2426,0.6,-62);if(Math.random()<0.4)bump(row,lo,hi,2480,0.6,-66);};}
     return m;}
+  // Z-Wave: narrow GFSK bursts that land on the region's fixed channels — a mesh
+  // chattering (device reports, hops, retries). Used for the no-hardware demo;
+  // with a dongle the real rtl_power sweep replaces this.
+  function zwaveModel(lo,hi,channels){
+    var chans=(channels||[]).map(function(c){return c.freq_mhz;});
+    return {lo:lo,hi:hi,floor:-112,ticks:null,zwaveChans:chans,
+      emit:function(row){
+        chans.forEach(function(f,idx){
+          if(Math.random()<(idx===0?0.55:0.32)) bump(row,lo,hi,f,0.12,-44-Math.random()*16);});
+        if(chans.length && Math.random()<0.15)
+          bump(row,lo,hi,chans[(Math.random()*chans.length)|0]+0.2,0.10,-60);}};}
 
-  var running=true, HZ=12, DEMO_ON=false;
+  var running=true, HZ=12, DEMO_ON=false, ZWAVE=null;
   var reduce=window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   function fmtF(mhz){return (mhz>=1000)?(mhz/1000).toFixed(mhz%1000?2:0)+"G":(mhz>=100?mhz.toFixed(1):mhz.toFixed(2));}
   function genTicks(lo,hi){var n=6,out=[];for(var i=0;i<=n;i++)out.push(lo+(hi-lo)*i/n);return out;}
@@ -210,7 +225,7 @@
     var self=this;
     this.cfg=cfg; this.mode='idle'; this.available=false; this.board=''; this.detErr='';
     this.liveBand=cfg.defaultBand; this.synthBand=cfg.synthDefault;
-    this.zoom=null; this.marker=null; this.decoding=false;
+    this.zoom=null; this.marker=null; this.decoding=false; this.zwave=null; this.zwaveRegion=null;
     this.busy=0; this.log=[]; this._lastLog=0; this._ismPoll=null;
     this.model=cfg.synth(cfg.synthDefault);
     this.lo=this.model.lo; this.hi=this.model.hi; this.floor=this.model.floor;
@@ -223,6 +238,7 @@
       +'<div class="scope-title"><span class="name">'+cfg.name+' <span class="tag idle scope-tag">idle</span></span><span class="dev">'+cfg.dev+'</span></div>'
       +'<div class="seg viewsel" role="group" aria-label="View"></div>'
       +'<div class="seg bandsel" role="group" aria-label="Band"></div>'
+      +'<div class="seg zwavesel hidden" role="group" aria-label="Z-Wave region"></div>'
       +'<div class="spacer"></div>'
       +'<div class="readout">'
         +'<div class="stat"><span class="k">Peak f</span><span class="v peak pk-f">&mdash;</span></div>'
@@ -257,7 +273,7 @@
     this.markEl=el.querySelector('.marker'); this.markLbl=el.querySelector('.marker .ml');
     this.pkF=el.querySelector('.pk-f'); this.pkD=el.querySelector('.pk-d'); this.busyEl=el.querySelector('.busyv');
     this.spanEl=el.querySelector('.span'); this.rateEl=el.querySelector('.rate');
-    this.bandSel=el.querySelector('.bandsel'); this.viewSel=el.querySelector('.viewsel');
+    this.bandSel=el.querySelector('.bandsel'); this.viewSel=el.querySelector('.viewsel'); this.zwaveSel=el.querySelector('.zwavesel');
     this.markTxt=el.querySelector('.marktxt'); this.zoomBtn=el.querySelector('.zoombtn'); this.resetBtn=el.querySelector('.resetbtn');
     this.fsBtn=el.querySelector('.fsbtn');
     this.logTitle=el.querySelector('.logtitle'); this.logCount=el.querySelector('.logcount'); this.logList=el.querySelector('.loglist');
@@ -369,10 +385,44 @@
   // ---- band / view selection ----
   Scope.prototype.selectBand=function(bandId,synthId){
     Array.prototype.forEach.call(this.bandSel.querySelectorAll('button'),function(x){x.setAttribute('aria-pressed',x.getAttribute('data-band')===bandId?'true':'false');});
-    this.liveBand=bandId; this.synthBand=synthId||bandId; this.zoom=null; this.resetBtn.disabled=true;
+    if(this.zwaveSel) Array.prototype.forEach.call(this.zwaveSel.querySelectorAll('button'),function(x){x.setAttribute('aria-pressed','false');});
+    this.liveBand=bandId; this.synthBand=synthId||bandId; this.zoom=null; this.zwave=null; this.zwaveRegion=null; this.resetBtn.disabled=true;
     if(this.decoding){ this.stopIsm(); this.startIsm(); return; }
     if(this.mode==='live'){ this.stopLive(); this._rangeKnown=false; this.resetCanvas(); this.startLive(); }
-    else if(this.mode==='synth'){ this.model=this.cfg.synth(this.synthBand); this.lo=this.model.lo;this.hi=this.model.hi;this.floor=this.model.floor; this.resetCanvas(); }
+    else if(this.mode==='synth'){ this.model=this.cfg.synth(this.synthBand); this.lo=this.model.lo;this.hi=this.model.hi;this.floor=this.model.floor; this.resetCanvas(); this.drawRuler(); }
+  };
+  // Z-Wave region selector: a dropdown (built once the plan loads) that sweeps
+  // the region's tight span and overlays its exact channel centres. Z-Wave is a
+  // sub-GHz mesh rtl_433 can't decode, so this is an energy/occupancy view of a
+  // band nobody usually looks at.
+  Scope.prototype.populateZwave=function(plan){
+    if(!this.cfg.zwave || !plan || this._zwaveBuilt) return;
+    var self=this; this._zwaveBuilt=true;
+    var tag=document.createElement('span'); tag.className='zwtag'; tag.textContent='📡 Z-Wave';
+    var sel=document.createElement('select'); sel.title='Sweep a Z-Wave region and overlay its channels';
+    var opt0=document.createElement('option'); opt0.value=''; opt0.textContent='Region…'; sel.appendChild(opt0);
+    Object.keys(plan).forEach(function(rid){
+      var o=document.createElement('option'); o.value=rid; o.textContent=plan[rid].label; sel.appendChild(o);
+    });
+    sel.addEventListener('change',function(){ if(sel.value) self.selectZwave(sel.value); else self.clearZwave(); });
+    this.zwaveDropdown=sel;
+    this.zwaveSel.appendChild(tag); this.zwaveSel.appendChild(sel);
+    this.zwaveSel.classList.remove('hidden');
+  };
+  Scope.prototype.clearZwave=function(){ // back to the normal band view
+    if(this.zwaveDropdown) this.zwaveDropdown.value='';
+    this.selectBand(this.liveBand,this.synthBand);
+  };
+  Scope.prototype.selectZwave=function(regionId){
+    var reg=ZWAVE&&ZWAVE[regionId]; if(!reg) return;
+    this.zwaveRegion=regionId; this.zwave=reg; this.zoom=null; this.marker=null; this.markEl.style.display='none'; this.resetBtn.disabled=true;
+    if(this.zwaveDropdown) this.zwaveDropdown.value=regionId;
+    if(this.decoding) this.setView('wf');   // decode can't do Z-Wave; back to sweep
+    Array.prototype.forEach.call(this.bandSel.querySelectorAll('button'),function(x){x.setAttribute('aria-pressed','false');});
+    if(this.mode==='live'){ this.stopLive(); this._rangeKnown=false; this.resetCanvas(); this.startLive(); }
+    else if(this.mode==='synth'){ this.model=zwaveModel(reg.lo_hz/1e6,reg.hi_hz/1e6,reg.channels);
+      this.lo=this.model.lo; this.hi=this.model.hi; this.floor=this.model.floor; this.resetCanvas(); this.drawRuler(); }
+    else { this.setMode(DEMO_ON?'synth':'idle'); if(this.mode==='synth'){ this.model=zwaveModel(reg.lo_hz/1e6,reg.hi_hz/1e6,reg.channels); this.lo=this.model.lo;this.hi=this.model.hi;this.floor=this.model.floor; this.drawRuler(); } }
   };
   Scope.prototype.setView=function(v){
     var want=(v==='decode');
@@ -431,7 +481,8 @@
   Scope.prototype.startLive=function(){
     var self=this; this.seq=0; this.liveErr=null;
     var body={band:this.liveBand};
-    if(this.zoom){ body.lo_hz=Math.round(this.zoom[0]*1e6); body.hi_hz=Math.round(this.zoom[1]*1e6); }
+    if(this.zwave){ body.lo_hz=this.zwave.lo_hz; body.hi_hz=this.zwave.hi_hz; body.label='zwave-'+this.zwaveRegion; }
+    else if(this.zoom){ body.lo_hz=Math.round(this.zoom[0]*1e6); body.hi_hz=Math.round(this.zoom[1]*1e6); }
     fetch(this.cfg.api.start,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)})
       .then(function(r){return r.json();}).then(function(res){
         if(res&&res.error){ self.liveErr=res.error; self.showVeil('Could not start '+self.cfg.short,res.error); }
@@ -548,6 +599,18 @@
 
   Scope.prototype.drawRuler=function(){
     var lo=this.lo,hi=this.hi,span=hi-lo,r=this.ruler; r.innerHTML=""; if(!(span>0))return;
+    // Z-Wave channel overlay: exact channel centres for the selected region,
+    // drawn as cyan bands so you can see which channel each burst lands on.
+    if(this.zwave){
+      (this.zwave.channels||[]).forEach(function(c){var x=(c.freq_mhz-lo)/span*100; if(x<0||x>100)return;
+        var d=document.createElement('div');d.className='ism';d.style.left=(x-1.1)+"%";d.style.width="2.2%";
+        d.innerHTML='<span class="il">'+esc(c.label)+'</span>';r.appendChild(d);
+        var t=document.createElement('div');t.className='tick';t.style.left=x+"%";t.style.background="var(--cyan)";r.appendChild(t);
+        var l=document.createElement('div');l.className='tlab';l.style.left=x+"%";l.textContent=c.freq_mhz.toFixed(2);r.appendChild(l);});
+      genTicks(lo,hi).forEach(function(fq){var x=(fq-lo)/span*100;if(x<0||x>100)return;
+        var t=document.createElement('div');t.className='tick';t.style.left=x+"%";r.appendChild(t);});
+      return;
+    }
     var m=this.model, showBands=(this.mode==='synth'&&!this.zoom&&m);
     if(showBands){
       (m.isms||[]).forEach(function(b){var x0=(b[0]-lo)/span*100,x1=(b[1]-lo)/span*100;
@@ -572,7 +635,7 @@
   var rtl=new Scope({ name:"Sub-GHz ISM", short:"RTL-SDR", dev:"RTL-SDR · rtl_power / rtl_433", rig:"rig-rtl",
     api:{status:'/api/net/rtl/status',start:'/api/net/rtl/power/start',stop:'/api/net/rtl/power/stop',frames:'/api/net/rtl/power/frames',
          ismStart:'/api/net/rtl/ism/start',ismStop:'/api/net/rtl/ism/stop',ismDevices:'/api/net/rtl/ism/devices'},
-    synth:function(b,lo,hi){return subGhzModel(lo,hi);}, synthDefault:'433', synthBands:false, decode:true, minSpan:0.2,
+    synth:function(b,lo,hi){return subGhzModel(lo,hi);}, synthDefault:'433', synthBands:false, decode:true, zwave:true, minSpan:0.2,
     liveBands:[{id:'433',label:'433'},{id:'868',label:'868'},{id:'915',label:'915'}], defaultBand:'433' });
   scopes.push(rtl); stack.appendChild(rtl.el);
   var hackrf=new Scope({ name:"Wi-Fi Bands", short:"HackRF", dev:"HackRF One · hackrf_sweep", rig:"rig-hackrf",
@@ -614,6 +677,12 @@
 
   function refreshConfig(){ return fetch('/api/config').then(function(r){return r.json();}).then(function(c){ DEMO_ON=!!(c&&(c.sdr_demo===true||c.sdr_demo==='true')); }).catch(function(){}); }
   function pollAll(){ scopes.forEach(function(s){s.checkStatus();}); setTimeout(updateFoot,400); }
+
+  // Load the Z-Wave regional plan once and build the region selector on scopes
+  // that support it (the RTL-SDR panel). No dongle needed — the plan is static.
+  fetch('/api/net/rtl/zwave').then(function(r){return r.json();}).then(function(d){
+    if(d&&d.regions){ ZWAVE=d.regions; scopes.forEach(function(s){ s.populateZwave(ZWAVE); }); }
+  }).catch(function(){});
 
   refreshConfig().then(function(){ scopes.forEach(function(s){s.applyDesired();s.updateTag();}); updateFoot(); pollAll();
     setInterval(function(){ refreshConfig().then(pollAll); },5000); });

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -18787,9 +18787,18 @@ def register_network_diagnostics(app, logger=None):
     def net_rtl_power_start():
         data = request.get_json(silent=True) or {}
         band = str(data.get('band') or '433').strip()
-        _log(f"net/rtl/power/start band={band} zoom={data.get('lo_hz')}:{data.get('hi_hz')}")
+        label = data.get('label')
+        label = str(label).strip()[:24] if label else None
+        _log(f"net/rtl/power/start band={band} zoom={data.get('lo_hz')}:{data.get('hi_hz')} label={label}")
         return jsonify(rtl_sdr.power_start(band=band, lo_hz=data.get('lo_hz'),
-                                           hi_hz=data.get('hi_hz')))
+                                           hi_hz=data.get('hi_hz'), label=label))
+
+    # Z-Wave regional plan (span + exact channel centres per region) for the
+    # "Z-Wave Spectrum" view. rtl_433 can't decode Z-Wave, so the UI sweeps the
+    # region span (via power/start with lo_hz/hi_hz) and overlays these channels.
+    @app.route('/api/net/rtl/zwave', methods=['GET'])
+    def net_rtl_zwave():
+        return jsonify({"regions": rtl_sdr.zwave_plan()})
 
     # rtl_433 ISM device decoder — names the sub-GHz transmitters (TPMS, weather
     # stations, doorbells, …). One dongle, so the scanner and the power sweep are

--- a/rtl_sdr.py
+++ b/rtl_sdr.py
@@ -71,6 +71,51 @@ ISM_FREQS = {
     "915": "915M",
 }
 
+# Z-Wave regional radio plan. Z-Wave is a sub-GHz mesh (GFSK/FSK) that lives on a
+# small set of FIXED narrow channels per regulatory region — not a wide ISM
+# scatter — so each region gets a tight sweep span plus the exact channel centres
+# to overlay on the spectrum. rtl_433 does NOT decode Z-Wave, so this is an
+# ENERGY / occupancy view: you watch the mesh's bursts land on the channels
+# (device chatter, retries, a jammer parked on a channel), band nobody usually
+# looks at. Frequencies are the published Z-Wave regional assignments (Hz).
+ZWAVE_REGIONS = {
+    "eu":    {"label": "EU (868)",        "span": (867_600_000, 870_200_000),
+              "channels": [(868_420_000, "R1/R2 9.6/40k"), (869_850_000, "R3 100k")]},
+    "us":    {"label": "US (908/916)",    "span": (907_000_000, 917_200_000),
+              "channels": [(908_420_000, "R1/R2 9.6/40k"), (916_000_000, "R3 100k")]},
+    "us-lr": {"label": "US Long Range",   "span": (910_500_000, 921_500_000),
+              "channels": [(912_000_000, "LR ch A"), (920_000_000, "LR ch B")]},
+    "anz":   {"label": "ANZ (919/921)",   "span": (919_000_000, 922_200_000),
+              "channels": [(919_820_000, "R1/R2"), (921_420_000, "R3")]},
+    "jp":    {"label": "Japan (922-926)", "span": (921_500_000, 927_200_000),
+              "channels": [(922_500_000, "ch1"), (923_900_000, "ch2"), (926_300_000, "ch3")]},
+    "kr":    {"label": "Korea (920-923)", "span": (920_000_000, 924_000_000),
+              "channels": [(920_900_000, "ch1"), (921_700_000, "ch2"), (923_100_000, "ch3")]},
+    "in":    {"label": "India (865)",     "span": (864_400_000, 866_000_000),
+              "channels": [(865_200_000, "R1/R2/R3")]},
+    "il":    {"label": "Israel (916)",    "span": (915_000_000, 917_000_000),
+              "channels": [(916_000_000, "R1/R2/R3")]},
+    "hk":    {"label": "Hong Kong (919)", "span": (919_000_000, 920_600_000),
+              "channels": [(919_820_000, "R1/R2/R3")]},
+    "ru":    {"label": "Russia (869)",    "span": (868_000_000, 870_000_000),
+              "channels": [(869_000_000, "R1/R2/R3")]},
+    "cn":    {"label": "China (868)",     "span": (867_600_000, 869_200_000),
+              "channels": [(868_400_000, "R1/R2/R3")]},
+}
+
+
+def zwave_plan():
+    """Region → sweep span + Z-Wave channel centres, for the UI's Z-Wave view."""
+    out = {}
+    for rid, r in ZWAVE_REGIONS.items():
+        out[rid] = {
+            "label": r["label"],
+            "lo_hz": r["span"][0], "hi_hz": r["span"][1],
+            "channels": [{"freq_hz": f, "freq_mhz": round(f / 1e6, 3), "label": lbl}
+                         for f, lbl in r["channels"]],
+        }
+    return out
+
 _POWER_BINS = 480          # display columns per waterfall frame
 _RING_FRAMES = 300         # rolling history of sweep frames kept in memory
 _FLOOR_DBM = -120          # sentinel for a display column no sweep bin filled
@@ -723,9 +768,10 @@ class PowerSweep:
         self._lo = None            # active sweep range in Hz (band OR zoom span)
         self._hi = None
 
-    def start(self, band="433", lo_hz=None, hi_hz=None):
-        # A custom [lo_hz, hi_hz] span (the page's zoom) overrides the named band
-        # when both edges are sane (>=100 kHz wide, inside the RTL-SDR's reach).
+    def start(self, band="433", lo_hz=None, hi_hz=None, label=None):
+        # A custom [lo_hz, hi_hz] span (the page's zoom, or a Z-Wave region)
+        # overrides the named band when both edges are sane (>=100 kHz wide,
+        # inside the RTL-SDR's reach). ``label`` names it (e.g. "zwave-eu").
         custom = None
         try:
             if lo_hz is not None and hi_hz is not None:
@@ -735,7 +781,7 @@ class PowerSweep:
         except (TypeError, ValueError):
             custom = None
         if custom:
-            label, lo, hi = "zoom", custom[0], custom[1]
+            label, lo, hi = (label or "zoom"), custom[0], custom[1]
         else:
             band = band if band in RTL_BANDS else "433"
             label, (lo, hi) = band, RTL_BANDS[band]
@@ -904,7 +950,7 @@ def ism_devices():
     return _ism.get_devices()
 
 
-def power_start(band="433", lo_hz=None, hi_hz=None):
+def power_start(band="433", lo_hz=None, hi_hz=None, label=None):
     global _detect_cache
     if _ism.status()["running"]:
         _ism.stop()            # one dongle: hand it to the sweep
@@ -913,7 +959,7 @@ def power_start(band="433", lo_hz=None, hi_hz=None):
         if not d.get("available"):
             return {"ok": False, "error": d.get("error", "no RTL-SDR")}
         _detect_cache = d
-    return _power.start(band, lo_hz=lo_hz, hi_hz=hi_hz)
+    return _power.start(band, lo_hz=lo_hz, hi_hz=hi_hz, label=label)
 
 
 def power_stop():
@@ -1112,6 +1158,23 @@ def selftest():
           all(b in RTL_BANDS for b in ("433", "868", "915", "subghz")))
     check("bands: ism 433/868/915 present",
           all(b in ISM_FREQS for b in ("433", "868", "915")))
+
+    # --- Z-Wave regional plan: channels sit inside their span, all in RTL reach ---
+    plan = zwave_plan()
+    check("zwave: eu + us regions present",
+          "eu" in plan and "us" in plan and "us-lr" in plan)
+    _zw_ok = True
+    for rid, r in plan.items():
+        if not (24_000_000 <= r["lo_hz"] < r["hi_hz"] <= 1_766_000_000):
+            _zw_ok = False
+        for ch in r["channels"]:
+            if not (r["lo_hz"] <= ch["freq_hz"] <= r["hi_hz"]):
+                _zw_ok = False
+    check("zwave: every channel lands inside its region span (and RTL range)", _zw_ok)
+    check("zwave: EU classic channel is 868.42 MHz",
+          any(abs(c["freq_hz"] - 868_420_000) < 1000 for c in plan["eu"]["channels"]))
+    check("zwave: span >= 100 kHz so power_start accepts it",
+          all(r["hi_hz"] - r["lo_hz"] >= 100_000 for r in plan.values()))
 
     passed = sum(1 for r in results if r["pass"])
     return {"pass": passed == len(results), "passed": passed,


### PR DESCRIPTION
This pull request adds a new "Z-Wave Spectrum" feature to the RF Waterfall demo, enabling users to select and visualize Z-Wave regional channels as an energy/occupancy view. It introduces a regional Z-Wave plan on both the backend and frontend, updates the UI to allow region selection, and overlays Z-Wave channels on the spectrum display. Additionally, it refactors the color map for better visual comfort and enhances the backend API to support these changes.

**Z-Wave Spectrum Feature**

* Added a Z-Wave regional plan (`ZWAVE_REGIONS`) to `rtl_sdr.py`, exposing sweep spans and channel centers per region for the UI. Also added the `zwave_plan()` function and a new `/api/net/rtl/zwave` API endpoint to serve this data. [[1]](diffhunk://#diff-647d5a60a378bdab96128570d6229c2a9e8cc219c3f4041773f1a9c4b4689d54R74-R118) [[2]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL18790-R18801)
* Updated the frontend (`rf_waterfall.html`) to load the Z-Wave plan, populate a region selector, and allow users to sweep Z-Wave bands, overlaying channel centers as cyan bands on the spectrum. [[1]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404R111-R113) [[2]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404R244) [[3]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404L260-R279) [[4]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404L372-R428) [[5]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404L434-R488) [[6]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404R605-R616) [[7]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404R684-R689)
* Modified the sweep start logic in both the backend (`rtl_sdr.py` and `network_diagnostics.py`) and frontend to accept and propagate a `label` (e.g., "zwave-eu") for custom spans, ensuring correct identification and handling of Z-Wave region sweeps. [[1]](diffhunk://#diff-647d5a60a378bdab96128570d6229c2a9e8cc219c3f4041773f1a9c4b4689d54L726-R774) [[2]](diffhunk://#diff-647d5a60a378bdab96128570d6229c2a9e8cc219c3f4041773f1a9c4b4689d54L738-R784) [[3]](diffhunk://#diff-647d5a60a378bdab96128570d6229c2a9e8cc219c3f4041773f1a9c4b4689d54L907-R953) [[4]](diffhunk://#diff-fe0d7f173ab6ce86be393ec289db8034beebccf46d5366094a1b4594c3054ddaL18790-R18801)

**UI and Visualization Improvements**

* Changed the waterfall colormap from a warm amber/white-hot palette to a cooler "Aurora" palette (navy→blue→teal→periwinkle→lavender) for improved eye comfort and less glare. [[1]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404L64-R64) [[2]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404R163-R173)
* Updated the HTML footer to explain the new Z-Wave Spectrum feature and its purpose.

**Other Enhancements**

* Enabled Z-Wave support in the RTL-SDR panel configuration.

These changes collectively introduce a powerful new tool for observing Z-Wave mesh activity and improve the overall user experience of the RF Waterfall demo.