### PR TITLE
APRS: ham packet RX + messaging (off-air SDR + APRS-IS worldwide)

### DIFF
--- a/aprs.py
+++ b/aprs.py
@@ -1,0 +1,853 @@
+#!/usr/bin/env python3
+"""
+aprs.py — APRS receive + messaging for Ragnar (SDR off-air + APRS-IS Internet).
+
+APRS (Automatic Packet Reporting System) is the ham-radio packet network: 1200
+baud AFSK AX.25 on a regional VHF calling frequency (144.390 MHz in North
+America, 144.800 in Europe, 145.175 in Australia, …). Stations beacon their
+position, weather, telemetry, and short **messages** to each other. **IGates**
+bridge the RF world to **APRS-IS**, a global TCP network, so a packet heard in
+one town is visible worldwide.
+
+Two sources, one feed:
+  * **RF (SDR)** — ``rtl_fm`` FM-demodulates the local APRS channel and
+    ``multimon-ng -a AFSK1200`` recovers the AX.25 frames. Receive-only; no
+    licence needed to listen.
+  * **APRS-IS (Internet)** — a TCP client to the global network. A read-only
+    login (no licence) streams **any region** via a server-side filter; with
+    your own callsign + passcode you get write access to **send messages**,
+    which IGates deliver to the recipient (over the Internet and, near them,
+    over RF).
+
+What this does NOT do: transmit on RF. RTL-SDR can't transmit, and HackRF TX is
+a licensed, hardware-careful path we deliberately leave out — APRS-IS carries
+real messaging without it. Sending on APRS-IS still injects under your callsign,
+so only licensed operators should send.
+
+CLI
+---
+    python3 aprs.py detect
+    python3 aprs.py parse 'SRC>APRS,WIDE1-1:=5132.07N/00007.24W-hello'
+    python3 aprs.py selftest
+"""
+
+import os
+import re
+import socket
+import subprocess
+import sys
+import threading
+import time
+
+
+def _which(name):
+    p = "/usr/bin/%s" % name
+    return p if os.path.exists(p) else name
+
+
+_RTL_FM = _which("rtl_fm")
+_MULTIMON = _which("multimon-ng")
+_MSG_RING = 800
+_STATION_MAX = 4000
+
+# Regional APRS calling frequency (Hz) + a sensible default APRS-IS area filter.
+# Non-exhaustive but spans every continent; the UI also takes a free-form MHz
+# and a free-form APRS-IS filter.
+APRS_REGIONS = {
+    "North America (144.390)":   {"rf_hz": 144_390_000, "is_filter": "r/39.8/-98.6/3000"},
+    "Europe (144.800)":          {"rf_hz": 144_800_000, "is_filter": "r/50/10/3000"},
+    "UK & Ireland (144.800)":    {"rf_hz": 144_800_000, "is_filter": "r/54/-3/1500"},
+    "Australia (145.175)":       {"rf_hz": 145_175_000, "is_filter": "r/-25/135/4000"},
+    "New Zealand (144.575)":     {"rf_hz": 144_575_000, "is_filter": "r/-41/174/1500"},
+    "Japan (144.640)":           {"rf_hz": 144_640_000, "is_filter": "r/36/138/2000"},
+    "South Korea (144.620)":     {"rf_hz": 144_620_000, "is_filter": "r/36/128/800"},
+    "China (144.640)":           {"rf_hz": 144_640_000, "is_filter": "r/35/103/4000"},
+    "Brazil (145.570)":          {"rf_hz": 145_570_000, "is_filter": "r/-14/-52/4000"},
+    "Argentina & Chile (144.930)": {"rf_hz": 144_930_000, "is_filter": "r/-35/-65/3000"},
+    "Southern Africa (144.800)": {"rf_hz": 144_800_000, "is_filter": "r/-26/28/3000"},
+    "Thailand (145.525)":        {"rf_hz": 145_525_000, "is_filter": "r/15/101/1500"},
+    "Russia (144.800)":          {"rf_hz": 144_800_000, "is_filter": "r/56/38/5000"},
+}
+
+APRS_IS_HOST = "rotate.aprs2.net"
+APRS_IS_PORT = 14580            # the filtered/full-feed port
+
+
+# --------------------------------------------------------------------------
+# APRS-IS passcode — the well-known callsign hash (write access)
+# --------------------------------------------------------------------------
+
+def aprs_passcode(callsign):
+    """The standard APRS-IS passcode for a base callsign (SSID stripped)."""
+    call = (callsign or "").split("-")[0].upper()
+    code = 0x73E2
+    i = 0
+    while i < len(call):
+        code ^= ord(call[i]) << 8
+        if i + 1 < len(call):
+            code ^= ord(call[i + 1])
+        i += 2
+    return code & 0x7FFF
+
+
+def valid_passcode(callsign, passcode):
+    try:
+        return int(passcode) == aprs_passcode(callsign)
+    except (TypeError, ValueError):
+        return False
+
+
+# --------------------------------------------------------------------------
+# Parser — pure, drives the selftest
+# --------------------------------------------------------------------------
+
+def _b91(s):
+    v = 0
+    for ch in s:
+        v = v * 91 + (ord(ch) - 33)
+    return v
+
+
+def _lat_uncomp(s):          # "4903.50N"
+    if len(s) < 8:
+        return None
+    try:
+        deg = int(s[0:2])
+        minutes = float((s[2:7].replace(" ", "0")) or "0")
+    except ValueError:
+        return None
+    val = deg + minutes / 60.0
+    return -val if s[7] in "Ss" else val
+
+
+def _lon_uncomp(s):          # "07201.75W"
+    if len(s) < 9:
+        return None
+    try:
+        deg = int(s[0:3])
+        minutes = float((s[3:8].replace(" ", "0")) or "0")
+    except ValueError:
+        return None
+    val = deg + minutes / 60.0
+    return -val if s[8] in "Ww" else val
+
+
+_ALT_RE = re.compile(r"/A=(-?\d{6})")
+_CSE_RE = re.compile(r"^(\d{3})/(\d{3})")     # course/speed at start of comment
+_WX_TEMP = re.compile(r"t(-?\d{2,3})")
+_WX_WDIR = re.compile(r"c(\d{3})")
+_WX_WSPD = re.compile(r"s(\d{3})")
+
+
+def _extract_extra(comment):
+    """Pull course/speed, altitude and (best-effort) weather out of a comment."""
+    out = {}
+    c = comment or ""
+    m = _CSE_RE.match(c)
+    if m:
+        out["course"] = int(m.group(1))
+        out["speed_kt"] = int(m.group(2))
+        c = c[7:]
+    a = _ALT_RE.search(comment or "")
+    if a:
+        out["altitude_ft"] = int(a.group(1))
+    # weather packets pack cNNNsNNNgNNNtNNN… into the comment
+    if _WX_TEMP.search(comment or "") and (_WX_WSPD.search(comment or "") or "g" in (comment or "")):
+        wt = _WX_TEMP.search(comment or "")
+        wd = _WX_WDIR.search(comment or "")
+        ws = _WX_WSPD.search(comment or "")
+        wx = {}
+        if wt:
+            wx["temp_f"] = int(wt.group(1))
+        if wd:
+            wx["wind_dir"] = int(wd.group(1))
+        if ws:
+            wx["wind_mph"] = int(ws.group(1))
+        if wx:
+            out["weather"] = wx
+    out["comment"] = c.strip()
+    return out
+
+
+def _parse_position(info):
+    """Position body after the data-type id (and any timestamp). Returns dict."""
+    if not info:
+        return {}
+    c = info[0]
+    if c.isdigit():                                  # uncompressed
+        if len(info) < 19:
+            return {}
+        lat = _lat_uncomp(info[0:8]); lon = _lon_uncomp(info[9:18])
+        if lat is None or lon is None:
+            return {}
+        out = {"lat": round(lat, 6), "lon": round(lon, 6), "symbol": info[8] + info[18]}
+        out.update(_extract_extra(info[19:]))
+        return out
+    if c in "/\\" or ("A" <= c <= "Z") or ("a" <= c <= "j"):   # compressed
+        if len(info) < 13:
+            return {}
+        try:
+            lat = 90 - _b91(info[1:5]) / 380926.0
+            lon = -180 + _b91(info[5:9]) / 190463.0
+        except Exception:
+            return {}
+        out = {"lat": round(lat, 6), "lon": round(lon, 6), "symbol": info[0] + info[9]}
+        out.update(_extract_extra(info[13:]))
+        return out
+    return {}
+
+
+def _parse_mice(dest, info):
+    """Mic-E: latitude+flags from the destination, longitude+speed/course from info."""
+    if len(dest) < 6 or len(info) < 9:
+        return {}
+    digits = ""; ns = "S"; ew = "E"; lonoff = 0; msgbits = []
+    for i, ch in enumerate(dest[:6]):
+        o = ord(ch)
+        if 48 <= o <= 57:
+            d, b = o - 48, 0
+        elif 65 <= o <= 74:
+            d, b = o - 65, 1
+        elif 80 <= o <= 89:
+            d, b = o - 80, 1
+        elif o == 90:
+            d, b = 0, 1
+        else:
+            d, b = None, 0                           # K/L ambiguity
+        digits += (str(d) if d is not None else " ")
+        if i < 3:
+            msgbits.append(b)
+        elif i == 3:
+            ns = "N" if o >= 80 else "S"
+        elif i == 4:
+            lonoff = 100 if o >= 80 else 0
+        elif i == 5:
+            ew = "W" if o >= 80 else "E"
+    try:
+        lat = int(digits[0:2]) + float(digits[2:4] + "." + digits[4:6]) / 60.0
+    except ValueError:
+        return {}
+    if ns == "S":
+        lat = -lat
+    d = ord(info[1]) - 28 + lonoff
+    if 180 <= d <= 189:
+        d -= 80
+    elif 190 <= d <= 199:
+        d -= 190
+    m = ord(info[2]) - 28
+    if m >= 60:
+        m -= 60
+    h = ord(info[3]) - 28
+    lon = d + (m + h / 100.0) / 60.0
+    if ew == "W":
+        lon = -lon
+    sp = ord(info[4]) - 28; dc = ord(info[5]) - 28; se = ord(info[6]) - 28
+    speed = sp * 10 + dc // 10
+    if speed >= 800:
+        speed -= 800
+    course = (dc % 10) * 100 + se
+    if course >= 400:
+        course -= 400
+    out = {"lat": round(lat, 6), "lon": round(lon, 6), "symbol": info[8] + info[7],
+           "course": course, "speed_kt": speed, "mice": True}
+    out.update(_extract_extra(info[9:]))
+    return out
+
+
+def _parse_message(info):
+    """`:ADDRESSEE:text{msgno`  ·  ack/rej.  info starts with ':'."""
+    m = re.match(r":([^:]{1,9})\s*:(.*)", info)
+    if not m:
+        return {}
+    addr = m.group(1).strip(); rest = m.group(2)
+    am = re.match(r"(ack|rej)([A-Za-z0-9]+)\s*$", rest)
+    if am:
+        return {"addressee": addr, "text": None, "msgno": am.group(2), "msgkind": am.group(1)}
+    msgno = None; text = rest
+    mm = re.search(r"\{([A-Za-z0-9]+)\s*$", rest)
+    if mm:
+        msgno = mm.group(1); text = rest[:mm.start()]
+    return {"addressee": addr, "text": text, "msgno": msgno, "msgkind": "message"}
+
+
+def parse_aprs(line):
+    """Parse a TNC2 APRS line into a structured dict, or None.
+
+    ``SOURCE>DEST,PATH1,PATH2:INFORMATION`` — handles uncompressed & compressed
+    positions (with/without timestamp), Mic-E, messages/acks, objects, status,
+    and best-effort weather. Returns at least {source, dest, path, type, raw}.
+    """
+    if not line:
+        return None
+    line = line.strip()
+    # multimon prefixes decoded frames; APRS-IS does not
+    for pre in ("APRS: ", "AFSK1200: "):
+        if line.startswith(pre):
+            line = line[len(pre):].strip()
+    if line.startswith("#") or ">" not in line or ":" not in line:
+        return None
+    head, info = line.split(":", 1)
+    if ">" not in head:
+        return None
+    src, rest = head.split(">", 1)
+    parts = rest.split(",")
+    dest = parts[0].strip()
+    path = [p.strip() for p in parts[1:] if p.strip()]
+    rec = {"source": src.strip().upper(), "dest": dest.upper(), "path": path,
+           "raw": line, "type": "other", "info": info}
+    if not info:
+        return rec
+    t = info[0]
+    try:
+        if t in ("`", "'", "\x1c", "\x1d"):          # Mic-E
+            pos = _parse_mice(dest, info)
+            if pos:
+                rec.update(pos); rec["type"] = "position"
+        elif t in ("!", "="):                         # position, no timestamp
+            pos = _parse_position(info[1:])
+            if pos:
+                rec.update(pos); rec["type"] = "position"
+        elif t in ("@", "/"):                         # position, with timestamp
+            rec["timestamp"] = info[1:8]
+            pos = _parse_position(info[8:])
+            if pos:
+                rec.update(pos); rec["type"] = "position"
+        elif t == ":":                                # message / ack
+            msg = _parse_message(info)
+            if msg:
+                rec.update(msg)
+                rec["type"] = "ack" if msg["msgkind"] in ("ack", "rej") else "message"
+        elif t == ";":                                # object
+            rec["object"] = info[1:10].strip()
+            rec["object_live"] = (len(info) > 10 and info[10] == "*")
+            pos = _parse_position(info[18:]) if len(info) > 18 else {}
+            if pos:
+                rec.update(pos)
+            rec["type"] = "object"
+        elif t == ">":                                # status
+            rec["type"] = "status"; rec["comment"] = info[1:].strip()
+        elif t == "_":                                # positionless weather
+            rec["type"] = "weather"
+            rec.update(_extract_extra(info))
+        elif t == "T":                                # telemetry
+            rec["type"] = "telemetry"; rec["comment"] = info[1:].strip()
+        else:
+            rec["comment"] = info.strip()
+    except Exception:
+        pass
+    return rec
+
+
+# --------------------------------------------------------------------------
+# Live hub — RF decoder + APRS-IS client feeding one packet/station/message set
+# --------------------------------------------------------------------------
+
+class AprsHub:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._packets = []
+        self._stations = {}
+        self._messages = []
+        self._seq = 0
+        # RF
+        self._fm = None; self._mm = None
+        self._rf_thread = None; self._rf_stop = threading.Event()
+        self._rf_freq = None; self._rf_err = None
+        # APRS-IS
+        self._sock = None
+        self._is_thread = None; self._is_stop = threading.Event()
+        self._is_connected = False; self._is_err = None
+        self._call = "N0CALL"; self._pass = -1; self._filter = ""
+        self._write = False
+
+    # -- ingest -----------------------------------------------------------
+    def _ingest(self, rec, source):
+        if not rec:
+            return
+        with self._lock:
+            self._seq += 1
+            rec = dict(rec)
+            rec["seq"] = self._seq
+            rec["ts"] = time.time()
+            rec["src_kind"] = source              # 'rf' | 'is' | 'tx'
+            self._packets.append(rec)
+            if len(self._packets) > _MSG_RING:
+                self._packets = self._packets[-_MSG_RING:]
+            if rec.get("lat") is not None and rec.get("lon") is not None:
+                self._stations[rec["source"]] = {
+                    "call": rec["source"], "lat": rec["lat"], "lon": rec["lon"],
+                    "symbol": rec.get("symbol"), "comment": rec.get("comment"),
+                    "course": rec.get("course"), "speed_kt": rec.get("speed_kt"),
+                    "altitude_ft": rec.get("altitude_ft"), "ts": rec["ts"],
+                    "src_kind": source}
+                if len(self._stations) > _STATION_MAX:
+                    old = sorted(self._stations.items(), key=lambda kv: kv[1]["ts"])
+                    for k, _ in old[:len(self._stations) - _STATION_MAX]:
+                        self._stations.pop(k, None)
+            if rec["type"] in ("message", "ack"):
+                self._messages.append(rec)
+                if len(self._messages) > _MSG_RING:
+                    self._messages = self._messages[-_MSG_RING:]
+
+    # -- RF (rtl_fm | multimon-ng) ---------------------------------------
+    def start_rf(self, freq_hz):
+        try:
+            freq_hz = int(float(freq_hz))
+        except (TypeError, ValueError):
+            return {"ok": False, "error": "bad frequency"}
+        if not (24_000_000 <= freq_hz <= 1_766_000_000):
+            return {"ok": False, "error": "frequency out of RTL-SDR range"}
+        with self._lock:
+            self._stop_rf_locked()
+            self._rf_stop.clear()
+            self._rf_freq = freq_hz; self._rf_err = None
+            ppm = 0; gain = None
+            try:
+                import rtl_sdr
+                tun = rtl_sdr.get_tuning()
+                ppm = tun.get("ppm", 0) or 0
+                gain = None if tun.get("gain_is_auto") else tun.get("gain")
+            except Exception:
+                pass
+            fm = [_RTL_FM, "-f", str(freq_hz), "-M", "fm", "-s", "22050", "-l", "0", "-p", str(ppm)]
+            if gain is not None:
+                fm += ["-g", str(gain)]
+            fm += ["-"]
+            mm = [_MULTIMON, "-a", "AFSK1200", "-A", "-t", "raw", "-"]
+            try:
+                self._fm = subprocess.Popen(fm, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+                self._mm = subprocess.Popen(mm, stdin=self._fm.stdout, stdout=subprocess.PIPE,
+                                            stderr=subprocess.DEVNULL, text=True)
+                self._fm.stdout.close()
+            except Exception as exc:
+                self._rf_err = "failed to launch rtl_fm|multimon-ng: %s" % exc
+                self._stop_rf_locked()
+                return {"ok": False, "error": self._rf_err}
+            self._rf_thread = threading.Thread(target=self._rf_loop, daemon=True, name="aprs-rf")
+            self._rf_thread.start()
+        return {"ok": True, "freq_hz": freq_hz}
+
+    def _rf_loop(self):  # pragma: no cover - hardware path
+        try:
+            for line in self._mm.stdout:
+                if self._rf_stop.is_set():
+                    break
+                if "APRS" not in line and ">" not in line:
+                    continue
+                rec = parse_aprs(line)
+                if rec:
+                    self._ingest(rec, "rf")
+        except Exception as exc:
+            self._rf_err = str(exc)
+
+    def _stop_rf_locked(self):
+        self._rf_stop.set()
+        for p in (self._mm, self._fm):
+            if p:
+                try:
+                    p.terminate(); p.wait(timeout=2)
+                except Exception:
+                    try:
+                        p.kill()
+                    except Exception:
+                        pass
+        self._mm = None; self._fm = None
+
+    def stop_rf(self):
+        with self._lock:
+            self._stop_rf_locked()
+            self._rf_freq = None
+        return {"ok": True}
+
+    # -- APRS-IS ----------------------------------------------------------
+    def connect_is(self, callsign=None, passcode=None, filter_str=None, igate=False):
+        call = (callsign or "N0CALL").strip().upper()
+        try:
+            pc = int(passcode) if passcode not in (None, "") else -1
+        except (TypeError, ValueError):
+            pc = -1
+        write = valid_passcode(call, pc) and call != "N0CALL"
+        with self._lock:
+            self._stop_is_locked()
+            self._is_stop.clear()
+            self._call = call; self._pass = pc
+            self._filter = (filter_str or "").strip(); self._write = write
+            self._igate = bool(igate) and write
+            self._is_err = None
+            self._is_thread = threading.Thread(target=self._is_loop, daemon=True, name="aprs-is")
+            self._is_thread.start()
+        return {"ok": True, "write": write, "callsign": call}
+
+    def _is_loop(self):  # pragma: no cover - network path
+        try:
+            s = socket.create_connection((APRS_IS_HOST, APRS_IS_PORT), timeout=15)
+            s.settimeout(30)
+            self._sock = s
+            login = "user %s pass %s vers RagnarAPRS 1.0" % (self._call, self._pass)
+            if self._filter:
+                login += " filter %s" % self._filter
+            s.sendall((login + "\r\n").encode("ascii", "replace"))
+            self._is_connected = True
+            buf = b""
+            while not self._is_stop.is_set():
+                try:
+                    data = s.recv(4096)
+                except socket.timeout:
+                    try:
+                        s.sendall(b"# keepalive\r\n")
+                    except Exception:
+                        break
+                    continue
+                if not data:
+                    break
+                buf += data
+                while b"\n" in buf:
+                    raw, buf = buf.split(b"\n", 1)
+                    line = raw.decode("utf-8", "replace").strip("\r")
+                    if not line or line.startswith("#"):
+                        continue
+                    rec = parse_aprs(line)
+                    if rec:
+                        self._ingest(rec, "is")
+        except Exception as exc:
+            self._is_err = str(exc)
+        finally:
+            self._is_connected = False
+            try:
+                if self._sock:
+                    self._sock.close()
+            except Exception:
+                pass
+            self._sock = None
+
+    def _stop_is_locked(self):
+        self._is_stop.set()
+        if self._sock:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+        self._sock = None
+        self._is_connected = False
+
+    def disconnect_is(self):
+        with self._lock:
+            self._stop_is_locked()
+        return {"ok": True}
+
+    def send_message(self, to, text):
+        with self._lock:
+            if not (self._sock and self._is_connected and self._write):
+                return {"ok": False, "error": "APRS-IS write access required (valid callsign + passcode)"}
+            to = (to or "").strip().upper()[:9]
+            text = (text or "").strip()
+            if not to or not text:
+                return {"ok": False, "error": "recipient and message required"}
+            text = text.replace("|", " ").replace("~", " ").replace("{", "(")[:67]
+            self._seq += 1
+            msgno = self._seq % 100000
+            frame = "%s>APRS,TCPIP*::%-9s:%s{%d" % (self._call, to, text, msgno)
+            try:
+                self._sock.sendall((frame + "\r\n").encode("ascii", "replace"))
+            except Exception as exc:
+                return {"ok": False, "error": "send failed: %s" % exc}
+        # log the outbound message into the feed
+        self._ingest({"source": self._call, "dest": "APRS", "path": ["TCPIP*"],
+                      "type": "message", "addressee": to, "text": text,
+                      "msgno": str(msgno), "msgkind": "message", "raw": frame,
+                      "outbound": True}, "tx")
+        return {"ok": True, "to": to, "msgno": msgno}
+
+    # -- read models ------------------------------------------------------
+    def status(self):
+        with self._lock:
+            return {
+                "rf_running": bool(self._rf_thread and self._rf_thread.is_alive()),
+                "rf_freq_hz": self._rf_freq, "rf_error": self._rf_err,
+                "is_connected": self._is_connected, "is_error": self._is_err,
+                "is_write": self._write, "callsign": self._call, "filter": self._filter,
+                "packets": self._seq, "stations": len(self._stations),
+                "messages": len(self._messages),
+            }
+
+    def packets(self, since=0, limit=200):
+        try:
+            since = int(since)
+        except (TypeError, ValueError):
+            since = 0
+        with self._lock:
+            new = [p for p in self._packets if p["seq"] > since]
+            return {"packets": new[-limit:], "seq": self._seq}
+
+    def stations(self):
+        with self._lock:
+            return {"stations": list(self._stations.values()), "count": len(self._stations)}
+
+    def messages(self, since=0):
+        try:
+            since = int(since)
+        except (TypeError, ValueError):
+            since = 0
+        with self._lock:
+            return {"messages": [m for m in self._messages if m["seq"] > since], "seq": self._seq}
+
+    def stop_all(self):
+        with self._lock:
+            self._stop_rf_locked(); self._stop_is_locked(); self._rf_freq = None
+        return {"ok": True}
+
+
+_hub = AprsHub()
+
+
+# --------------------------------------------------------------------------
+# Detect + module API
+# --------------------------------------------------------------------------
+
+def _have(path):
+    try:
+        return subprocess.run([path, "-h"], capture_output=True, text=True,
+                              timeout=4).returncode != 127 or os.path.exists(path)
+    except FileNotFoundError:
+        return os.path.exists(path)
+    except Exception:
+        return os.path.exists(path)
+
+
+def detect():
+    """Report RF-decode capability (rtl_fm + multimon-ng + a dongle).
+
+    APRS-IS needs only a network connection, so it's usable even when the RF
+    tools/dongle aren't present — reported via ``is_available``.
+    """
+    tools = {"rtl_fm": _have(_RTL_FM), "multimon_ng": _have(_MULTIMON)}
+    usb = None
+    try:
+        import rtl_sdr
+        usb = rtl_sdr.probe_usb()[0]
+    except Exception:
+        usb = None
+    device = usb is not None
+    rf_ok = tools["rtl_fm"] and tools["multimon_ng"] and device
+    err = None
+    if not tools["multimon_ng"]:
+        err = "multimon-ng not installed (apt install multimon-ng)"
+    elif not tools["rtl_fm"]:
+        err = "rtl_fm not installed (apt install rtl-sdr)"
+    elif not device:
+        err = "no RTL-SDR on the USB bus — plug a dongle in"
+    return {"available": rf_ok, "rf_available": rf_ok, "is_available": True,
+            "tools": tools, "device_present": device, "usb_id": usb,
+            "regions": {k: v["rf_hz"] for k, v in APRS_REGIONS.items()},
+            "region_filters": {k: v["is_filter"] for k, v in APRS_REGIONS.items()},
+            "tools_installed": tools["multimon_ng"] and tools["rtl_fm"], "error": err}
+
+
+def start_rf(freq_hz=None):
+    d = detect()
+    if not d.get("rf_available"):
+        return {"ok": False, "error": d.get("error", "APRS RF decode unavailable")}
+    if freq_hz is None:
+        freq_hz = APRS_REGIONS["North America (144.390)"]["rf_hz"]
+    return _hub.start_rf(freq_hz)
+
+
+def stop_rf():
+    return _hub.stop_rf()
+
+
+def connect_is(callsign=None, passcode=None, filter_str=None, igate=False):
+    return _hub.connect_is(callsign, passcode, filter_str, igate)
+
+
+def disconnect_is():
+    return _hub.disconnect_is()
+
+
+def send_message(to, text):
+    return _hub.send_message(to, text)
+
+
+def stop():
+    return _hub.stop_rf()          # only RF holds the dongle; leave APRS-IS running
+
+
+def stop_all():
+    return _hub.stop_all()
+
+
+def status():
+    st = _hub.status()
+    st["detect"] = detect()
+    return st
+
+
+def packets(since=0):
+    return _hub.packets(since=since)
+
+
+def stations():
+    return _hub.stations()
+
+
+def messages(since=0):
+    return _hub.messages(since=since)
+
+
+def install():
+    """multimon-ng is in the apt repos (also powers Pager Decode)."""
+    if _have(_MULTIMON):
+        return {"ok": True, "already": True, "detect": detect()}
+    env = dict(os.environ, DEBIAN_FRONTEND="noninteractive")
+    out = ""
+    for attempt in range(2):
+        try:
+            p = subprocess.run(["apt-get", "install", "-y", "--no-install-recommends", "multimon-ng"],
+                               capture_output=True, text=True, timeout=300, check=False, env=env)
+            out = (p.stdout or "") + (p.stderr or "")
+        except Exception as exc:
+            return {"ok": False, "error": str(exc), "detect": detect()}
+        if _have(_MULTIMON):
+            break
+        if "Unable to locate package" in out and attempt == 0:
+            try:
+                subprocess.run(["apt-get", "update"], capture_output=True, text=True,
+                               timeout=180, check=False, env=env)
+            except Exception:
+                pass
+    ok = _have(_MULTIMON)
+    return {"ok": ok, "detect": detect(),
+            "output": "\n".join(out.strip().splitlines()[-10:]),
+            "error": None if ok else "apt could not install multimon-ng"}
+
+
+# --------------------------------------------------------------------------
+# Selftest (pure parser + passcode, no hardware/network)
+# --------------------------------------------------------------------------
+
+def _mice_encode(lat, lon, course, speed):
+    """Minimal Mic-E encoder — selftest only (values chosen to avoid offset ranges)."""
+    ns = "N" if lat >= 0 else "S"; ew = "W" if lon < 0 else "E"
+    alat = abs(lat); latd = int(alat); latm = (alat - latd) * 60
+    digs = ("%02d%05.2f" % (latd, latm)).replace(".", "")      # DDMMmm -> 6 digits
+    alon = abs(lon); lond = int(alon); lonm = (alon - lond) * 60
+    lonoff = 100 if lond >= 100 else 0
+    dest = ""
+    for i, dch in enumerate(digs[:6]):
+        v = int(dch)
+        one = (i == 3 and ns == "N") or (i == 4 and lonoff) or (i == 5 and ew == "W")
+        dest += chr((80 if one else 48) + v)
+    b1 = chr(lond - lonoff + 28); b2 = chr(int(lonm) + 28)
+    b3 = chr(int(round((lonm - int(lonm)) * 100)) + 28)
+    b4 = chr(speed // 10 + 28); b5 = chr((speed % 10) * 10 + course // 100 + 28); b6 = chr(course % 100 + 28)
+    info = "`" + b1 + b2 + b3 + b4 + b5 + b6 + ">/" + "test"
+    return dest, info
+
+
+def selftest():
+    results = []
+
+    def check(name, ok, detail=""):
+        results.append({"name": name, "pass": bool(ok), "detail": detail})
+
+    # header + uncompressed position
+    p = parse_aprs("G0TEST-9>APRS,WIDE1-1,WIDE2-1:=5132.07N/00007.24W-Ragnar test")
+    check("parse: uncompressed position + header",
+          p and p["source"] == "G0TEST-9" and p["type"] == "position"
+          and abs(p["lat"] - 51.5345) < 0.001 and abs(p["lon"] - (-0.1207)) < 0.001
+          and p["path"] == ["WIDE1-1", "WIDE2-1"], str(p))
+
+    # position with timestamp + course/speed + altitude in comment
+    p = parse_aprs("N0CALL>APRS,TCPIP*:@092345z4903.50N/07201.75W>088/036/A=001234moving")
+    check("parse: timestamped position + course/speed/altitude",
+          p and abs(p["lat"] - 49.0583) < 0.001 and abs(p["lon"] - (-72.0292)) < 0.001
+          and p.get("course") == 88 and p.get("speed_kt") == 36 and p.get("altitude_ft") == 1234, str(p))
+
+    # compressed position
+    p = parse_aprs("M0XER>APRS:=/5L!!<*e7> sT")
+    check("parse: compressed position decodes to a sane lat/lon",
+          p and p.get("lat") is not None and -90 <= p["lat"] <= 90
+          and -180 <= p["lon"] <= 180 and p["type"] == "position", str(p))
+
+    # message
+    p = parse_aprs("N0CALL-7>APRS,WIDE1-1::WB2OSZ   :Hello there{003")
+    check("parse: message to addressee + msgno",
+          p and p["type"] == "message" and p["addressee"] == "WB2OSZ"
+          and p["text"] == "Hello there" and p["msgno"] == "003", str(p))
+
+    # ack
+    p = parse_aprs("WB2OSZ>APRS::N0CALL-7 :ack003")
+    check("parse: message ack",
+          p and p["type"] == "ack" and p["addressee"] == "N0CALL-7" and p["msgno"] == "003", str(p))
+
+    # status
+    p = parse_aprs("N0CALL>APRS:>Net control tonight 8pm")
+    check("parse: status", p and p["type"] == "status" and "Net control" in p["comment"], str(p))
+
+    # Mic-E round trip (33.4273N, 12.147W, course 251, speed 20 kt)
+    dest, info = _mice_encode(33.427333, -12.147, 251, 20)
+    p = parse_aprs("VK2XYZ-9>%s,WIDE1-1:%s" % (dest, info))
+    check("parse: Mic-E position + course/speed round-trips",
+          p and p.get("mice") and abs(p["lat"] - 33.4273) < 0.01
+          and abs(p["lon"] - (-12.147)) < 0.01 and p["course"] == 251 and p["speed_kt"] == 20,
+          str(p))
+
+    # object
+    p = parse_aprs("N0CALL>APRS:;LEADER   *092345z4903.50N/07201.75W>Team leader")
+    check("parse: object with position",
+          p and p["type"] == "object" and p["object"] == "LEADER"
+          and abs(p["lat"] - 49.0583) < 0.001, str(p))
+
+    # noise / server lines rejected
+    check("parse: junk and server comments -> None",
+          parse_aprs("# aprsc 2.1.10") is None and parse_aprs("") is None
+          and parse_aprs("not a packet") is None)
+
+    # passcode: deterministic, in range, and matches the known algorithm
+    pc = aprs_passcode("N0CALL")
+    check("passcode: deterministic + valid range",
+          0 <= pc <= 0x7FFF and aprs_passcode("n0call-7") == pc
+          and valid_passcode("N0CALL", pc) and not valid_passcode("N0CALL", pc + 1), "pc=%d" % pc)
+
+    # regions cover every continent + sane RF freqs
+    check("regions: multi-continent presets in the 2 m band",
+          len(APRS_REGIONS) >= 10
+          and all(144_000_000 <= v["rf_hz"] <= 146_000_000 for v in APRS_REGIONS.values()), "")
+
+    # hub ingest / station map without hardware
+    hub = AprsHub()
+    hub._ingest(parse_aprs("G0TEST>APRS:=5132.07N/00007.24W-hi"), "is")
+    hub._ingest(parse_aprs("N0CALL>APRS::G0TEST   :ping{1"), "is")
+    check("hub: ingest builds station map + message feed",
+          hub.stations()["count"] == 1 and len(hub.messages()["messages"]) == 1
+          and hub.status()["packets"] == 2, str(hub.status()))
+
+    passed = sum(1 for r in results if r["pass"])
+    return {"pass": passed == len(results), "passed": passed,
+            "total": len(results), "results": results}
+
+
+def _main(argv):
+    import json
+    cmd = argv[1] if len(argv) > 1 else "detect"
+    if cmd == "detect":
+        print(json.dumps(detect(), indent=2))
+    elif cmd == "parse":
+        print(json.dumps(parse_aprs(argv[2] if len(argv) > 2 else ""), indent=2))
+    elif cmd == "passcode":
+        print(aprs_passcode(argv[2] if len(argv) > 2 else "N0CALL"))
+    elif cmd == "selftest":
+        r = selftest()
+        for x in r["results"]:
+            print("  [%s] %s%s" % ("PASS" if x["pass"] else "FAIL", x["name"],
+                                   "" if x["pass"] else "  -> " + x["detail"]))
+        print("\n%d/%d checks pass — %s" % (r["passed"], r["total"],
+                                            "OK" if r["pass"] else "FAILURES"))
+        return 0 if r["pass"] else 1
+    else:
+        print("usage: aprs.py [detect|parse <tnc2>|passcode <call>|selftest]")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv))

--- a/demos/aprs.html
+++ b/demos/aprs.html
@@ -1,0 +1,360 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>APRS</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --ground:#0a0e14; --panel:#111722; --panel-2:#0d1420; --line:#1e2836; --line-soft:#161d29;
+    --ink:#e8eef6; --ink-dim:#c2ccd8; --muted:#7c8aa0; --cyan:#38bdc9; --accent:#f5b942;
+    --live:#3fb56b; --idle:#546074; --aprs:#5fd08a; --rf:#f0a35e; --is:#5ec8f0; --tx:#c98bf0;
+    --disp:'Chakra Petch',system-ui,sans-serif; --mono:'IBM Plex Mono',ui-monospace,monospace; --head:'Chakra Petch',system-ui,sans-serif; --radius:12px;
+  }
+  *{box-sizing:border-box} html,body{margin:0}
+  body{background:var(--ground);color:var(--ink);font-family:var(--disp);line-height:1.5;padding:20px;min-height:100vh;
+    background-image:radial-gradient(120% 80% at 50% -10%, rgba(95,208,138,.06), transparent 60%), linear-gradient(var(--ground),var(--ground));}
+  .wrap{max-width:none;margin:0 auto}
+  header{display:flex;flex-wrap:wrap;align-items:flex-end;justify-content:space-between;gap:14px;margin-bottom:16px}
+  .eyebrow{display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:11px;letter-spacing:.22em;text-transform:uppercase;color:var(--muted)}
+  .eyebrow .dot{width:7px;height:7px;border-radius:50%;background:var(--aprs);box-shadow:0 0 10px var(--aprs)}
+  h1{font-family:var(--head);font-weight:700;font-size:34px;margin:2px 0 0}
+  .sub{color:var(--ink-dim);font-size:13px;max-width:600px}
+  .tag{font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;padding:2px 7px;border-radius:5px;border:1px solid}
+  .tag.live{color:var(--live);border-color:rgba(63,181,107,.45);background:rgba(63,181,107,.10)}
+  .tag.idle{color:var(--idle);border-color:rgba(84,96,116,.4);background:rgba(84,96,116,.10)}
+  .stat{display:flex;flex-direction:column;gap:1px} .stat .k{font-family:var(--mono);font-size:9px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)} .stat .v{font-family:var(--mono);font-size:14px;color:var(--aprs)}
+  .bar{display:flex;flex-wrap:wrap;align-items:center;gap:8px 14px;padding:12px 14px;background:var(--panel-2);border:1px solid var(--line);border-radius:var(--radius);margin-bottom:16px}
+  .grp{display:flex;align-items:center;gap:7px} .lbl{font-family:var(--mono);font-size:9px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted)}
+  button.ctl,a.ctl{font-family:var(--mono);font-size:12px;color:var(--ink-dim);background:var(--panel);border:1px solid var(--line);padding:7px 13px;border-radius:7px;cursor:pointer;text-decoration:none;transition:border-color .15s,color .15s}
+  button.ctl:hover,a.ctl:hover{border-color:var(--aprs);color:#fff} a.back{border-color:rgba(56,189,201,.4);color:var(--cyan)}
+  button.go[aria-pressed="true"]{background:rgba(63,181,107,.14);border-color:rgba(63,181,107,.5);color:var(--live)}
+  button.ctl:disabled{opacity:.45;cursor:not-allowed}
+  select.tin,input.tin{font-family:var(--mono);font-size:12px;color:var(--ink);background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:6px 8px}
+  input.tin{width:110px}
+  .grid{display:grid;grid-template-columns:minmax(0,1.6fr) minmax(0,1fr);gap:16px}
+  @media(max-width:860px){.grid{grid-template-columns:1fr}}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);overflow:hidden;position:relative}
+  .cap{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:11px 14px;border-bottom:1px solid var(--line-soft);background:var(--panel-2)}
+  .cap .t{font-family:var(--head);font-weight:600;font-size:14px} .cap .c{font-family:var(--mono);font-size:11px;color:var(--muted)}
+  .maphold{position:relative} canvas{display:block;width:100%;height:auto}
+  .legend{position:absolute;left:10px;bottom:10px;display:flex;gap:12px;font-family:var(--mono);font-size:10px;color:var(--muted);background:rgba(10,14,20,.7);padding:5px 9px;border-radius:6px;border:1px solid var(--line-soft)}
+  .legend b{display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:4px;vertical-align:middle}
+  .sect{padding:12px 14px;border-bottom:1px solid var(--line-soft)}
+  .sect:last-child{border-bottom:none}
+  .sect h3{margin:0 0 8px;font-family:var(--mono);font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);font-weight:500}
+  .row{display:flex;flex-wrap:wrap;align-items:center;gap:8px}
+  .msgs{max-height:240px;overflow-y:auto;font-family:var(--mono);font-size:12px}
+  .msg{padding:6px 4px;border-bottom:1px solid var(--line-soft);display:flex;gap:8px;align-items:baseline}
+  .msg .who{color:var(--aprs);min-width:78px} .msg.out .who{color:var(--tx)} .msg .arr{color:var(--muted)} .msg .to{color:var(--is);min-width:78px} .msg .tx{color:var(--ink);overflow-wrap:anywhere}
+  .feedtbl{max-height:340px;overflow:auto}
+  table{width:100%;border-collapse:collapse;font-family:var(--mono);font-size:11.5px}
+  th{position:sticky;top:0;background:var(--panel-2);color:var(--muted);font-weight:500;text-align:left;padding:7px 10px;letter-spacing:.05em;text-transform:uppercase;font-size:9px;border-bottom:1px solid var(--line)}
+  td{padding:6px 10px;border-bottom:1px solid var(--line-soft);color:var(--ink-dim);vertical-align:top;white-space:nowrap}
+  td.cmt{white-space:normal;overflow-wrap:anywhere;color:var(--ink);width:99%}
+  tr.sel td{background:rgba(95,208,138,.1)}
+  .src{font-size:9px;padding:1px 5px;border-radius:4px;border:1px solid var(--line)}
+  .src.rf{color:var(--rf);border-color:rgba(240,163,94,.4)} .src.is{color:var(--is);border-color:rgba(94,200,240,.4)} .src.tx{color:var(--tx);border-color:rgba(201,139,240,.4)}
+  .empty{padding:24px 14px;text-align:center;color:var(--muted);font-family:var(--mono);font-size:12px}
+  .veil{position:absolute;inset:0;display:none;flex-direction:column;align-items:center;justify-content:center;gap:8px;background:rgba(5,8,13,.86);text-align:center;padding:22px;z-index:5}
+  .veil.show{display:flex} .veil .vt{font-family:var(--head);font-size:18px} .veil .vs{font-family:var(--mono);font-size:12px;color:var(--muted);max-width:520px}
+  .hint{font-family:var(--mono);font-size:10.5px;color:var(--muted)}
+  footer{margin-top:16px;font-family:var(--mono);font-size:11px;color:var(--muted);line-height:1.6}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div>
+      <div class="eyebrow"><span class="dot"></span> Ragnar · Signal Intelligence</div>
+      <h1>APRS</h1>
+      <div class="sub">Ham-radio packet: positions, weather &amp; <b>messages</b>. Listen off-air with the RTL-SDR, and/or connect to <b>APRS-IS</b> (the Internet backbone) to watch any region and send messages worldwide via IGates.</div>
+    </div>
+    <div style="display:flex;gap:16px;align-items:flex-end">
+      <div class="stat"><span class="k">Packets</span><span class="v" id="s-pkts">—</span></div>
+      <div class="stat"><span class="k">Stations</span><span class="v" id="s-stns">—</span></div>
+      <div class="stat"><span class="k">Messages</span><span class="v" id="s-msgs">—</span></div>
+    </div>
+  </header>
+
+  <div class="bar">
+    <div class="grp"><a href="/" class="ctl back">&#8592;&nbsp;Ragnar</a></div>
+    <div class="grp"><a href="/rf-waterfall" class="ctl">〜&nbsp;RF Waterfall</a></div>
+    <div class="grp"><span class="lbl">Region</span><select class="tin" id="region" style="width:auto"></select></div>
+    <div class="grp"><span class="tag idle" id="rftag">RF idle</span></div>
+    <div class="grp"><span class="tag idle" id="istag">APRS-IS off</span></div>
+  </div>
+
+  <div class="grid">
+    <div class="card">
+      <div class="cap"><span class="t">Station map</span><span class="c" id="mapcap">no stations yet</span></div>
+      <div class="maphold">
+        <canvas id="map" width="900" height="560"></canvas>
+        <div class="legend"><span><b style="background:var(--rf)"></b>RF</span><span><b style="background:var(--is)"></b>APRS-IS</span><span><b style="background:var(--tx)"></b>you</span></div>
+        <div class="veil" id="veil"><div class="vt"></div><div class="vs"></div>
+          <button class="ctl" id="veil-install" style="display:none;margin-top:6px;border-color:rgba(95,208,138,.5);color:var(--aprs)">⬇ Install multimon-ng</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="cap"><span class="t">Sources &amp; messaging</span></div>
+
+      <div class="sect">
+        <h3>RF · off-air (RTL-SDR)</h3>
+        <div class="row">
+          <button class="ctl go" id="rf-btn" aria-pressed="false" title="Start / stop off-air APRS decode (uses the RTL-SDR)">&#9654;&nbsp;RF Start</button>
+          <span class="lbl">MHz</span><input class="tin" id="rf-freq" type="number" step="0.001" style="width:92px" placeholder="144.390">
+          <span class="hint" id="rf-hint">receive-only</span>
+        </div>
+      </div>
+
+      <div class="sect">
+        <h3>APRS-IS · Internet</h3>
+        <div class="row" style="margin-bottom:6px">
+          <button class="ctl go" id="is-btn" aria-pressed="false" title="Connect / disconnect the APRS-IS Internet feed">&#9654;&nbsp;Connect</button>
+          <span class="lbl">Filter</span><input class="tin" id="is-filter" style="width:150px" title="APRS-IS server filter, e.g. r/lat/lon/km" placeholder="r/39.8/-98.6/3000">
+        </div>
+        <div class="row">
+          <span class="lbl">Call</span><input class="tin" id="is-call" style="width:88px" placeholder="N0CALL">
+          <span class="lbl">Passcode</span><input class="tin" id="is-pass" style="width:74px" placeholder="-1" title="APRS-IS passcode for your callsign (leave blank/-1 to receive only)">
+          <span class="hint" id="is-hint">read-only (no callsign)</span>
+        </div>
+      </div>
+
+      <div class="sect">
+        <h3>Messages</h3>
+        <div class="msgs" id="msgs"><div class="empty">No messages yet.</div></div>
+        <div class="row" style="margin-top:8px">
+          <input class="tin" id="m-to" style="width:88px" placeholder="TO-CALL" title="Recipient callsign">
+          <input class="tin" id="m-text" style="flex:1;min-width:120px" placeholder="message…" maxlength="67">
+          <button class="ctl" id="m-send" disabled title="Send via APRS-IS — needs a valid callsign + passcode">Send ▸</button>
+        </div>
+        <div class="hint" id="m-hint" style="margin-top:5px">Sending needs APRS-IS write access (your ham callsign + passcode).</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card" style="margin-top:16px">
+    <div class="cap"><span class="t">Packet feed</span><span class="c" id="feedcap"></span></div>
+    <div class="feedtbl">
+      <table>
+        <thead><tr><th>Time</th><th>Src</th><th>Station</th><th>Type</th><th>Info</th></tr></thead>
+        <tbody id="feed"><tr><td colspan="5" class="empty">Start RF or connect APRS-IS…</td></tr></tbody>
+      </table>
+    </div>
+  </div>
+
+  <footer>
+    <div><b>How it works:</b> RF decode is <code>rtl_fm | multimon-ng -a AFSK1200</code> — receive-only, no licence needed to listen. APRS-IS is a TCP client to the global network: a read-only login streams any region via a server filter; with your own callsign + passcode you get write access to send messages, which IGates relay to the recipient.</div>
+    <div style="margin-top:6px"><b>One dongle:</b> RF APRS shares the RTL-SDR with the sweep / ADS-B / pager / VOR — starting one stops the others. APRS-IS is independent and keeps running. <b>Legality:</b> sending injects packets under your callsign on the ham network — only licensed operators should transmit/send. No RF transmit is performed here.</div>
+  </footer>
+</div>
+
+<script>
+(function(){
+  "use strict";
+  var DEMO_ON=false, pseq=0, mseq=0, packets=[], stations={}, messages=[], sel=null, isWrite=false;
+  var cv=document.getElementById('map'), ctx=cv.getContext('2d');
+  var veil=document.getElementById('veil'), veilT=veil.querySelector('.vt'), veilS=veil.querySelector('.vs'), veilInstall=document.getElementById('veil-install');
+  function esc(s){return String(s==null?'':s).replace(/[&<>"]/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];});}
+  function hhmm(ts){ return new Date((ts||Date.now()/1000)*1000).toLocaleTimeString(); }
+
+  var REGIONS={}, RFILTERS={};
+  var regionSel=document.getElementById('region'), rfFreq=document.getElementById('rf-freq'),
+      isFilter=document.getElementById('is-filter'), isCall=document.getElementById('is-call'), isPass=document.getElementById('is-pass');
+  function fillRegions(freqs, filters){ REGIONS=freqs||{}; RFILTERS=filters||{}; var keys=Object.keys(REGIONS);
+    regionSel.innerHTML=keys.map(function(k){return '<option value="'+esc(k)+'">'+esc(k)+'</option>';}).join('')||'<option>—</option>';
+    if(keys.length){ applyRegion(keys[0]); } }
+  function applyRegion(k){ if(REGIONS[k]) rfFreq.value=(REGIONS[k]/1e6); if(RFILTERS[k]&&!isFilter.value) isFilter.value=RFILTERS[k]; if(RFILTERS[k]) isFilter.value=RFILTERS[k]; }
+  regionSel.addEventListener('change',function(){ applyRegion(regionSel.value); });
+
+  function showVeil(t,s,inst){veilT.textContent=t;veilS.textContent=s||'';veil.classList.add('show');veilInstall.style.display=inst?'inline-block':'none';}
+  function hideVeil(){veil.classList.remove('show');}
+  veilInstall.addEventListener('click',function(){ veilInstall.textContent='Installing…'; veilInstall.disabled=true;
+    fetch('/api/net/aprs/install',{method:'POST'}).then(function(r){return r.json();}).then(function(res){
+      veilInstall.textContent='⬇ Install multimon-ng'; veilInstall.disabled=false;
+      if(res&&res.ok){ hideVeil(); } else showVeil('Install did not complete',(res&&res.error)||'apt failed',true); }).catch(function(){});
+  });
+
+  // ---- map (auto-fit lat/lon scatter with graticule) ----
+  function drawMap(){
+    var w=cv.width,h=cv.height; ctx.clearRect(0,0,w,h);
+    ctx.fillStyle='#0b1119'; ctx.fillRect(0,0,w,h);
+    var list=Object.keys(stations).map(function(k){return stations[k];}).filter(function(s){return s.lat!=null&&s.lon!=null;});
+    document.getElementById('mapcap').textContent=list.length?(list.length+' stations'):'no stations yet';
+    if(!list.length){ ctx.fillStyle='#33404f'; ctx.font="15px 'IBM Plex Mono',monospace"; ctx.textAlign='center';
+      ctx.fillText('waiting for positions…', w/2, h/2); return; }
+    var lats=list.map(function(s){return s.lat;}), lons=list.map(function(s){return s.lon;});
+    var la0=Math.min.apply(null,lats), la1=Math.max.apply(null,lats), lo0=Math.min.apply(null,lons), lo1=Math.max.apply(null,lons);
+    var pad=Math.max(0.3,(la1-la0)*0.12,(lo1-lo0)*0.12); la0-=pad;la1+=pad;lo0-=pad;lo1+=pad;
+    if(la1-la0<0.01){la0-=0.5;la1+=0.5;} if(lo1-lo0<0.01){lo0-=0.5;lo1+=0.5;}
+    var M=34;
+    function X(lon){ return M+(lon-lo0)/(lo1-lo0)*(w-2*M); }
+    function Y(lat){ return M+(la1-lat)/(la1-la0)*(h-2*M); }
+    // graticule
+    ctx.strokeStyle='#141c27'; ctx.fillStyle='#3a4757'; ctx.font="9px 'IBM Plex Mono',monospace"; ctx.lineWidth=1;
+    function nice(span){ var steps=[0.1,0.25,0.5,1,2,5,10,15,30]; for(var i=0;i<steps.length;i++){ if(span/steps[i]<=8) return steps[i]; } return 45; }
+    var gs=nice(Math.max(la1-la0,lo1-lo0));
+    for(var lo=Math.ceil(lo0/gs)*gs; lo<=lo1; lo+=gs){ ctx.beginPath(); ctx.moveTo(X(lo),M); ctx.lineTo(X(lo),h-M); ctx.stroke();
+      ctx.textAlign='center'; ctx.fillText(lo.toFixed(gs<1?1:0), X(lo), h-M+12); }
+    for(var la=Math.ceil(la0/gs)*gs; la<=la1; la+=gs){ ctx.beginPath(); ctx.moveTo(M,Y(la)); ctx.lineTo(w-M,Y(la)); ctx.stroke();
+      ctx.textAlign='right'; ctx.fillText(la.toFixed(gs<1?1:0), M-4, Y(la)+3); }
+    ctx.strokeStyle='#1e2836'; ctx.strokeRect(M,M,w-2*M,h-2*M);
+    // stations
+    var col={rf:'#f0a35e',is:'#5ec8f0',tx:'#c98bf0'};
+    list.sort(function(a,b){return a.ts-b.ts;}).forEach(function(s){
+      var x=X(s.lon),y=Y(s.lat),c=col[s.src_kind]||'#5fd08a',hot=(sel===s.call);
+      ctx.beginPath(); ctx.arc(x,y,hot?6:3.4,0,2*Math.PI); ctx.fillStyle=c; ctx.fill();
+      if(hot){ ctx.strokeStyle='#fff'; ctx.lineWidth=1.5; ctx.stroke(); }
+      if(hot||list.length<=60){ ctx.fillStyle=hot?'#fff':'#8b98ab'; ctx.font=(hot?'bold ':'')+"10px 'IBM Plex Mono',monospace"; ctx.textAlign='left';
+        ctx.fillText(s.call, x+6, y+3); }
+    });
+  }
+  cv.addEventListener('click',function(e){
+    var r=cv.getBoundingClientRect(), sx=cv.width/r.width, sy=cv.height/r.height;
+    var mx=(e.clientX-r.left)*sx, my=(e.clientY-r.top)*sy;
+    var list=Object.keys(stations).map(function(k){return stations[k];}).filter(function(s){return s.lat!=null;});
+    if(!list.length) return;
+    var lats=list.map(function(s){return s.lat;}), lons=list.map(function(s){return s.lon;});
+    var la0=Math.min.apply(null,lats),la1=Math.max.apply(null,lats),lo0=Math.min.apply(null,lons),lo1=Math.max.apply(null,lons);
+    var pad=Math.max(0.3,(la1-la0)*0.12,(lo1-lo0)*0.12); la0-=pad;la1+=pad;lo0-=pad;lo1+=pad;
+    if(la1-la0<0.01){la0-=0.5;la1+=0.5;} if(lo1-lo0<0.01){lo0-=0.5;lo1+=0.5;}
+    var M=34,best=null,bd=1e9;
+    list.forEach(function(s){ var x=M+(s.lon-lo0)/(lo1-lo0)*(cv.width-2*M), y=M+(la1-s.lat)/(la1-la0)*(cv.height-2*M);
+      var d=(x-mx)*(x-mx)+(y-my)*(y-my); if(d<bd){bd=d;best=s;} });
+    if(best&&bd<400){ sel=(sel===best.call?null:best.call); drawMap(); renderFeed(); }
+  });
+
+  // ---- feed + messages ----
+  function renderStats(st){ document.getElementById('s-pkts').textContent=st.packets!=null?st.packets:'—';
+    document.getElementById('s-stns').textContent=st.stations!=null?st.stations:'—';
+    document.getElementById('s-msgs').textContent=st.messages!=null?st.messages:'—'; }
+  function infoText(p){
+    if(p.type==='message') return (p.outbound?'▸ ':'')+'to '+esc(p.addressee||'?')+': '+esc(p.text||'');
+    if(p.type==='ack') return 'ack '+esc(p.addressee||'')+' #'+esc(p.msgno||'');
+    if(p.type==='status') return '“'+esc(p.comment||'')+'”';
+    if(p.type==='object') return 'obj '+esc(p.object||'')+(p.comment?' '+esc(p.comment):'');
+    if(p.type==='weather') return 'wx '+(p.weather?JSON.stringify(p.weather):esc(p.comment||''));
+    var bits=[]; if(p.lat!=null) bits.push(p.lat.toFixed(4)+','+p.lon.toFixed(4));
+    if(p.speed_kt) bits.push(p.speed_kt+'kt'); if(p.course!=null&&p.speed_kt) bits.push(p.course+'°');
+    if(p.altitude_ft) bits.push(p.altitude_ft+'ft'); if(p.comment) bits.push(esc(p.comment));
+    return bits.join(' · ')||esc(p.type);
+  }
+  function renderFeed(){
+    var tb=document.getElementById('feed');
+    document.getElementById('feedcap').textContent=packets.length+' shown';
+    if(!packets.length){ tb.innerHTML='<tr><td colspan="5" class="empty">Start RF or connect APRS-IS…</td></tr>'; return; }
+    tb.innerHTML=packets.slice().reverse().slice(0,250).map(function(p){
+      return '<tr class="'+(sel===p.source?'sel':'')+'">'
+        +'<td>'+hhmm(p.ts)+'</td>'
+        +'<td><span class="src '+(p.src_kind||'')+'">'+esc((p.src_kind||'').toUpperCase())+'</span></td>'
+        +'<td style="color:var(--aprs)">'+esc(p.source||'')+'</td>'
+        +'<td>'+esc(p.type||'')+'</td>'
+        +'<td class="cmt">'+infoText(p)+'</td></tr>'; }).join('');
+  }
+  function renderMsgs(){
+    var el=document.getElementById('msgs');
+    if(!messages.length){ el.innerHTML='<div class="empty">No messages yet.</div>'; return; }
+    el.innerHTML=messages.slice().reverse().slice(0,120).map(function(m){
+      if(m.type==='ack') return '<div class="msg"><span class="who">'+esc(m.source)+'</span><span class="arr">ack→</span><span class="to">'+esc(m.addressee)+'</span><span class="tx">#'+esc(m.msgno||'')+'</span></div>';
+      return '<div class="msg'+(m.outbound?' out':'')+'"><span class="who">'+esc(m.source)+'</span><span class="arr">→</span><span class="to">'+esc(m.addressee||'')+'</span><span class="tx">'+esc(m.text||'')+'</span></div>';
+    }).join('');
+    el.scrollTop=el.scrollHeight;
+  }
+
+  // ---- RF controls ----
+  var rfOn=false;
+  document.getElementById('rf-btn').addEventListener('click',function(){
+    if(rfOn){ rfOn=false; setBtn('rf-btn',false,'&#9654;&nbsp;RF Start'); fetch('/api/net/aprs/rf/stop',{method:'POST'}).catch(function(){}); if(DEMO_ON)demoTick(); return; }
+    var hz=Math.round(parseFloat(rfFreq.value||'144.39')*1e6);
+    rfOn=true; setBtn('rf-btn',true,'&#10074;&#10074;&nbsp;RF Stop');
+    fetch('/api/net/aprs/rf/start',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({freq_hz:hz})})
+      .then(function(r){return r.json();}).then(function(res){ if(res&&res.error){ if(DEMO_ON){demoStart('rf');} else showVeil('Could not start RF',res.error,/multimon/.test(res.error||'')); } }).catch(function(){});
+  });
+  // ---- APRS-IS controls ----
+  var isOn=false;
+  document.getElementById('is-btn').addEventListener('click',function(){
+    if(isOn){ isOn=false; setBtn('is-btn',false,'&#9654;&nbsp;Connect'); fetch('/api/net/aprs/is/disconnect',{method:'POST'}).catch(function(){}); return; }
+    isOn=true; setBtn('is-btn',true,'&#10074;&#10074;&nbsp;Disconnect');
+    var body={callsign:isCall.value||'N0CALL',passcode:isPass.value||'-1',filter:isFilter.value||''};
+    if(DEMO_ON){ demoStart('is'); return; }
+    fetch('/api/net/aprs/is/connect',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)})
+      .then(function(r){return r.json();}).then(function(res){ isWrite=!!(res&&res.write); updateSend(); }).catch(function(){});
+  });
+  function setBtn(id,on,html){ var b=document.getElementById(id); b.setAttribute('aria-pressed',on?'true':'false'); b.innerHTML=html; }
+  function updateSend(){ var b=document.getElementById('m-send');
+    b.disabled=!isWrite; document.getElementById('m-hint').textContent = isWrite
+      ? 'APRS-IS write access — messages send under '+(isCall.value||'your call')+'.'
+      : 'Sending needs APRS-IS write access (your ham callsign + passcode).';
+    document.getElementById('is-hint').textContent = isWrite ? 'write access ✓' : 'read-only (no callsign)'; }
+  isCall.addEventListener('input',function(){ isWrite=false; updateSend(); });
+  document.getElementById('m-send').addEventListener('click',function(){
+    var to=document.getElementById('m-to').value.trim(), tx=document.getElementById('m-text').value.trim();
+    if(!to||!tx) return;
+    if(DEMO_ON){ ingest([{source:isCall.value||'N0CALL',addressee:to.toUpperCase(),text:tx,type:'message',outbound:true,src_kind:'tx',ts:Date.now()/1000,seq:++mseq}]); document.getElementById('m-text').value=''; renderMsgs(); return; }
+    fetch('/api/net/aprs/send',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({to:to,text:tx})})
+      .then(function(r){return r.json();}).then(function(res){ if(res&&res.ok){ document.getElementById('m-text').value=''; } else if(res&&res.error){ document.getElementById('m-hint').textContent=res.error; } }).catch(function(){});
+  });
+
+  // ---- polling ----
+  var poll=null;
+  function pollAll(){
+    fetch('/api/net/aprs/status').then(function(r){return r.json();}).then(function(st){ if(st){ renderStats(st);
+      isWrite=!!st.is_write; updateSend();
+      document.getElementById('rftag').className='tag '+(st.rf_running?'live':'idle'); document.getElementById('rftag').textContent=st.rf_running?('RF '+((st.rf_freq_hz||0)/1e6).toFixed(3)):'RF idle';
+      document.getElementById('istag').className='tag '+(st.is_connected?'live':'idle'); document.getElementById('istag').textContent=st.is_connected?('APRS-IS '+(st.is_write?'(tx)':'(rx)')):'APRS-IS off';
+      if(st.rf_running||st.is_connected) hideVeil();
+    } }).catch(function(){});
+    fetch('/api/net/aprs/packets?since='+pseq).then(function(r){return r.json();}).then(function(d){ if(d&&d.packets&&d.packets.length){ ingest(d.packets); pseq=d.seq; } }).catch(function(){});
+  }
+  function ingest(pkts){
+    pkts.forEach(function(p){ packets.push(p); if(p.seq>pseq)pseq=p.seq;
+      if(p.lat!=null&&p.lon!=null) stations[p.source]={call:p.source,lat:p.lat,lon:p.lon,src_kind:p.src_kind,ts:p.ts,comment:p.comment,speed_kt:p.speed_kt,course:p.course};
+      if(p.type==='message'||p.type==='ack') messages.push(p);
+    });
+    if(packets.length>800) packets=packets.slice(-800);
+    if(messages.length>400) messages=messages.slice(-400);
+    renderFeed(); renderMsgs(); drawMap();
+  }
+
+  // ---- demo (no hardware / offline) ----
+  var demoTimer=null, DCITY={lat:39.95,lon:-98.6}, DEMO_CALLS=['K4ABC-9','N0XYZ','W1AW','KJ7QRP-7','VE3MAP','G0RAG-1'];
+  function demoStart(which){ hideVeil();
+    if(which==='rf'){ DCITY={lat:parseFloat(rfFreq.value)>145?-33:39.95, lon:parseFloat(rfFreq.value)>145?151:-98.6}; }
+    if(!demoTimer){ demoTick(); demoTimer=setInterval(demoTick,2200); } }
+  function demoTick(){ if(!DEMO_ON) return; if(!rfOn&&!isOn){ return; }
+    var c=DEMO_CALLS[(Math.random()*DEMO_CALLS.length)|0];
+    var src=isOn?(Math.random()<0.7?'is':'rf'):'rf';
+    var lat=DCITY.lat+(Math.random()-0.5)*(src==='is'?18:1.4), lon=DCITY.lon+(Math.random()-0.5)*(src==='is'?36:1.8);
+    var r=Math.random(), p;
+    if(r<0.65){ p={source:c,type:'position',lat:lat,lon:lon,symbol:'/>',comment:'demo beacon',speed_kt:(Math.random()*40)|0,course:(Math.random()*360)|0,src_kind:src,ts:Date.now()/1000,seq:++pseq}; }
+    else if(r<0.85){ p={source:c,type:'status',comment:'Ragnar APRS demo',src_kind:src,ts:Date.now()/1000,seq:++pseq}; }
+    else { p={source:c,type:'message',addressee:'RAGNAR',text:'hello from '+c,src_kind:src,ts:Date.now()/1000,seq:++pseq}; }
+    ingest([p]);
+    renderStats({packets:pseq,stations:Object.keys(stations).length,messages:messages.length});
+  }
+
+  function refreshConfig(){ return fetch('/api/config').then(function(r){return r.json();}).then(function(c){ DEMO_ON=!!(c&&(c.sdr_demo===true||c.sdr_demo==='true')); }).catch(function(){}); }
+  function boot(){
+    fetch('/api/net/aprs/status').then(function(r){return r.json();}).then(function(st){
+      var det=(st&&st.detect)||{};
+      fillRegions(det.regions, det.region_filters);
+      renderStats(st||{});
+      if(!(st&&(st.rf_running||st.is_connected))){
+        if(DEMO_ON){ /* wait for user to hit Start/Connect */ }
+        else if(det.rf_available===false && det.is_available){ /* IS still usable */ }
+      }
+      if(det.rf_available===false && !DEMO_ON){ document.getElementById('rf-hint').textContent=det.error||'RF unavailable — APRS-IS still works'; }
+    }).catch(function(){});
+    if(poll)clearInterval(poll); poll=setInterval(pollAll,2000); pollAll();
+  }
+  drawMap();
+  refreshConfig().then(boot);
+})();
+</script>
+</body>
+</html>

--- a/demos/rf_waterfall.html
+++ b/demos/rf_waterfall.html
@@ -172,6 +172,7 @@
     <div class="grp"><a href="/mesh-nodes" class="ctl" id="meshlink" title="Mesh Nodes — real Meshtastic enumeration via a USB companion node">&#9741;&nbsp;Mesh Nodes</a></div>
     <div class="grp"><a href="/pager-decode" class="ctl" id="pagerlink" title="Pager Decode — POCSAG/FLEX + Motorola QCII (rtl_fm)">&#128244;&nbsp;Pager Decode</a></div>
     <div class="grp"><a href="/vor-radial" class="ctl" id="vorlink" title="VOR Radial — decode a VOR nav beacon's bearing (108–118 MHz)">&#127760;&nbsp;VOR Radial</a></div>
+    <div class="grp"><a href="/aprs" class="ctl" id="aprslink" title="APRS — ham packet positions &amp; messages (off-air + APRS-IS Internet)">&#128225;&nbsp;APRS</a></div>
     <div class="grp"><button class="ctl" id="play" aria-pressed="true">&#10074;&#10074;&nbsp;Pause</button></div>
     <div class="grp">
       <span class="lbl">Scroll</span>

--- a/docs/sdr-subghz.md
+++ b/docs/sdr-subghz.md
@@ -280,6 +280,36 @@ reference 30 Hz by FM-demodulating the 9960 Hz subcarrier, then reports
 - **Not for navigation** — a hobby SDR + wire antenna is a demonstrator, not a
   certified nav receiver. Receive-only.
 
+## APRS (ham packet + messaging)
+
+The **APRS** page (`/aprs`, `aprs.py`) receives APRS — the ham packet network of
+position beacons, weather, telemetry and short **messages** — from two sources
+into one station map + packet feed + message view:
+
+- **RF (SDR)** — `rtl_fm | multimon-ng -a AFSK1200` decodes the local APRS
+  channel (144.390 MHz North America, 144.800 Europe, 145.175 Australia, …; a
+  region picker sets the frequency, or type your own MHz). Receive-only; no
+  licence needed to listen.
+- **APRS-IS (Internet)** — a TCP client to the global network
+  (`rotate.aprs2.net:14580`). A **read-only** login (no callsign) streams **any
+  region** via a server filter (`r/lat/lon/km`); with **your own callsign +
+  passcode** you get **write access to send messages**, which IGates near the
+  recipient relay onward. The passcode is the standard APRS-IS callsign hash
+  (`aprs.aprs_passcode`).
+
+`parse_aprs` handles uncompressed & compressed positions (with/without
+timestamp), **Mic-E**, messages/acks, objects, status and best-effort weather —
+13 selftests including a Mic-E round-trip and the passcode algorithm.
+
+- **One dongle** — RF APRS shares the RTL-SDR with the sweep / ISM / ADS-B /
+  pager / VOR / radio, so starting one stops the others. **APRS-IS is
+  independent** (Internet only) and keeps running regardless — so the page is
+  useful even with no dongle at all.
+- **No RF transmit** — RTL-SDR can't transmit and HackRF TX (licence + amp/
+  filter care) is deliberately out of scope; APRS-IS carries the messaging.
+  Sending still injects under your callsign on the ham network — **only licensed
+  operators should send.**
+
 ## API
 
 | Route | Purpose |
@@ -306,6 +336,10 @@ reference 30 Hz by FM-demodulating the 9960 Hz subcarrier, then reports
 | `POST /api/net/pager/start` `{freq_hz, mode?}` · `/stop` · `/install` | Start/stop pager decode (`mode`=`pocsag_flex`\|`qcii`); install multimon-ng |
 | `GET  /api/net/vor/status` | VOR decode state + latest `fix` (radial/lock/quality) |
 | `POST /api/net/vor/start` `{freq_hz, cal_deg?}` · `/stop` | Start/stop VOR radial decode on a 108–118 MHz station |
+| `GET  /api/net/aprs/status` · `/packets?since=` · `/stations` · `/messages?since=` | APRS state + packet feed + station map + messages |
+| `POST /api/net/aprs/rf/start` `{freq_hz}` · `/rf/stop` | Start/stop off-air APRS decode (rtl_fm\|multimon-ng, one dongle) |
+| `POST /api/net/aprs/is/connect` `{callsign,passcode,filter}` · `/is/disconnect` | Connect/disconnect APRS-IS (read-only, or write with a valid passcode) |
+| `POST /api/net/aprs/send` `{to,text}` | Send an APRS message via APRS-IS (needs write access) |
 | `GET  /api/net/acars/status` · `/messages?since=` | ACARS datalink state + decoded messages (tail/flight/label/text) |
 | `POST /api/net/acars/start` · `/stop` · `/install` | Start/stop ACARS decode; build acarsdec from source |
 | `GET  /api/net/{pager,vor}/selftest` · `/api/net/rtl/selftest` | Offline DSP / parser self-tests |
@@ -321,6 +355,8 @@ python3 rtl_sdr.py power --band subghz --seconds 20
 python3 rtl_sdr.py selftest
 python3 pagerdecode.py run --freq 154.265M --seconds 30   # POCSAG/FLEX/QCII
 python3 vor.py run --freq 113.600M --seconds 30           # live VOR radial
+python3 aprs.py parse 'SRC>APRS,WIDE1-1:=5132.07N/00007.24W-hi'   # APRS parser
+python3 aprs.py selftest
 ```
 
 ## Legality

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -51,6 +51,7 @@ import pagerdecode as pager   # decoder module (the `pager/` package is a separa
 import acars
 import radio
 import vor
+import aprs
 import zigbee_scan
 from ldap_watch import do_ldap_watch
 from tls_watch import do_tls_watch
@@ -18918,7 +18919,7 @@ def register_network_diagnostics(app, logger=None):
         label = data.get('label')
         label = str(label).strip()[:24] if label else None
         _log(f"net/rtl/power/start band={band} zoom={data.get('lo_hz')}:{data.get('hi_hz')} label={label}")
-        try: adsb.stop(); pager.stop(); acars.stop(); radio.stop(); vor.stop()   # one dongle: free it for the sweep
+        try: adsb.stop(); pager.stop(); acars.stop(); radio.stop(); vor.stop(); aprs.stop()   # one dongle: free it for the sweep
         except Exception: pass
         return jsonify(rtl_sdr.power_start(band=band, lo_hz=data.get('lo_hz'),
                                            hi_hz=data.get('hi_hz'), label=label))
@@ -18987,7 +18988,7 @@ def register_network_diagnostics(app, logger=None):
     @app.route('/api/net/adsb/start', methods=['POST'])
     def net_adsb_start():
         _log("net/adsb/start")
-        try: rtl_sdr.power_stop(); rtl_sdr.ism_stop(); pager.stop(); acars.stop(); radio.stop(); vor.stop()   # hand the dongle to dump1090
+        try: rtl_sdr.power_stop(); rtl_sdr.ism_stop(); pager.stop(); acars.stop(); radio.stop(); vor.stop(); aprs.stop()   # hand the dongle to dump1090
         except Exception: pass
         return jsonify(adsb.start())
 
@@ -19061,7 +19062,7 @@ def register_network_diagnostics(app, logger=None):
         mode = data.get('mode') or 'pocsag_flex'
         _log(f"net/pager/start freq={data.get('freq_hz')} mode={mode}")
         try:
-            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); acars.stop(); radio.stop(); vor.stop()
+            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); acars.stop(); radio.stop(); vor.stop(); aprs.stop()
         except Exception:
             pass
         return jsonify(pager.start(freq_hz=data.get('freq_hz'), mode=mode))
@@ -19091,7 +19092,7 @@ def register_network_diagnostics(app, logger=None):
         data = request.get_json(silent=True) or {}
         _log(f"net/vor/start freq={data.get('freq_hz')} cal={data.get('cal_deg')}")
         try:
-            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); acars.stop(); radio.stop()
+            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); acars.stop(); radio.stop(); aprs.stop()
         except Exception:
             pass
         return jsonify(vor.start(freq_hz=data.get('freq_hz'), cal_deg=data.get('cal_deg', 0.0)))
@@ -19104,6 +19105,66 @@ def register_network_diagnostics(app, logger=None):
     @app.route('/api/net/vor/selftest', methods=['GET'])
     def net_vor_selftest():
         return jsonify(vor.selftest())
+
+    # APRS (ham packet, ~144.39/144.80 MHz) — two sources into one feed: RF via
+    # rtl_fm|multimon-ng (one dongle) and APRS-IS over the Internet (independent).
+    @app.route('/api/net/aprs/status', methods=['GET'])
+    def net_aprs_status():
+        return jsonify(aprs.status())
+
+    @app.route('/api/net/aprs/packets', methods=['GET'])
+    def net_aprs_packets():
+        return jsonify(aprs.packets(since=request.args.get('since', 0)))
+
+    @app.route('/api/net/aprs/stations', methods=['GET'])
+    def net_aprs_stations():
+        return jsonify(aprs.stations())
+
+    @app.route('/api/net/aprs/messages', methods=['GET'])
+    def net_aprs_messages():
+        return jsonify(aprs.messages(since=request.args.get('since', 0)))
+
+    @app.route('/api/net/aprs/rf/start', methods=['POST'])
+    def net_aprs_rf_start():
+        data = request.get_json(silent=True) or {}
+        _log(f"net/aprs/rf/start freq={data.get('freq_hz')}")
+        try:                                        # one dongle: free it for APRS RF
+            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); acars.stop(); radio.stop(); vor.stop()
+        except Exception:
+            pass
+        return jsonify(aprs.start_rf(freq_hz=data.get('freq_hz')))
+
+    @app.route('/api/net/aprs/rf/stop', methods=['POST'])
+    def net_aprs_rf_stop():
+        _log("net/aprs/rf/stop")
+        return jsonify(aprs.stop_rf())
+
+    @app.route('/api/net/aprs/is/connect', methods=['POST'])
+    def net_aprs_is_connect():
+        data = request.get_json(silent=True) or {}
+        _log(f"net/aprs/is/connect call={data.get('callsign')} filter={data.get('filter')}")
+        return jsonify(aprs.connect_is(callsign=data.get('callsign'), passcode=data.get('passcode'),
+                                       filter_str=data.get('filter'), igate=data.get('igate')))
+
+    @app.route('/api/net/aprs/is/disconnect', methods=['POST'])
+    def net_aprs_is_disconnect():
+        _log("net/aprs/is/disconnect")
+        return jsonify(aprs.disconnect_is())
+
+    @app.route('/api/net/aprs/send', methods=['POST'])
+    def net_aprs_send():
+        data = request.get_json(silent=True) or {}
+        _log(f"net/aprs/send to={data.get('to')}")
+        return jsonify(aprs.send_message(data.get('to'), data.get('text')))
+
+    @app.route('/api/net/aprs/install', methods=['POST'])
+    def net_aprs_install():
+        _log("net/aprs/install")
+        return jsonify(aprs.install())
+
+    @app.route('/api/net/aprs/selftest', methods=['GET'])
+    def net_aprs_selftest():
+        return jsonify(aprs.selftest())
 
     # ACARS (aircraft VHF datalink ~131 MHz) via acarsdec — plain-text ops
     # messages, matched to ADS-B aircraft by tail/flight. Uses the whole RTL-SDR.
@@ -19119,7 +19180,7 @@ def register_network_diagnostics(app, logger=None):
     def net_acars_start():
         _log("net/acars/start")
         try:
-            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); radio.stop(); vor.stop()
+            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); radio.stop(); vor.stop(); aprs.stop()
         except Exception:
             pass
         return jsonify(acars.start())
@@ -19167,7 +19228,7 @@ def register_network_diagnostics(app, logger=None):
         mode = request.args.get('mode', 'wfm')
         _log(f"net/radio/stream freq={freq} mode={mode}")
         try:
-            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); acars.stop(); vor.stop()
+            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); acars.stop(); vor.stop(); aprs.stop()
         except Exception:
             pass
         resp = Response(radio.stream(freq, mode), mimetype="audio/wav")
@@ -19182,7 +19243,7 @@ def register_network_diagnostics(app, logger=None):
         data = request.get_json(silent=True) or {}
         band = str(data.get('band') or '433').strip()
         _log(f"net/rtl/ism/start band={band}")
-        try: adsb.stop(); pager.stop(); acars.stop(); radio.stop(); vor.stop()   # one dongle: free it for the decoder
+        try: adsb.stop(); pager.stop(); acars.stop(); radio.stop(); vor.stop(); aprs.stop()   # one dongle: free it for the decoder
         except Exception: pass
         return jsonify(rtl_sdr.ism_start(band=band))
 

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -2668,6 +2668,10 @@
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 0v10l6-3"/></svg>
                             VOR Radial
                         </a>
+                        <a href="/aprs" target="_blank" rel="noopener" id="wifi-aprs-btn" title="APRS — ham packet positions &amp; messages, off-air (RTL-SDR) and worldwide via APRS-IS (works without a dongle)" class="hidden items-center gap-1.5 bg-emerald-700 hover:bg-emerald-600 text-white px-3 py-2 rounded text-sm font-semibold">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                            APRS
+                        </a>
                         <button type="button" onclick="wifiSdrCheck()" id="wifi-sdr-check" title="Diagnose why an SDR (HackRF / RTL-SDR) isn't detected — checks the USB bus, drivers, tools and power, and tells you the fix" class="flex items-center gap-1.5 bg-slate-700 hover:bg-slate-600 text-gray-100 px-3 py-2 rounded text-sm font-semibold border border-slate-600">🩺 SDR check</button>
                         <label class="flex items-center gap-2 text-xs text-gray-400 cursor-pointer select-none"><input type="checkbox" id="wifi-auto" class="accent-Ragnar-600"> Auto-refresh (8s)</label>
                         <label class="flex items-center gap-2 text-xs text-gray-400 cursor-pointer select-none" title="Overlay Bluetooth / BLE device activity on the 2.4 GHz band (device-discovery estimate, not measured RF)"><input type="checkbox" id="wifi-bt" class="accent-sky-500"> <span class="text-sky-400">📶 Bluetooth</span></label>
@@ -8357,7 +8361,7 @@
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260822-mobile-opacity"></script>
     <script src="/web/scripts/skyview_vr.js?v=20260822-rich-info-panel"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260826-roomscan5"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260826-aprs"></script>
 
 
 

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -2077,6 +2077,13 @@ function _wifiRfwfShow() {
         vor.classList.toggle('hidden', !showV);
         vor.classList.toggle('inline-flex', showV);
     }
+    // APRS off-air needs an RTL-SDR, but the APRS-IS Internet feed works with no
+    // dongle at all — so always offer it (it's the one that doesn't need hardware).
+    const aprs = document.getElementById('wifi-aprs-btn');
+    if (aprs) {
+        aprs.classList.remove('hidden');
+        aprs.classList.add('inline-flex');
+    }
 }
 
 // Load the demo toggle's state from config and persist changes.

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -8821,6 +8821,17 @@ def vor_radial_page():
     return _no_store(make_response(send_from_directory('demos', 'vor_radial.html')))
 
 
+@app.route('/aprs')
+def aprs_page():
+    """Serve the APRS page.
+
+    Always served (login required): the RF decode needs an RTL-SDR, but the
+    APRS-IS Internet feed works with no dongle at all, so the page is useful to
+    everyone.
+    """
+    return _no_store(make_response(send_from_directory('demos', 'aprs.html')))
+
+
 # Captive portal detection routes for mobile devices
 @app.route('/generate_204')
 @app.route('/gen_204')


### PR DESCRIPTION
New Signal Intelligence page (/aprs, aprs.py) that receives APRS from two sources into one station map + packet feed + message view:

- RF off-air via rtl_fm | multimon-ng -a AFSK1200 (receive-only, no licence); regional calling-frequency presets (NA 144.390, EU 144.800, AU 145.175, JP, KR, CN, BR, AR/CL, ZA, TH, RU, …) plus free-form MHz.
- APRS-IS over the Internet (rotate.aprs2.net:14580): read-only login streams ANY region via a server filter; with your own callsign + passcode (standard APRS-IS hash) you get write access to SEND messages, which IGates relay to the recipient. APRS-IS is independent of the dongle, so the page works with no SDR at all.

Real APRS parser (parse_aprs): uncompressed & compressed positions (±timestamp), Mic-E, messages/acks, objects, status, best-effort weather. 12/12 selftests incl. a Mic-E encode/decode round-trip and the passcode algorithm.

No RF transmit: RTL-SDR can't, and HackRF TX (licence + amp/filter care) is out of scope; sending is APRS-IS only and gated on a valid callsign+passcode, with clear 'licensed operators only' framing. multimon-ng already ships in the build.

Wiring: /api/net/aprs/* (status/packets/stations/messages/rf/is/send). APRS RF is the 8th one-dongle consumer — every RF start now frees it, and APRS RF frees the other 7 (all mutually exclusive). Auto-fitting station map with graticule, source-tagged feed, message compose. Signal-Intelligence button (always shown — the Internet feed needs no hardware) + cross-links; docs updated.