### PR TITLE
Signal Intelligence: Dome is the default view, moved before Bar

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -2486,8 +2486,8 @@
                         <div>
                             <label class="block text-xs text-gray-400 mb-1">View</label>
                             <div class="flex rounded-lg overflow-hidden border border-slate-700">
-                                <button id="wifi-view-bar"  class="px-3 py-1.5 text-sm bg-Ragnar-600 text-white">📊 Bar</button>
-                                <button id="wifi-view-dome" class="px-3 py-1.5 text-sm text-slate-300 hover:bg-slate-700">◗ Dome</button>
+                                <button id="wifi-view-dome" class="px-3 py-1.5 text-sm bg-Ragnar-600 text-white">◗ Dome</button>
+                                <button id="wifi-view-bar"  class="px-3 py-1.5 text-sm text-slate-300 hover:bg-slate-700">📊 Bar</button>
                                 <button id="wifi-view-wf" disabled class="px-3 py-1.5 text-sm text-slate-500 opacity-40 cursor-not-allowed border-l border-slate-700" title="Connect a HackRF SDR to enable true-RF waterfall">Waterfall</button>
                             </div>
                         </div>
@@ -8151,8 +8151,8 @@
                 <button data-band="6" class="wifi-hm-seg-btn wifi-hm-seg-off">6&nbsp;GHz</button>
             </div>
             <div class="wifi-hm-segment" id="wifi-fs-view">
-                <button data-view="bar" class="wifi-hm-seg-btn wifi-hm-seg-on">📊 Bar</button>
-                <button data-view="dome" class="wifi-hm-seg-btn wifi-hm-seg-off">◗ Dome</button>
+                <button data-view="dome" class="wifi-hm-seg-btn wifi-hm-seg-on">◗ Dome</button>
+                <button data-view="bar" class="wifi-hm-seg-btn wifi-hm-seg-off">📊 Bar</button>
                 <button data-view="waterfall" id="wifi-fs-view-wf" disabled class="wifi-hm-seg-btn wifi-hm-seg-off" title="Connect a HackRF SDR to enable the true-RF waterfall">Waterfall</button>
             </div>
             <button onclick="wifiScan()" id="wifi-fs-scan" class="wifi-hm-btn-primary">Scan</button>
@@ -8199,7 +8199,7 @@
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260822-mobile-opacity"></script>
     <script src="/web/scripts/skyview_vr.js?v=20260822-rich-info-panel"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260823-sigint"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260823-dome"></script>
 
 
 

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -1485,7 +1485,7 @@ function showNetworkSubtab(name) {
 // WiFi Spectrum Analyzer (Network > WiFi Analyzer sub-tab)
 // Passive tri-band survey. Backend: /api/net/wifi/* (wifi_analyzer.py)
 // ============================================================================
-const _wifiState = { iface: '', band: 'all', view: 'bar', data: null, selected: null, auto: null, inited: false, bt: null, btOn: false, btBusy: false, btSelected: null,
+const _wifiState = { iface: '', band: 'all', view: 'dome', data: null, selected: null, auto: null, inited: false, bt: null, btOn: false, btBusy: false, btSelected: null,
     zb: null, zbOn: false, zbBusy: false, zbSelected: null, zbAvailable: false,
     hoverBssid: null, radius: null, fs: { open: false, wired: false, native: false },
     sdr: { available: false, running: false, band: '2.4', bandMhz: null, floor: -120, seq: 0, rows: [], maxhold: null, poll: null, statusPoll: null, error: null } };


### PR DESCRIPTION
The Wi-Fi spectrum view selector now defaults to Dome and lists it first (◗ Dome · 📊 Bar · Waterfall) in both the inline and full-screen selectors. _wifiState.view default 'bar' -> 'dome'; wifiSetView() already fully manages the active styling on init, HTML initial-active class moved to Dome to avoid a flash. Keyboard shortcuts (b/d) unchanged. Cache-bust v=20260823-dome.