### PR TITLE
RF Waterfall: FM/Airband band scopes + click-a-peak-to-tune the radio

### DIFF
--- a/demos/rf_waterfall.html
+++ b/demos/rf_waterfall.html
@@ -546,6 +546,14 @@
     frac=Math.max(0,Math.min(1,frac)); var f=this.lo+frac*(this.hi-this.lo);
     this.marker=f; this.placeMarker();
     this.markTxt.innerHTML='Marked <span class="mk">'+fmtMHz(f)+'</span>';
+    // On the RTL panel, dropping a marker also loads it into the Local Radio bar
+    // (pick a sensible demod by band) so the flow is: sweep → click a station →
+    // Listen. One dongle, so listening pauses this sweep.
+    if(this.cfg.tuner && window.RADIO && f>=24 && f<=1766){
+      var m=(f>=88&&f<=108)?'wfm':((f>108&&f<=137)?'am':'nfm');
+      window.RADIO.set(f, m);
+      this.markTxt.innerHTML+=' <span class="zi">→ radio '+m.toUpperCase()+' · press Listen</span>';
+    }
     var canZoom=(this.mode==='live')||(this.mode==='synth'); this.zoomBtn.disabled=!canZoom;
     this.resetBtn.disabled=!this.zoom;
     this.zoomBtn.title=(this.mode==='live')?'Retune a narrow sweep around the marker':'Zoom the synthetic view (a real radio retunes the hardware)';
@@ -835,7 +843,7 @@
     api:{status:'/api/net/rtl/status',start:'/api/net/rtl/power/start',stop:'/api/net/rtl/power/stop',frames:'/api/net/rtl/power/frames',
          ismStart:'/api/net/rtl/ism/start',ismStop:'/api/net/rtl/ism/stop',ismDevices:'/api/net/rtl/ism/devices'},
     synth:function(b,lo,hi){return subGhzModel(lo,hi);}, synthDefault:'433', synthBands:false, decode:true, zwave:true, tuner:true, record:true, minSpan:0.2,
-    liveBands:[{id:'27',label:'27'},{id:'40',label:'40'},{id:'315',label:'315'},{id:'433',label:'433'},{id:'868',label:'868'},{id:'915',label:'915'}], defaultBand:'433' });
+    liveBands:[{id:'fm',label:'FM'},{id:'air',label:'Air'},{id:'27',label:'27'},{id:'40',label:'40'},{id:'315',label:'315'},{id:'433',label:'433'},{id:'868',label:'868'},{id:'915',label:'915'}], defaultBand:'433' });
   scopes.push(rtl); stack.appendChild(rtl.el);
   var hackrf=new Scope({ name:"Wi-Fi Bands", short:"HackRF", dev:"HackRF One · hackrf_sweep", rig:"rig-hackrf",
     api:{status:'/api/net/sdr/status',start:'/api/net/sdr/start',stop:'/api/net/sdr/stop',frames:'/api/net/sdr/frames'},
@@ -955,6 +963,14 @@
       nowEl.textContent='off · one dongle, so listening pauses the sub-GHz sweep'; }
     listenBtn.addEventListener('click',function(){ playing?stop():tune(); });
     audio.addEventListener('error',function(){ if(playing){ nowEl.innerHTML='<span style="color:#fb7185">Audio failed — check rtl_fm / dongle</span>'; } });
+    // Public hook: the sub-GHz waterfall calls this when you click a peak, so
+    // "sweep → click a station → Listen" works. Sets freq + mode, doesn't play.
+    window.RADIO={ set:function(mhz,mode){ if(!isFinite(mhz))return;
+      freqEl.value=(Math.round(mhz*1000)/1000);
+      if(mode){ rmode=mode; Array.prototype.forEach.call(modeSeg.querySelectorAll('button'),function(x){x.setAttribute('aria-pressed',x.getAttribute('data-m')===rmode?'true':'false');}); }
+      updateSaveBtn();
+      if(!playing) nowEl.innerHTML='<span style="color:var(--accent)">tuned '+freqEl.value+' MHz '+rmode.toUpperCase()+'</span> · press Listen';
+    }};
     rebuildPresets(); updateSaveBtn();   // show any saved stations immediately
     // load built-in presets + rtl_fm availability
     fetch('/api/net/radio/status').then(function(r){return r.json();}).then(function(st){

--- a/rtl_sdr.py
+++ b/rtl_sdr.py
@@ -60,6 +60,8 @@ _RTL_POWER = _which("rtl_power")
 RTL_BANDS = {
     "27":     (26900000, 27500000),     # CB / 27 MHz RC (near the tuner's low edge)
     "40":     (40000000, 41000000),     # 40 MHz RC / toys
+    "fm":     (88000000, 108000000),    # FM broadcast band scope (listen w/ radio)
+    "air":    (108000000, 137000000),   # VHF airband (AM voice) band scope
     "315":    (313500000, 316500000),   # US keyfobs / TPMS / garage & gate remotes
     "433":    (433050000, 434790000),   # EU 433 ISM
     "868":    (863000000, 870000000),   # EU 868 SRD
@@ -1525,6 +1527,9 @@ def selftest():
     # --- new bands: 315 (US keyfobs/TPMS/garage) + 40/27 present ---
     check("bands: 315/40/27 MHz added",
           all(b in RTL_BANDS for b in ("315", "40", "27")) and "315" in ISM_FREQS)
+    check("bands: FM (88-108) + airband (108-137) band scopes present",
+          RTL_BANDS.get("fm") == (88000000, 108000000)
+          and RTL_BANDS.get("air") == (108000000, 137000000))
 
     # --- tuner corrections (PPM + gain) build the right rtl_* flags ---
     _saved_ppm, _saved_gain = _ppm, _gain


### PR DESCRIPTION
(1) New RTL waterfall band presets: FM (88-108) and Air (108-137) added to RTL_BANDS and the sub-GHz scope's band buttons, so you can sweep the broadcast/airband as a band scope. Selftest 50/50.

(2) Click-to-tune: clicking a peak on the sub-GHz (RTL) waterfall now loads that frequency into the Local Radio bar and auto-picks the demod (88-108 WFM, 108-137 AM, else NFM) via a new window.RADIO.set() hook, so the flow is sweep -> click a station -> press Listen. It sets freq+mode but doesn't auto-play; pressing Listen starts audio (which pauses the sweep — one dongle). Confirmed in a render (click ~704 MHz -> 'tuned 704.812 MHz NFM').

Band buttons show in live mode (RTL scope has synthBands:false).