### PR TITLE
RF Waterfall: add AM (medium-wave) + Shortwave HF band scopes

### DIFF
--- a/demos/rf_waterfall.html
+++ b/demos/rf_waterfall.html
@@ -549,8 +549,10 @@
     // On the RTL panel, dropping a marker also loads it into the Local Radio bar
     // (pick a sensible demod by band) so the flow is: sweep → click a station →
     // Listen. One dongle, so listening pauses this sweep.
-    if(this.cfg.tuner && window.RADIO && f>=24 && f<=1766){
-      var m=(f>=88&&f<=108)?'wfm':((f>108&&f<=137)?'am':'nfm');
+    if(this.cfg.tuner && window.RADIO && f>=0.5 && f<=1766){
+      // WFM for the FM band; AM for airband + all HF broadcast (AM/shortwave,
+      // which the dongle only reaches via direct sampling); NFM otherwise.
+      var m=(f>=88&&f<=108)?'wfm':((f>108&&f<=137)||f<30?'am':'nfm');
       window.RADIO.set(f, m);
       this.markTxt.innerHTML+=' <span class="zi">→ radio '+m.toUpperCase()+' · press Listen</span>';
     }
@@ -843,7 +845,7 @@
     api:{status:'/api/net/rtl/status',start:'/api/net/rtl/power/start',stop:'/api/net/rtl/power/stop',frames:'/api/net/rtl/power/frames',
          ismStart:'/api/net/rtl/ism/start',ismStop:'/api/net/rtl/ism/stop',ismDevices:'/api/net/rtl/ism/devices'},
     synth:function(b,lo,hi){return subGhzModel(lo,hi);}, synthDefault:'433', synthBands:false, decode:true, zwave:true, tuner:true, record:true, minSpan:0.2,
-    liveBands:[{id:'fm',label:'FM'},{id:'air',label:'Air'},{id:'27',label:'27'},{id:'40',label:'40'},{id:'315',label:'315'},{id:'433',label:'433'},{id:'868',label:'868'},{id:'915',label:'915'}], defaultBand:'433' });
+    liveBands:[{id:'am',label:'AM'},{id:'sw',label:'SW'},{id:'fm',label:'FM'},{id:'air',label:'Air'},{id:'27',label:'27'},{id:'40',label:'40'},{id:'315',label:'315'},{id:'433',label:'433'},{id:'868',label:'868'},{id:'915',label:'915'}], defaultBand:'433' });
   scopes.push(rtl); stack.appendChild(rtl.el);
   var hackrf=new Scope({ name:"Wi-Fi Bands", short:"HackRF", dev:"HackRF One · hackrf_sweep", rig:"rig-hackrf",
     api:{status:'/api/net/sdr/status',start:'/api/net/sdr/start',stop:'/api/net/sdr/stop',frames:'/api/net/sdr/frames'},

--- a/rtl_sdr.py
+++ b/rtl_sdr.py
@@ -58,6 +58,10 @@ _RTL_POWER = _which("rtl_power")
 
 # Power-sweep ranges (Hz). Kept inside the RTL-SDR's reach (~24 MHz–1.7 GHz).
 RTL_BANDS = {
+    # HF broadcast bands (below the R820T2 tuner floor -> need the dongle's
+    # DIRECT-SAMPLING path, ~0.1-24 MHz, not the normal quadrature tuner).
+    "am":     (530000, 1710000),        # AM / medium-wave broadcast (direct sampling)
+    "sw":     (3000000, 24000000),      # shortwave HF broadcast (direct sampling; capped at ~25 MHz DS ceiling)
     "27":     (26900000, 27500000),     # CB / 27 MHz RC (near the tuner's low edge)
     "40":     (40000000, 41000000),     # 40 MHz RC / toys
     "fm":     (88000000, 108000000),    # FM broadcast band scope (listen w/ radio)
@@ -1530,6 +1534,9 @@ def selftest():
     check("bands: FM (88-108) + airband (108-137) band scopes present",
           RTL_BANDS.get("fm") == (88000000, 108000000)
           and RTL_BANDS.get("air") == (108000000, 137000000))
+    check("bands: AM (0.53-1.71) + shortwave (3-24) HF band scopes present",
+          RTL_BANDS.get("am") == (530000, 1710000)
+          and RTL_BANDS.get("sw") == (3000000, 24000000))
 
     # --- tuner corrections (PPM + gain) build the right rtl_* flags ---
     _saved_ppm, _saved_gain = _ppm, _gain


### PR DESCRIPTION
Mirrors the FM/Airband additions with two HF broadcast presets next to FM:
  am -> 0.53-1.71 MHz (medium-wave / AM broadcast)
  sw -> 3-24 MHz     (shortwave broadcast)

Both live below the R820T2 tuner's ~24 MHz floor, so they use the dongle's DIRECT-SAMPLING path. radio.py already plumbs this (rtl_fm gets -E direct below 24 MHz with AM demod), so click-a-peak -> Listen works end to end: the onPick hook now reaches down to HF and picks AM for anything under 30 MHz (WFM stays for the FM band, NFM otherwise). Band buttons render AM/SW/FM/Air grouped as the broadcast cluster. Selftest 51/51 (rtl) + 9/9 (radio).