### PR TITLE
Mesh overlay: Meshtastic / MeshCore / LoRaWAN spectrum view (energy-o…

### DIFF
--- a/demos/rf_waterfall.html
+++ b/demos/rf_waterfall.html
@@ -160,7 +160,7 @@
 
   <footer id="footer"><div id="foot-msg"></div>
     <div style="margin-top:6px"><b>Backends:</b> rtl_sdr.py (rtl_power sweep · rtl_433 decode) · sdr_spectrum.py (hackrf_sweep). Click a signal to pin a marker and retune a narrow zoom sweep there; the sub-GHz panel can switch to rtl_433 to name devices (one dongle, so Waterfall and Decode are mutually exclusive).</div>
-    <div style="margin-top:6px"><b>📡 Z-Wave Spectrum:</b> pick a region to sweep its exact Z-Wave channels and watch the mesh's bursts land on them — device chatter, retries, or a jammer parked on a channel. Z-Wave is a sub-GHz mesh that rtl_433 can't decode, so this is an energy/occupancy view of a band almost nobody scans. Receive-only.</div>
+    <div style="margin-top:6px"><b>📡 Mesh overlay:</b> the sub-GHz panel's <b>Mesh/LoRa</b> dropdown sweeps a chosen mesh's band and overlays its exact channels — <b>Z-Wave</b> (FSK) regions, plus the LoRa meshes <b>Meshtastic</b>, <b>MeshCore</b> and <b>LoRaWAN</b>. Watch bursts/chirps land on the channels: device chatter, retries, or a jammer parked on one. This is an <b>energy/occupancy view only</b> — LoRa (chirp spread-spectrum) can't be demodulated with rtl_power/rtl_433 and the payloads are encrypted, so you see presence and activity, not IDs or messages. Receive-only.</div>
   </footer>
 </div>
 
@@ -209,16 +209,21 @@
   // Z-Wave: narrow GFSK bursts that land on the region's fixed channels — a mesh
   // chattering (device reports, hops, retries). Used for the no-hardware demo;
   // with a dongle the real rtl_power sweep replaces this.
-  function zwaveModel(lo,hi,channels){
+  // Synthetic model for any mesh overlay (Z-Wave FSK or LoRa CSS) — bursts on the
+  // overlay's channels for the no-hardware demo. Bump width scales with the span
+  // (narrow for Z-Wave, wider for LoRa). Real hardware replaces this with the
+  // rtl_power sweep.
+  function overlayModel(lo,hi,channels){
     var chans=(channels||[]).map(function(c){return c.freq_mhz;});
-    return {lo:lo,hi:hi,floor:-112,ticks:null,zwaveChans:chans,
+    var w=Math.min(0.25,Math.max(0.1,(hi-lo)*0.015));
+    return {lo:lo,hi:hi,floor:-112,ticks:null,
       emit:function(row){
         chans.forEach(function(f,idx){
-          if(Math.random()<(idx===0?0.55:0.32)) bump(row,lo,hi,f,0.12,-44-Math.random()*16);});
+          if(Math.random()<(idx===0?0.55:0.32)) bump(row,lo,hi,f,w,-44-Math.random()*16);});
         if(chans.length && Math.random()<0.15)
-          bump(row,lo,hi,chans[(Math.random()*chans.length)|0]+0.2,0.10,-60);}};}
+          bump(row,lo,hi,chans[(Math.random()*chans.length)|0]+w,w*0.8,-60);}};}
 
-  var running=true, HZ=12, DEMO_ON=false, ZWAVE=null;
+  var running=true, HZ=12, DEMO_ON=false, OVERLAYS={};
   var reduce=window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   function fmtF(mhz){return (mhz>=1000)?(mhz/1000).toFixed(mhz%1000?2:0)+"G":(mhz>=100?mhz.toFixed(1):mhz.toFixed(2));}
   function genTicks(lo,hi){var n=6,out=[];for(var i=0;i<=n;i++)out.push(lo+(hi-lo)*i/n);return out;}
@@ -388,44 +393,50 @@
   // ---- band / view selection ----
   Scope.prototype.selectBand=function(bandId,synthId){
     Array.prototype.forEach.call(this.bandSel.querySelectorAll('button'),function(x){x.setAttribute('aria-pressed',x.getAttribute('data-band')===bandId?'true':'false');});
-    if(this.zwaveSel) Array.prototype.forEach.call(this.zwaveSel.querySelectorAll('button'),function(x){x.setAttribute('aria-pressed','false');});
+    if(this.ovDropdown) this.ovDropdown.value='';
     this.liveBand=bandId; this.synthBand=synthId||bandId; this.zoom=null; this.zwave=null; this.zwaveRegion=null; this.resetBtn.disabled=true;
     if(this.decoding){ this.stopIsm(); this.startIsm(); return; }
     if(this.mode==='live'){ this.stopLive(); this._rangeKnown=false; this.resetCanvas(); this.startLive(); }
     else if(this.mode==='synth'){ this.model=this.cfg.synth(this.synthBand); this.lo=this.model.lo;this.hi=this.model.hi;this.floor=this.model.floor; this.resetCanvas(); this.drawRuler(); }
   };
-  // Z-Wave region selector: a dropdown (built once the plan loads) that sweeps
-  // the region's tight span and overlays its exact channel centres. Z-Wave is a
-  // sub-GHz mesh rtl_433 can't decode, so this is an energy/occupancy view of a
-  // band nobody usually looks at.
-  Scope.prototype.populateZwave=function(plan){
-    if(!this.cfg.zwave || !plan || this._zwaveBuilt) return;
-    var self=this; this._zwaveBuilt=true;
-    var tag=document.createElement('span'); tag.className='zwtag'; tag.textContent='📡 Z-Wave';
-    var sel=document.createElement('select'); sel.title='Sweep a Z-Wave region and overlay its channels';
-    var opt0=document.createElement('option'); opt0.value=''; opt0.textContent='Region…'; sel.appendChild(opt0);
-    Object.keys(plan).forEach(function(rid){
-      var o=document.createElement('option'); o.value=rid; o.textContent=plan[rid].label; sel.appendChild(o);
+  // Mesh overlay selector: one dropdown (built once the plans load) grouping
+  // Z-Wave regions + LoRa meshes (Meshtastic / MeshCore / LoRaWAN). Picking one
+  // sweeps its band span and overlays its channel centres. Z-Wave is FSK; the
+  // LoRa meshes are CSS and can't be demodulated here (encrypted anyway) — so
+  // this is an energy/occupancy view: see the mesh's bursts land on its channels.
+  Scope.prototype.populateOverlays=function(map){
+    if(!this.cfg.zwave || !map || this._ovBuilt) return;
+    var self=this; this._ovBuilt=true;
+    var tag=document.createElement('span'); tag.className='zwtag'; tag.textContent='📡 Mesh';
+    var sel=document.createElement('select'); sel.title='Overlay a mesh/LPWAN band + its channels (energy view — LoRa is not demodulated)';
+    var opt0=document.createElement('option'); opt0.value=''; opt0.textContent='Mesh / LoRa…'; sel.appendChild(opt0);
+    var order=['Z-Wave','Meshtastic','MeshCore','LoRaWAN'], byGroup={};
+    Object.keys(map).forEach(function(id){var g=map[id].group||'Other';(byGroup[g]=byGroup[g]||[]).push(id);});
+    var groups=order.concat(Object.keys(byGroup).filter(function(g){return order.indexOf(g)<0;}));
+    groups.forEach(function(g){ if(!byGroup[g])return;
+      var og=document.createElement('optgroup'); og.label=g;
+      byGroup[g].forEach(function(id){var o=document.createElement('option');o.value=id;o.textContent=map[id].short||map[id].name;o.title=map[id].note||'';og.appendChild(o);});
+      sel.appendChild(og);
     });
-    sel.addEventListener('change',function(){ if(sel.value) self.selectZwave(sel.value); else self.clearZwave(); });
-    this.zwaveDropdown=sel;
+    sel.addEventListener('change',function(){ if(sel.value) self.selectOverlay(sel.value); else self.clearOverlay(); });
+    this.ovDropdown=sel;
     this.zwaveSel.appendChild(tag); this.zwaveSel.appendChild(sel);
     this.zwaveSel.classList.remove('hidden');
   };
-  Scope.prototype.clearZwave=function(){ // back to the normal band view
-    if(this.zwaveDropdown) this.zwaveDropdown.value='';
+  Scope.prototype.clearOverlay=function(){ // back to the normal band view
+    if(this.ovDropdown) this.ovDropdown.value='';
     this.selectBand(this.liveBand,this.synthBand);
   };
-  Scope.prototype.selectZwave=function(regionId){
-    var reg=ZWAVE&&ZWAVE[regionId]; if(!reg) return;
-    this.zwaveRegion=regionId; this.zwave=reg; this.zoom=null; this.marker=null; this.markEl.style.display='none'; this.resetBtn.disabled=true;
-    if(this.zwaveDropdown) this.zwaveDropdown.value=regionId;
-    if(this.decoding) this.setView('wf');   // decode can't do Z-Wave; back to sweep
+  Scope.prototype.selectOverlay=function(id){
+    var e=OVERLAYS[id]; if(!e) return;
+    this.zwave=e; this.zwaveRegion=e.sweepLabel; this.zoom=null; this.marker=null; this.markEl.style.display='none'; this.resetBtn.disabled=true;
+    if(this.ovDropdown) this.ovDropdown.value=id;
+    if(this.decoding) this.setView('wf');   // decode can't do these; back to sweep
     Array.prototype.forEach.call(this.bandSel.querySelectorAll('button'),function(x){x.setAttribute('aria-pressed','false');});
     if(this.mode==='live'){ this.stopLive(); this._rangeKnown=false; this.resetCanvas(); this.startLive(); }
-    else if(this.mode==='synth'){ this.model=zwaveModel(reg.lo_hz/1e6,reg.hi_hz/1e6,reg.channels);
+    else if(this.mode==='synth'){ this.model=overlayModel(e.lo_hz/1e6,e.hi_hz/1e6,e.channels);
       this.lo=this.model.lo; this.hi=this.model.hi; this.floor=this.model.floor; this.resetCanvas(); this.drawRuler(); }
-    else { this.setMode(DEMO_ON?'synth':'idle'); if(this.mode==='synth'){ this.model=zwaveModel(reg.lo_hz/1e6,reg.hi_hz/1e6,reg.channels); this.lo=this.model.lo;this.hi=this.model.hi;this.floor=this.model.floor; this.drawRuler(); } }
+    else { this.setMode(DEMO_ON?'synth':'idle'); if(this.mode==='synth'){ this.model=overlayModel(e.lo_hz/1e6,e.hi_hz/1e6,e.channels); this.lo=this.model.lo;this.hi=this.model.hi;this.floor=this.model.floor; this.drawRuler(); } }
   };
   Scope.prototype.setView=function(v){
     var want=(v==='decode');
@@ -484,7 +495,7 @@
   Scope.prototype.startLive=function(){
     var self=this; this.seq=0; this.liveErr=null;
     var body={band:this.liveBand};
-    if(this.zwave){ body.lo_hz=this.zwave.lo_hz; body.hi_hz=this.zwave.hi_hz; body.label='zwave-'+this.zwaveRegion; }
+    if(this.zwave){ body.lo_hz=this.zwave.lo_hz; body.hi_hz=this.zwave.hi_hz; body.label=this.zwave.sweepLabel; }
     else if(this.zoom){ body.lo_hz=Math.round(this.zoom[0]*1e6); body.hi_hz=Math.round(this.zoom[1]*1e6); }
     fetch(this.cfg.api.start,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)})
       .then(function(r){return r.json();}).then(function(res){
@@ -683,8 +694,14 @@
 
   // Load the Z-Wave regional plan once and build the region selector on scopes
   // that support it (the RTL-SDR panel). No dongle needed — the plan is static.
-  fetch('/api/net/rtl/zwave').then(function(r){return r.json();}).then(function(d){
-    if(d&&d.regions){ ZWAVE=d.regions; scopes.forEach(function(s){ s.populateZwave(ZWAVE); }); }
+  Promise.all([
+    fetch('/api/net/rtl/zwave').then(function(r){return r.json();}).catch(function(){return null;}),
+    fetch('/api/net/rtl/lora').then(function(r){return r.json();}).catch(function(){return null;})
+  ]).then(function(res){
+    var zw=res[0]&&res[0].regions, lp=res[1]&&res[1].plans;
+    if(zw) Object.keys(zw).forEach(function(id){ OVERLAYS['zwave-'+id]={name:zw[id].label,short:zw[id].label,group:'Z-Wave',lo_hz:zw[id].lo_hz,hi_hz:zw[id].hi_hz,channels:zw[id].channels,sweepLabel:'zwave-'+id,note:'Z-Wave (FSK)'}; });
+    if(lp) Object.keys(lp).forEach(function(id){ var sh=lp[id].label.split('·').pop().trim(); OVERLAYS[id]={name:lp[id].label,short:sh,group:lp[id].proto,lo_hz:lp[id].lo_hz,hi_hz:lp[id].hi_hz,channels:lp[id].channels,sweepLabel:'lora-'+id,note:lp[id].note}; });
+    scopes.forEach(function(s){ s.populateOverlays(OVERLAYS); });
   }).catch(function(){});
 
   refreshConfig().then(function(){ scopes.forEach(function(s){s.applyDesired();s.updateTag();}); updateFoot(); pollAll();

--- a/docs/sdr-subghz.md
+++ b/docs/sdr-subghz.md
@@ -114,17 +114,53 @@ driver is holding it. That lets `/status` tell three cases apart:
   DVB-T driver still holds it (blacklist `dvb_usb_rtl28xxu`, replug).
 - **`available: true`** — good; the SDR tab and RF Waterfall button light up.
 
+## Mesh overlays (Z-Wave / Meshtastic / MeshCore / LoRaWAN)
+
+The RF Waterfall page's sub-GHz panel has a **📡 Mesh / LoRa** dropdown that
+sweeps a chosen mesh's band and overlays its exact channel centres on the
+spectrum, so you can watch the mesh's bursts/chirps land on its channels — device
+chatter, retries, or a **jammer** parked on a channel.
+
+- **Z-Wave** (FSK) — per-region channels (EU 868.42/869.85, US 908.42/916.0,
+  US-LR 912/920, ANZ/JP/KR/IN/IL/HK/RU/CN). `GET /api/net/rtl/zwave`.
+- **Meshtastic / MeshCore / LoRaWAN** (LoRa/CSS) — per protocol+region band +
+  channels: Meshtastic US/EU868/EU433/ANZ, MeshCore EU/US, LoRaWAN
+  EU868/US915/IN865/AS923. `GET /api/net/rtl/lora`.
+
+**This is an energy / occupancy view, not a decoder — and deliberately so:**
+
+- **LoRa cannot be demodulated with `rtl_power`/`rtl_433`.** LoRa is chirp
+  spread-spectrum; demodulating it needs `gr-lora_sdr` (GNU Radio — heavy) or a
+  real LoRa radio (SX127x/SX126x). This view never claims to read LoRa frames.
+- **The payloads are encrypted anyway** — Meshtastic AES-256 (channel PSK;
+  the *public* channel key is well-known), LoRaWAN AES-128. So even a demodulator
+  gives you addresses/metadata at best, not message contents.
+- **What you get RF-only:** presence, activity/occupancy per channel, and which
+  band a mesh is on. Not node IDs or messages.
+- **To actually identify/enumerate a mesh** (node list, names, and to decrypt the
+  Meshtastic public channel), the practical path is a **companion LoRa node**
+  (a Meshtastic/MeshCore device over USB, the way Huginn/Zigbee attach) — a
+  possible future integration, not part of this receive-only spectrum view.
+
+Frequencies: LoRaWAN entries follow the published regional band plans; Meshtastic
+default channels are preset/hash-derived and MeshCore's are user-configurable, so
+those are marked "~" / "default" — scan the band for the actual chirps.
+
 ## API
 
 | Route | Purpose |
 |---|---|
 | `GET  /api/net/rtl/status` | Dongle detection (gates the tab) + capture state for both modes |
+| `GET  /api/net/rtl/diagnose` | SDR health check (USB/tools/DVB/power) — the "SDR check" button |
+| `POST /api/net/rtl/install` | One-click install of rtl-sdr/rtl-433 + DVB unblock |
 | `POST /api/net/rtl/ism/start` `{band}` | Start the ISM scanner (433/868/915) |
 | `POST /api/net/rtl/ism/stop` | Stop the ISM scanner |
 | `GET  /api/net/rtl/ism/devices` | The live decoded-device table |
-| `POST /api/net/rtl/power/start` `{band}` | Start the sub-GHz sweep (433/868/915/subghz) |
+| `POST /api/net/rtl/power/start` `{band, lo_hz?, hi_hz?, label?}` | Start the sub-GHz sweep (band or custom/zoom/mesh span) |
 | `POST /api/net/rtl/power/stop` | Stop the sweep |
 | `GET  /api/net/rtl/power/frames?since=` | New waterfall frames + max-hold since a seq |
+| `GET  /api/net/rtl/zwave` | Z-Wave regional plan (spans + channel centres) |
+| `GET  /api/net/rtl/lora` | LoRa mesh plan — Meshtastic/MeshCore/LoRaWAN (spans + channels) |
 | `GET  /api/net/rtl/selftest` | Offline parser / frame-assembly self-test |
 
 ## CLI

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -18800,6 +18800,13 @@ def register_network_diagnostics(app, logger=None):
     def net_rtl_zwave():
         return jsonify({"regions": rtl_sdr.zwave_plan()})
 
+    # LoRa mesh / LPWAN plan (Meshtastic, MeshCore, LoRaWAN) for the mesh overlay.
+    # Energy view only — LoRa (CSS) can't be demodulated with rtl_power/rtl_433,
+    # and payloads are encrypted; the UI sweeps the span and overlays channels.
+    @app.route('/api/net/rtl/lora', methods=['GET'])
+    def net_rtl_lora():
+        return jsonify({"plans": rtl_sdr.lora_plan()})
+
     # rtl_433 ISM device decoder — names the sub-GHz transmitters (TPMS, weather
     # stations, doorbells, …). One dongle, so the scanner and the power sweep are
     # mutually exclusive: starting one stops the other (handled in rtl_sdr.py).

--- a/rtl_sdr.py
+++ b/rtl_sdr.py
@@ -116,6 +116,83 @@ def zwave_plan():
         }
     return out
 
+
+# LoRa mesh / LPWAN radio plans (Meshtastic, MeshCore, LoRaWAN). These are all
+# LoRa (chirp spread-spectrum), NOT the FSK that rtl_433 decodes — so this is an
+# ENERGY / occupancy view only: sweep the band and watch the mesh's chirps land
+# on its channels. We CANNOT demodulate LoRa with rtl_power/rtl_433 (that needs
+# gr-lora_sdr or a real LoRa radio), and the payloads are encrypted regardless;
+# so no node IDs / message contents — just presence, activity and which channels.
+# Each entry: proto, sweep span (Hz), reference channel centres, and a note.
+# LoRaWAN band plans are standards (accurate); Meshtastic/MeshCore defaults are
+# preset/config-derived, so their channels are marked "~" / "default".
+LORA_PLANS = {
+    # --- Meshtastic (LoRa; default LongFast preset, BW 250 kHz) ---
+    "meshtastic-us":    {"proto": "Meshtastic", "label": "Meshtastic · US (902-928)",
+                         "span": (902_000_000, 928_000_000),
+                         "channels": [(906_875_000, "LongFast ~")],
+                         "note": "US: 902-928 MHz, LongFast BW250/SF11 (default channel is hash-derived; scan the band for 250 kHz chirps)"},
+    "meshtastic-eu868": {"proto": "Meshtastic", "label": "Meshtastic · EU868",
+                         "span": (869_300_000, 869_750_000),
+                         "channels": [(869_525_000, "LongFast")],
+                         "note": "EU868: single 250 kHz channel in the 10% duty sub-band"},
+    "meshtastic-eu433": {"proto": "Meshtastic", "label": "Meshtastic · EU433",
+                         "span": (433_050_000, 434_790_000),
+                         "channels": [(433_175_000, "LongFast ~")],
+                         "note": "EU433: BW250 (default channel hash-derived)"},
+    "meshtastic-anz":   {"proto": "Meshtastic", "label": "Meshtastic · ANZ (915-928)",
+                         "span": (915_000_000, 928_000_000),
+                         "channels": [(915_900_000, "LongFast ~")],
+                         "note": "ANZ: 915-928 MHz, BW250 (default channel hash-derived)"},
+    # --- MeshCore (LoRa; frequency is user-configurable — common defaults) ---
+    "meshcore-eu":      {"proto": "MeshCore", "label": "MeshCore · EU (default)",
+                         "span": (868_000_000, 870_500_000),
+                         "channels": [(869_525_000, "default ~")],
+                         "note": "MeshCore EU default ~869.525 MHz (configurable), BW250"},
+    "meshcore-us":      {"proto": "MeshCore", "label": "MeshCore · US (default)",
+                         "span": (902_000_000, 928_000_000),
+                         "channels": [(910_525_000, "default ~")],
+                         "note": "MeshCore US default ~910.525 MHz (configurable), BW250"},
+    # --- LoRaWAN (band plans are standards; payload AES-encrypted, DevAddr/MAC
+    #     in clear only if demodulated — which we cannot do here) ---
+    "lorawan-eu868":    {"proto": "LoRaWAN", "label": "LoRaWAN · EU868",
+                         "span": (867_000_000, 869_700_000),
+                         "channels": [(868_100_000, "ch0"), (868_300_000, "ch1"),
+                                      (868_500_000, "ch2"), (867_100_000, "ch3"),
+                                      (867_300_000, "ch4"), (867_500_000, "ch5"),
+                                      (867_700_000, "ch6"), (867_900_000, "ch7"),
+                                      (869_525_000, "RX2/dl")],
+                         "note": "EU868: 125 kHz uplinks 867.1-868.5 + 869.525 RX2 downlink (SF12)"},
+    "lorawan-us915":    {"proto": "LoRaWAN", "label": "LoRaWAN · US915",
+                         "span": (902_000_000, 928_000_000),
+                         "channels": [(902_300_000, "up0 125k"), (903_000_000, "up 500k"),
+                                      (914_900_000, "up63 125k"), (923_300_000, "dl0 500k"),
+                                      (927_500_000, "dl7 500k")],
+                         "note": "US915: 64×125k + 8×500k uplinks (902.3-914.9); 8×500k downlinks (923.3-927.5)"},
+    "lorawan-in865":    {"proto": "LoRaWAN", "label": "LoRaWAN · IN865",
+                         "span": (865_000_000, 867_000_000),
+                         "channels": [(865_062_500, "ch0"), (865_402_500, "ch1"),
+                                      (865_985_000, "ch2")],
+                         "note": "IN865: 3 mandatory 125 kHz channels"},
+    "lorawan-as923":    {"proto": "LoRaWAN", "label": "LoRaWAN · AS923-1",
+                         "span": (921_000_000, 928_000_000),
+                         "channels": [(923_200_000, "ch0"), (923_400_000, "ch1")],
+                         "note": "AS923-1: 923.2/923.4 default (+ up to 8 channels)"},
+}
+
+
+def lora_plan():
+    """Protocol/region → sweep span + LoRa channel centres, for the mesh view."""
+    out = {}
+    for pid, p in LORA_PLANS.items():
+        out[pid] = {
+            "proto": p["proto"], "label": p["label"], "note": p.get("note", ""),
+            "lo_hz": p["span"][0], "hi_hz": p["span"][1],
+            "channels": [{"freq_hz": f, "freq_mhz": round(f / 1e6, 3), "label": lbl}
+                         for f, lbl in p["channels"]],
+        }
+    return out
+
 _POWER_BINS = 480          # display columns per waterfall frame
 _RING_FRAMES = 300         # rolling history of sweep frames kept in memory
 _FLOOR_DBM = -120          # sentinel for a display column no sweep bin filled
@@ -1175,6 +1252,25 @@ def selftest():
           any(abs(c["freq_hz"] - 868_420_000) < 1000 for c in plan["eu"]["channels"]))
     check("zwave: span >= 100 kHz so power_start accepts it",
           all(r["hi_hz"] - r["lo_hz"] >= 100_000 for r in plan.values()))
+
+    # --- LoRa mesh plan (Meshtastic / MeshCore / LoRaWAN): channels inside span,
+    #     spans in RTL reach + acceptable width, all three protocols present ---
+    lp = lora_plan()
+    check("lora: meshtastic + meshcore + lorawan present",
+          {p["proto"] for p in lp.values()} >= {"Meshtastic", "MeshCore", "LoRaWAN"})
+    _lp_ok = True
+    for pid, p in lp.items():
+        if not (24_000_000 <= p["lo_hz"] < p["hi_hz"] <= 1_766_000_000):
+            _lp_ok = False
+        if p["hi_hz"] - p["lo_hz"] < 100_000:
+            _lp_ok = False
+        for ch in p["channels"]:
+            if not (p["lo_hz"] <= ch["freq_hz"] <= p["hi_hz"]):
+                _lp_ok = False
+    check("lora: every channel inside its span, span in RTL range + >=100 kHz", _lp_ok)
+    check("lora: LoRaWAN EU868 lists the three mandatory uplinks",
+          all(any(abs(c["freq_hz"] - f) < 1000 for c in lp["lorawan-eu868"]["channels"])
+              for f in (868_100_000, 868_300_000, 868_500_000)))
 
     passed = sum(1 for r in results if r["pass"])
     return {"pass": passed == len(results), "passed": passed,


### PR DESCRIPTION
This pull request adds a new "Mesh overlay" feature to the RF Waterfall demo, allowing users to visualize the energy/occupancy of various sub-GHz mesh and LPWAN networks (Z-Wave, Meshtastic, MeshCore, LoRaWAN) by overlaying their channel plans on the spectrum. The implementation includes both UI and backend changes, supporting a new `/api/net/rtl/lora` endpoint and the necessary data/modeling for these overlays. Documentation is updated to explain the new feature and its limitations (energy view only, no demodulation or message decoding).

**Mesh overlay / LoRa/LPWAN support:**

* Added a new dropdown in the RF Waterfall UI (`demos/rf_waterfall.html`) for selecting mesh overlays (Z-Wave, Meshtastic, MeshCore, LoRaWAN), which overlays their channel plans and sweeps the relevant frequency span. The overlay is energy/occupancy only; LoRa cannot be demodulated and payloads are encrypted. [[1]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404L163-R163) [[2]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404L391-R439) [[3]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404L686-R704)
* Added a synthetic model for mesh overlays (`overlayModel`) for demo mode, supporting both FSK (Z-Wave) and CSS (LoRa) overlays.
* Updated the UI logic to generalize from Z-Wave-only overlays to support all mesh/LPWAN overlays, including grouping in the dropdown and handling selection/clearing. [[1]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404L391-R439) [[2]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404L487-R498)

**Backend/API changes:**

* Added `/api/net/rtl/lora` endpoint (Flask route in `network_diagnostics.py`) to serve LoRa mesh/LPWAN plans for overlays.
* Added `LORA_PLANS` and `lora_plan()` in `rtl_sdr.py` to provide protocol/region → sweep span + channel centers for Meshtastic, MeshCore, and LoRaWAN.
* Extended self-test (`rtl_sdr.py`) to validate LoRa mesh plans, ensuring all channels are within their spans and all protocols are present.

**Documentation:**

* Added a new "Mesh overlays" section to `docs/sdr-subghz.md`, describing the feature, supported protocols, limitations (energy view only, no LoRa demodulation), and relevant API routes.

These changes significantly expand the tool's visibility into sub-GHz mesh/LPWAN activity, making it easy to spot mesh bursts, retries, or jamming on the air without needing protocol decoders.