### PR TITLE
Meshtastic: MQTT Internet source + transmit (the full mesh suite)

### DIFF
--- a/demos/mesh_nodes.html
+++ b/demos/mesh_nodes.html
@@ -70,7 +70,7 @@
     <div>
       <div class="eyebrow"><span class="dot"></span> Ragnar · Signal Intelligence</div>
       <h1>Mesh Nodes</h1>
-      <div class="sub">Real Meshtastic enumeration via a USB companion node — the node DB (names, hardware, role, SNR, hops, battery, GPS) and decoded public-channel messages. This is the <i>who's on it</i> to the spectrum overlay's <i>where it is</i>.</div>
+      <div class="sub">Real Meshtastic mesh — the node DB (names, hardware, role, SNR, hops, battery, GPS) and messages, from a USB node <b>and/or MQTT</b> (the Internet bridge, like APRS-IS — no node needed). <b>Send</b> messages onto the mesh through your node's LoRa or via MQTT.</div>
     </div>
     <div style="display:flex;gap:16px;align-items:flex-end">
       <div class="stat"><span class="k">Nodes</span><span class="v" id="s-count">—</span></div>
@@ -82,8 +82,11 @@
   <div class="bar">
     <div class="grp"><a href="/" class="ctl back">&#8592;&nbsp;Ragnar</a></div>
     <div class="grp"><a href="/rf-waterfall" class="ctl" title="LoRa spectrum overlay (energy view)">〜&nbsp;RF Waterfall</a></div>
-    <div class="grp"><button class="ctl go" id="startbtn" aria-pressed="false" title="Connect to the USB Meshtastic node">&#9654;&nbsp;Connect</button></div>
+    <div class="grp"><button class="ctl go" id="startbtn" aria-pressed="false" title="Connect to the USB Meshtastic node (real LoRa RF)">&#9654;&nbsp;Node</button></div>
+    <div class="grp"><button class="ctl go" id="mqtt-btn" aria-pressed="false" title="Connect the Meshtastic MQTT Internet feed (no node needed)">&#9729;&nbsp;MQTT</button></div>
+    <div class="grp"><span class="lbl">Topic</span><input class="tin" id="mqtt-topic" style="width:148px" placeholder="msh/+/2/json/#"></div>
     <div class="grp"><span class="tag idle" id="devtag">detecting…</span></div>
+    <div class="grp"><span class="tag idle" id="mqtttag">MQTT off</span></div>
   </div>
 
   <div class="layout">
@@ -98,8 +101,15 @@
         </div>
       </div>
       <div class="card">
-        <div class="cap"><span class="t">Public channel</span><span class="c" id="msgcap"></span></div>
+        <div class="cap"><span class="t">Messages</span><span class="c" id="msgcap"></span></div>
         <div class="msgs" id="msgs"><div class="empty">No messages yet…</div></div>
+        <div style="display:flex;flex-wrap:wrap;gap:7px;align-items:center;padding:10px 14px;border-top:1px solid var(--line-soft)">
+          <input class="tin" id="m-to" style="width:96px" placeholder="^all or !id" title="Recipient: ^all (broadcast) or a node id">
+          <input class="tin" id="m-ch" type="number" style="width:52px" value="0" title="Channel index">
+          <input class="tin" id="m-text" style="flex:1;min-width:120px" placeholder="message…" maxlength="200">
+          <button class="ctl" id="m-send" disabled title="Send via the connected node (LoRa RF) or MQTT">Send ▸</button>
+        </div>
+        <div style="padding:0 14px 10px;font-family:var(--mono);font-size:10.5px;color:var(--muted)" id="m-hint">Connect a node or MQTT to send.</div>
       </div>
     </div>
     <div class="card">
@@ -114,8 +124,8 @@
   </div>
 
   <footer>
-    <div><b>How it works:</b> a Meshtastic device (Heltec / RAK / T-Beam …) on USB does the LoRa demodulation in hardware; the meshtastic Python API hands Ragnar the decoded node DB and messages. The <b>public</b> channel key is well-known so its traffic is readable; private channels stay encrypted. The device's own USB radio is used, so this does not contend for the RTL-SDR.</div>
-    <div style="margin-top:6px"><b>Map:</b> nodes with a GPS position are plotted relative to your node (self = green centre). SNR colours the link. Nodes without GPS appear in the table only.</div>
+    <div><b>How it works:</b> a Meshtastic device (Heltec / RAK / T-Beam …) on USB does the LoRa demod in hardware; the meshtastic Python API hands Ragnar the node DB + messages. <b>MQTT</b> is Meshtastic's Internet bridge — gateways publish mesh traffic to a broker (default the public <code>mqtt.meshtastic.org</code>), so ☁ MQTT streams the mesh worldwide with no node. The public channel key is well-known so its traffic is readable; private channels stay encrypted. The USB radio is used, so this doesn't contend for the RTL-SDR.</div>
+    <div style="margin-top:6px"><b>Send:</b> a message goes out via your connected node's LoRa (real RF, licence-free ISM) when a node is connected, otherwise via MQTT (which needs a downlink-enabled gateway to reach RF). <b>Map:</b> GPS-positioned nodes are plotted relative to your node (self = green centre); MQTT-only stations show too. SNR colours the link.</div>
   </footer>
 </div>
 
@@ -228,34 +238,67 @@
     document.getElementById('msgcap').textContent=msgs.length?(msgs.length+' messages'):'';
     if(!msgs.length){ el.innerHTML='<div class="empty">No messages yet…</div>'; return; }
     var byId={}; nodes.forEach(function(n){byId[n.id]=n.long_name||n.short_name||n.id;});
-    el.innerHTML=msgs.slice().reverse().slice(0,60).map(function(m){
-      var who=byId[m.from]||m.from||'?';
-      return '<div class="msg"><span class="mf">'+esc(who)+'</span> <span class="mt">'+esc(m.text||'')+'</span>'
+    el.innerHTML=msgs.slice().reverse().slice(0,80).map(function(m){
+      var src=m.src||'serial';
+      var scol={serial:'var(--mesh)',mqtt:'#5ec8f0',tx:'#c98bf0'}[src]||'var(--mesh)';
+      var who=m.outbound?'you ▸ '+esc(m.to||'^all'):(esc(byId[m.from||m.sender]||m.from||m.sender||'?'));
+      return '<div class="msg"><span style="font-size:8.5px;color:'+scol+';border:1px solid '+scol+';border-radius:3px;padding:0 3px;margin-right:5px;text-transform:uppercase">'+src+'</span>'
+        +'<span class="mf" style="color:'+(m.outbound?'#c98bf0':'')+'">'+who+'</span> <span class="mt">'+esc(m.text||'')+'</span>'
         +' <span class="mm">'+(m.snr!=null?('SNR '+m.snr+' · '):'')+ago(m.ts)+'</span></div>';
     }).join('');
   }
+  // ---- MQTT + send ----
+  var mqttOn=false;
+  function ensurePoll(){ if(!poll && (running||mqttOn)){ poll=setInterval(pollLive,2000); pollLive(); } }
+  document.getElementById('mqtt-btn').addEventListener('click',function(){
+    var b=document.getElementById('mqtt-btn');
+    if(mqttOn){ mqttOn=false; b.setAttribute('aria-pressed','false'); b.innerHTML='&#9729;&nbsp;MQTT';
+      fetch('/api/net/mesh/mqtt/disconnect',{method:'POST'}).catch(function(){}); updateSend(); if(DEMO_ON)synthMode(); return; }
+    mqttOn=true; b.setAttribute('aria-pressed','true'); b.innerHTML='&#10074;&#10074;&nbsp;MQTT';
+    var topic=document.getElementById('mqtt-topic').value.trim();
+    if(DEMO_ON){ hideVeil(); setMode('synth'); synthMode(); updateSend(); return; }
+    fetch('/api/net/mesh/mqtt/connect',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(topic?{topic:topic}:{})})
+      .then(function(r){return r.json();}).then(function(res){ if(res&&res.error){ mqttOn=false; b.setAttribute('aria-pressed','false'); b.innerHTML='&#9729;&nbsp;MQTT'; showVeil('MQTT connect failed',res.error); } else { hideVeil(); ensurePoll(); } updateSend(); }).catch(function(){});
+  });
+  function updateSend(){ var can=running||mqttOn; document.getElementById('m-send').disabled=!can;
+    document.getElementById('m-hint').textContent = can
+      ? (running?'Sends via the connected node (LoRa RF).':'Sends via MQTT (needs a downlink-enabled gateway to reach RF).')
+      : 'Connect a node or MQTT to send.'; }
+  document.getElementById('m-send').addEventListener('click',function(){
+    var to=document.getElementById('m-to').value.trim()||'^all', ch=parseInt(document.getElementById('m-ch').value,10)||0,
+        tx=document.getElementById('m-text').value.trim();
+    if(!tx) return;
+    if(DEMO_ON){ msgs.push({from:'you',to:to,text:tx,channel:ch,src:'tx',outbound:true,ts:Date.now()/1000}); if(msgs.length>200)msgs=msgs.slice(-200); document.getElementById('m-text').value=''; renderMsgs(); return; }
+    fetch('/api/net/mesh/send',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({text:tx,to:to,channel:ch,via:'auto'})})
+      .then(function(r){return r.json();}).then(function(res){ if(res&&res.ok){ document.getElementById('m-text').value=''; pollLive(); } else if(res&&res.error){ document.getElementById('m-hint').textContent=res.error; } }).catch(function(){});
+  });
 
   var poll=null;
   function startRun(){
-    running=true; var b=document.getElementById('startbtn'); b.setAttribute('aria-pressed','true'); b.innerHTML='&#10074;&#10074;&nbsp;Disconnect';
+    running=true; var b=document.getElementById('startbtn'); b.setAttribute('aria-pressed','true'); b.innerHTML='&#10074;&#10074;&nbsp;Node';
     fetch('/api/net/mesh/start',{method:'POST',headers:{'Content-Type':'application/json'},body:'{}'})
       .then(function(r){return r.json();}).then(function(res){ if(res&&res.error){ if(DEMO_ON)synthMode(); else showVeil('Could not connect',res.error); } }).catch(function(){});
-    if(poll)clearInterval(poll); poll=setInterval(pollLive,2000); pollLive();
+    updateSend(); if(poll)clearInterval(poll); poll=setInterval(pollLive,2000); pollLive();
   }
   function stopRun(){
-    running=false; var b=document.getElementById('startbtn'); b.setAttribute('aria-pressed','false'); b.innerHTML='&#9654;&nbsp;Connect';
-    if(poll){clearInterval(poll);poll=null;}
+    running=false; var b=document.getElementById('startbtn'); b.setAttribute('aria-pressed','false'); b.innerHTML='&#9654;&nbsp;Node';
     fetch('/api/net/mesh/stop',{method:'POST'}).catch(function(){});
-    if(DEMO_ON) synthMode(); else { setMode('idle'); nodes=[]; msgs=[]; renderTable(); renderMsgs(); }
+    updateSend();
+    if(mqttOn){ pollLive(); }   // MQTT feed keeps running
+    else if(poll){clearInterval(poll);poll=null;}
+    if(!mqttOn){ if(DEMO_ON) synthMode(); else { setMode('idle'); nodes=[]; msgs=[]; renderTable(); renderMsgs(); } }
   }
   document.getElementById('startbtn').addEventListener('click',function(){ running?stopRun():startRun(); });
 
   function pollLive(){
+    if(!(running||mqttOn)) return;
     Promise.all([fetch('/api/net/mesh/nodes').then(function(r){return r.json();}).catch(function(){return null;}),
                  fetch('/api/net/mesh/messages').then(function(r){return r.json();}).catch(function(){return null;})])
       .then(function(res){ var nd=res[0],mg=res[1];
-        if(nd&&nd.connected){ hideVeil(); setMode('live'); nodes=nd.nodes||[]; msgs=(mg&&mg.messages)||[]; renderTable(); renderMsgs(); }
-        else if(nd&&nd.error){ if(DEMO_ON)synthMode(); else showVeil('Mesh link error',nd.error); }
+        if(!nd) return;
+        nodes=nd.nodes||[]; msgs=(mg&&mg.messages)||[];
+        if(nd.connected||mqttOn){ hideVeil(); setMode('live'); renderTable(); renderMsgs(); }
+        else if(nd.error && running){ if(DEMO_ON)synthMode(); else showVeil('Mesh link error',nd.error); }
       });
   }
 
@@ -283,11 +326,17 @@
   function checkStatus(){
     fetch('/api/net/mesh/status').then(function(r){return r.json();}).then(function(st){
       var det=(st&&st.detect)||{}; var dt=document.getElementById('devtag');
-      if(st&&st.running){ running=true; var b=document.getElementById('startbtn'); b.setAttribute('aria-pressed','true'); b.innerHTML='&#10074;&#10074;&nbsp;Disconnect'; if(!poll){poll=setInterval(pollLive,2000);pollLive();} }
-      if(det.available){ dt.className='tag live'; dt.textContent=(det.usb_desc||'Meshtastic')+' ready'; hideVeil(); if(!running&&mode==='idle'){} }
+      if(det.mqtt_defaults&&det.mqtt_defaults.topic&&!document.getElementById('mqtt-topic').value){ document.getElementById('mqtt-topic').placeholder=det.mqtt_defaults.topic; }
+      // MQTT (Internet) state — independent of the USB node
+      var mq=(st&&st.mqtt)||{}, mt=document.getElementById('mqtttag'), mb=document.getElementById('mqtt-btn');
+      if(mq.connected){ mqttOn=true; mt.className='tag live'; mt.textContent='MQTT on'; mb.setAttribute('aria-pressed','true'); mb.innerHTML='&#10074;&#10074;&nbsp;MQTT'; ensurePoll(); }
+      else { mt.className='tag idle'; mt.textContent=det.mqtt_available===false?'MQTT n/a':'MQTT off'; }
+      if(st&&st.running){ running=true; var b=document.getElementById('startbtn'); b.setAttribute('aria-pressed','true'); b.innerHTML='&#10074;&#10074;&nbsp;Node'; ensurePoll(); }
+      updateSend();
+      if(det.available){ dt.className='tag live'; dt.textContent=(det.usb_desc||'Meshtastic')+' ready'; if(running||mqttOn)hideVeil(); }
       else { dt.className='tag idle'; dt.textContent=det.error?'no node':'detecting…';
-        if(DEMO_ON){ synthMode(); }
-        else if(!running){ setMode('idle'); showVeil('No Meshtastic node', det.error||'Plug a Meshtastic device in via USB, or enable the RF Waterfall demo for a synthetic mesh.', det.tools_installed===false); } }
+        if(DEMO_ON){ if(!running&&!mqttOn) synthMode(); }
+        else if(!running&&!mqttOn){ setMode('idle'); showVeil('No Meshtastic node', (det.error||'Plug a Meshtastic device in via USB')+' — or connect ☁ MQTT to watch the mesh over the Internet with no node.', det.tools_installed===false); } }
     }).catch(function(){ if(DEMO_ON) synthMode(); });
   }
 

--- a/docs/sdr-subghz.md
+++ b/docs/sdr-subghz.md
@@ -159,16 +159,30 @@ decoded mesh:
 - **Public-channel messages** — the default Meshtastic channel key is
   well-known, so its text traffic is decoded and shown live. Private channels
   stay encrypted.
+- **MQTT (Internet bridge)** — Meshtastic gateways bridge the mesh to an MQTT
+  broker the way APRS IGates bridge to APRS-IS. The **☁ MQTT** button connects a
+  broker (default the public `mqtt.meshtastic.org`, JSON topic `msh/+/2/json/#`)
+  and streams mesh traffic **worldwide with no node at all** — nodes, positions
+  and text messages parsed from the JSON stream (`parse_mqtt_json`). Runs
+  independently of the USB node and of the RTL-SDR. Uses **paho-mqtt** (in
+  `requirements.txt`; the Install button grabs it too).
+- **Transmit** — the **Send** box puts a text message onto the mesh: through the
+  connected node's **LoRa RF** when a node is present (licence-free ISM), else
+  over **MQTT** (which reaches RF only via a downlink-enabled gateway). Messages
+  you send show in the feed tagged `TX`; RF/serial and MQTT sources are tagged
+  too.
 - **Own USB radio** — this does *not* contend for the RTL-SDR, so it can run
   alongside the sub-GHz sweep / ADS-B.
-- **Needs the `meshtastic` pip package** — installed best-effort by the
-  installer/updater; if missing, the page shows an **⬇ Install meshtastic**
-  button (`POST /api/net/mesh/install`).
+- **Needs the `meshtastic` pip package** (serial) and **paho-mqtt** (MQTT) —
+  installed best-effort by the installer/updater; if missing, the page shows an
+  **⬇ Install meshtastic** button (`POST /api/net/mesh/install`, installs both).
 - **MeshCore:** its companion tooling is still immature, so only the spectrum
   overlay covers it for now; node enumeration here is Meshtastic.
 
-Ragnar never *sends* mesh messages — it reads the node DB and listens. (The
-device itself still beacons as a normal mesh node.)
+> Meshtastic transmit is licence-free ISM (unlike ham APRS), so sending through
+> your own node is fine; over MQTT, mind the network's etiquette (don't flood
+> the public broker). Public-channel traffic is readable; private channels stay
+> encrypted.
 
 ## ADS-B radar (1090 MHz aircraft)
 
@@ -330,8 +344,10 @@ timestamp), **Mic-E**, messages/acks, objects, status and best-effort weather �
 | `POST /api/net/adsb/start` · `/stop` | Start / stop dump1090 (takes the dongle from the sub-GHz sweep) |
 | `POST /api/net/adsb/install` | One-click install of dump1090 (fixed package set) |
 | `…/rtl/record/{start,stop,status,list,get,delete}` | Session record & replay of the power sweep |
-| `GET  /api/net/mesh/status` · `/nodes` · `/messages` | Mesh Nodes: link state + enumerated nodes + decoded messages |
-| `POST /api/net/mesh/start` · `/stop` · `/install` | Connect / disconnect the USB Meshtastic node; install the pip package |
+| `GET  /api/net/mesh/status` · `/nodes` · `/messages` | Mesh Nodes: serial + MQTT link state + merged nodes/messages (src-tagged) |
+| `POST /api/net/mesh/start` · `/stop` · `/install` | Connect / disconnect the USB Meshtastic node; install meshtastic + paho-mqtt |
+| `POST /api/net/mesh/mqtt/connect` `{host?,port?,user?,password?,topic?}` · `/mqtt/disconnect` | Connect/disconnect the Meshtastic MQTT Internet feed (no node needed) |
+| `POST /api/net/mesh/send` `{text,to?,channel?,via?}` | Send a mesh text message via the node (LoRa) or MQTT (`via`=auto\|serial\|mqtt) |
 | `GET  /api/net/pager/status` · `/messages?since=` | Pager decode state (`mode`, `qcii_available`) + decoded POCSAG/FLEX/QCII messages |
 | `POST /api/net/pager/start` `{freq_hz, mode?}` · `/stop` · `/install` | Start/stop pager decode (`mode`=`pocsag_flex`\|`qcii`); install multimon-ng |
 | `GET  /api/net/vor/status` | VOR decode state + latest `fix` (radial/lock/quality) |

--- a/meshtastic_node.py
+++ b/meshtastic_node.py
@@ -14,8 +14,16 @@ traffic is readable; private channels stay encrypted).
 This is the honest counterpart to the spectrum overlay: the overlay shows *where*
 a mesh is on the band; this shows *who is on it*.
 
-Receive-only in spirit — this module never sends mesh messages; it only reads the
-node DB and listens. (The device itself still beacons as a normal mesh node.)
+Two sources, and transmit
+--------------------------
+  * **Serial (USB node)** — the local node does the LoRa demod and hands us the
+    node DB + public-channel messages, as above.
+  * **MQTT (Internet)** — Meshtastic gateways bridge the mesh to an MQTT broker
+    (the way APRS IGates bridge to APRS-IS). We subscribe to the broker's JSON
+    stream to watch mesh traffic worldwide, no node required — and can publish a
+    message back for a downlink-enabled gateway to inject.
+  * **Transmit** — send a text message onto the mesh through the connected USB
+    node (real LoRa RF, licence-free ISM), or over MQTT via a downlink gateway.
 
 CLI
 ---
@@ -25,11 +33,17 @@ CLI
 """
 
 import glob
+import json
 import os
 import subprocess
 import sys
 import threading
 import time
+
+try:
+    import paho.mqtt.client as _mqtt_client       # Meshtastic MQTT source/transmit
+except Exception:                                  # pragma: no cover - optional dep
+    _mqtt_client = None
 
 
 # Common USB-serial chips used by Meshtastic boards (VID:PID) — for detection
@@ -93,12 +107,17 @@ def _serial_ports():
 
 
 def detect():
-    """Report whether a Meshtastic companion node is usable.
+    """Report Meshtastic capability.
 
-    ``available`` needs the meshtastic Python package AND a serial device that
-    looks like a node. Mirrors the other SDR gates.
+    ``available`` (serial) needs the meshtastic package AND a USB node.
+    ``mqtt_available`` needs only paho-mqtt — the MQTT source/transmit works over
+    the Internet with no node at all, so it's reported independently.
     """
     have_pkg = _have_meshtastic()
+    mqtt_ok = _mqtt_client is not None
+    mqtt_extra = {"mqtt_available": mqtt_ok, "mqtt_defaults": {
+        "host": MESH_MQTT["host"], "port": MESH_MQTT["port"],
+        "user": MESH_MQTT["user"], "topic": MESH_MQTT["topic"]}}
     usb_id, usb_desc = None, None
     rc, out, _ = _run(["lsusb"], timeout=4)
     if rc == 0 and out:
@@ -110,14 +129,14 @@ def detect():
                 "device_present": device_present, "usb_id": usb_id,
                 "ports": ports,
                 "error": "meshtastic Python package not installed "
-                         "(pip install meshtastic)"}
+                         "(pip install meshtastic)", **mqtt_extra}
     if not device_present:
         return {"available": False, "tools_installed": True,
                 "device_present": False, "usb_id": None, "ports": [],
                 "error": "no Meshtastic device on USB — plug a node in "
-                         "(Heltec / RAK / T-Beam …) via USB"}
+                         "(Heltec / RAK / T-Beam …) via USB", **mqtt_extra}
     return {"available": True, "tools_installed": True, "device_present": True,
-            "usb_id": usb_id, "usb_desc": usb_desc, "ports": ports}
+            "usb_id": usb_id, "usb_desc": usb_desc, "ports": ports, **mqtt_extra}
 
 
 # --------------------------------------------------------------------------
@@ -225,7 +244,7 @@ class MeshLink:
                    "to": packet.get("toId") or packet.get("to"),
                    "channel": packet.get("channel", 0),
                    "snr": packet.get("rxSnr"), "rssi": packet.get("rxRssi"),
-                   "text": text, "ts": time.time()}
+                   "text": text, "ts": time.time(), "src": "serial"}
             with self._lock:
                 self._messages.append(rec)
                 if len(self._messages) > _MSG_RING:
@@ -287,6 +306,31 @@ class MeshLink:
                 break
             self._refresh_nodes()
 
+    def _store_outbound(self, text, dest, channel, via):
+        """Log a message we sent into the feed (tagged outbound)."""
+        rec = {"from": self._info.get("id") or "you", "to": dest or "^all",
+               "channel": int(channel or 0), "text": text, "ts": time.time(),
+               "src": "tx", "via": via, "outbound": True}
+        with self._lock:
+            self._messages.append(rec)
+            if len(self._messages) > _MSG_RING:
+                self._messages = self._messages[-_MSG_RING:]
+
+    def send_text(self, text, dest=None, channel=0):  # pragma: no cover - hardware path
+        """Transmit a text message onto the mesh through the connected node."""
+        with self._lock:
+            iface = self._iface
+            if not (iface and self._connected):
+                return {"ok": False, "error": "no Meshtastic node connected"}
+        try:
+            kwargs = {"channelIndex": int(channel or 0)}
+            if dest and dest not in ("^all", "!ffffffff", "", None):
+                kwargs["destinationId"] = dest
+            iface.sendText((text or "")[:228], **kwargs)
+            return {"ok": True, "via": "serial", "to": dest or "^all", "channel": int(channel or 0)}
+        except Exception as exc:
+            return {"ok": False, "error": "send failed: %s" % exc}
+
     def stop(self):
         self._stop.set()
         try:
@@ -300,7 +344,185 @@ class MeshLink:
         return {"ok": True}
 
 
+# --------------------------------------------------------------------------
+# MQTT source + transmit — Meshtastic's Internet bridge (like APRS-IS)
+# --------------------------------------------------------------------------
+
+# The public community broker + its well-known read credentials, and the JSON
+# topic that JSON-enabled gateways publish to. The UI takes a custom broker too.
+MESH_MQTT = {
+    "host": "mqtt.meshtastic.org", "port": 1883,
+    "user": "meshdev", "password": "large4cats",
+    "topic": "msh/+/2/json/#",              # worldwide JSON stream
+    "publish_topic": "msh/2/json/mqtt/",    # downlink command topic
+}
+
+
+def parse_mqtt_json(topic, payload):
+    """Parse one Meshtastic MQTT JSON message into a flat record, or None.
+
+    JSON-enabled gateways publish {type, from, sender, to, channel, payload, …}.
+    Pure — drives the selftest.
+    """
+    try:
+        d = json.loads(payload)
+    except Exception:
+        return None
+    if not isinstance(d, dict):
+        return None
+    t = d.get("type")
+    pl = d.get("payload")
+    frm = d.get("from")
+    sender = d.get("sender")
+    if not sender and isinstance(frm, int):
+        sender = "!%08x" % (frm & 0xFFFFFFFF)
+    rec = {"type": t, "from_num": frm, "sender": sender, "to": d.get("to"),
+           "channel": d.get("channel", 0), "ts": d.get("timestamp") or time.time(),
+           "topic": topic, "src": "mqtt"}
+    if t == "text":
+        rec["text"] = pl.get("text") if isinstance(pl, dict) else (pl if isinstance(pl, str) else None)
+    elif t == "position" and isinstance(pl, dict):
+        if isinstance(pl.get("latitude_i"), (int, float)):
+            rec["lat"] = pl["latitude_i"] / 1e7
+        if isinstance(pl.get("longitude_i"), (int, float)):
+            rec["lon"] = pl["longitude_i"] / 1e7
+        rec["altitude"] = pl.get("altitude")
+    elif t == "nodeinfo" and isinstance(pl, dict):
+        rec["long_name"] = pl.get("longname")
+        rec["short_name"] = pl.get("shortname")
+        rec["hw_model"] = pl.get("hardware")
+        if pl.get("id"):
+            rec["sender"] = pl["id"]
+    elif t == "telemetry" and isinstance(pl, dict):
+        rec["battery"] = pl.get("battery_level")
+        rec["voltage"] = pl.get("voltage")
+    return rec
+
+
+class MeshMqtt:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._client = None
+        self._messages = []
+        self._positions = {}        # sender -> {lat,lon,name,ts,src}
+        self._connected = False
+        self._error = None
+        self._cfg = {}
+
+    def status(self):
+        with self._lock:
+            return {"connected": self._connected, "error": self._error,
+                    "host": self._cfg.get("host"), "topic": self._cfg.get("topic"),
+                    "messages": len(self._messages), "positions": len(self._positions)}
+
+    def connect(self, host=None, port=None, user=None, password=None, topic=None):
+        if _mqtt_client is None:
+            return {"ok": False, "error": "paho-mqtt not installed (pip install paho-mqtt)"}
+        cfg = {"host": host or MESH_MQTT["host"], "port": int(port or MESH_MQTT["port"]),
+               "user": user if user is not None else MESH_MQTT["user"],
+               "password": password if password is not None else MESH_MQTT["password"],
+               "topic": topic or MESH_MQTT["topic"]}
+        with self._lock:
+            self._disconnect_locked()
+            self._cfg = cfg
+            self._error = None
+            try:
+                c = _mqtt_client.Client()
+                if cfg["user"]:
+                    c.username_pw_set(cfg["user"], cfg["password"] or "")
+                c.on_connect = self._on_connect
+                c.on_message = self._on_message
+                c.on_disconnect = self._on_disconnect
+                c.connect_async(cfg["host"], cfg["port"], keepalive=60)
+                c.loop_start()
+                self._client = c
+            except Exception as exc:
+                self._error = "MQTT connect failed: %s" % exc
+                return {"ok": False, "error": self._error}
+        return {"ok": True, "host": cfg["host"], "topic": cfg["topic"]}
+
+    def _on_connect(self, client, userdata, flags, rc, *a):  # pragma: no cover - network
+        if rc == 0:
+            with self._lock:
+                self._connected = True
+                self._error = None
+            try:
+                client.subscribe(self._cfg.get("topic") or MESH_MQTT["topic"])
+            except Exception:
+                pass
+        else:
+            with self._lock:
+                self._error = "MQTT rejected (rc=%s)" % rc
+
+    def _on_disconnect(self, *a):  # pragma: no cover - network
+        with self._lock:
+            self._connected = False
+
+    def _on_message(self, client, userdata, msg):  # pragma: no cover - network
+        try:
+            rec = parse_mqtt_json(msg.topic, msg.payload.decode("utf-8", "replace"))
+        except Exception:
+            rec = None
+        if not rec:
+            return
+        with self._lock:
+            if rec.get("type") == "text" and rec.get("text"):
+                rec["ts"] = time.time()
+                self._messages.append(rec)
+                if len(self._messages) > _MSG_RING:
+                    self._messages = self._messages[-_MSG_RING:]
+            if rec.get("lat") is not None and rec.get("lon") is not None and rec.get("sender"):
+                self._positions[rec["sender"]] = {
+                    "id": rec["sender"], "lat": rec["lat"], "lon": rec["lon"],
+                    "long_name": rec.get("long_name"), "ts": time.time(), "src": "mqtt"}
+            if rec.get("type") == "nodeinfo" and rec.get("sender"):
+                p = self._positions.setdefault(rec["sender"], {"id": rec["sender"], "src": "mqtt"})
+                p["long_name"] = rec.get("long_name") or p.get("long_name")
+                p["short_name"] = rec.get("short_name")
+                p["ts"] = time.time()
+
+    def publish_text(self, text, dest=None, channel=0, my_num=None):
+        with self._lock:
+            client = self._client
+            connected = self._connected
+        if not (client and connected):
+            return {"ok": False, "error": "MQTT not connected"}
+        cmd = {"from": my_num or 0, "type": "sendtext", "payload": (text or "")[:228],
+               "channel": int(channel or 0)}
+        if dest and dest not in ("^all", "!ffffffff"):
+            cmd["to"] = dest
+        try:
+            client.publish(self._cfg.get("publish_topic") or MESH_MQTT["publish_topic"], json.dumps(cmd))
+            return {"ok": True, "via": "mqtt", "to": dest or "^all", "channel": int(channel or 0)}
+        except Exception as exc:
+            return {"ok": False, "error": "MQTT publish failed: %s" % exc}
+
+    def messages(self):
+        with self._lock:
+            return list(self._messages)
+
+    def positions(self):
+        with self._lock:
+            return list(self._positions.values())
+
+    def _disconnect_locked(self):
+        if self._client:
+            try:
+                self._client.loop_stop()
+                self._client.disconnect()
+            except Exception:
+                pass
+        self._client = None
+        self._connected = False
+
+    def disconnect(self):
+        with self._lock:
+            self._disconnect_locked()
+        return {"ok": True}
+
+
 _link = MeshLink()
+_mqtt = MeshMqtt()
 
 
 def start(port=None):
@@ -314,25 +536,85 @@ def stop():
     return _link.stop()
 
 
+def connect_mqtt(host=None, port=None, user=None, password=None, topic=None):
+    return _mqtt.connect(host, port, user, password, topic)
+
+
+def disconnect_mqtt():
+    return _mqtt.disconnect()
+
+
+def send_text(text, dest=None, channel=0, via="auto"):
+    """Send a mesh text message via the connected node (serial) or MQTT.
+
+    ``via``: 'serial', 'mqtt', or 'auto' (serial if a node is connected, else MQTT).
+    """
+    text = (text or "").strip()
+    if not text:
+        return {"ok": False, "error": "empty message"}
+    serial_up = _link.status().get("running")
+    mqtt_up = _mqtt.status().get("connected")
+    order = {"serial": ["serial"], "mqtt": ["mqtt"]}.get(via, ["serial", "mqtt"])
+    last = {"ok": False, "error": "no Meshtastic node connected and MQTT not connected"}
+    for how in order:
+        if how == "serial" and serial_up:
+            last = _link.send_text(text, dest=dest, channel=channel)
+        elif how == "mqtt" and mqtt_up:
+            last = _mqtt.publish_text(text, dest=dest, channel=channel, my_num=_link._my_num)
+        else:
+            continue
+        if last.get("ok"):
+            _link._store_outbound(text, dest, channel, last.get("via"))
+            return last
+    return last
+
+
 def status():
     st = _link.status()
+    st["mqtt"] = _mqtt.status()
     st["detect"] = detect()
+    # merged counts across both sources
+    st["messages"] = st.get("messages", 0) + st["mqtt"].get("messages", 0)
     return st
 
 
 def nodes():
-    return _link.nodes()
+    n = _link.nodes()
+    serial_nodes = n.get("nodes", [])
+    have = {x.get("id") for x in serial_nodes if x.get("id")}
+    # add MQTT-only positioned stations the serial DB hasn't seen
+    for p in _mqtt.positions():
+        if p.get("id") and p["id"] not in have and p.get("lat") is not None:
+            serial_nodes.append({"id": p["id"], "num": None,
+                                 "long_name": p.get("long_name"), "short_name": p.get("short_name"),
+                                 "lat": p.get("lat"), "lon": p.get("lon"), "src": "mqtt",
+                                 "last_heard": int(p.get("ts") or 0), "is_self": False})
+            have.add(p["id"])
+    n["nodes"] = serial_nodes
+    n["count"] = len(serial_nodes)
+    return n
 
 
 def messages():
-    return _link.messages()
+    merged = []
+    for m in _link.messages().get("messages", []):
+        mm = dict(m); mm.setdefault("src", "serial"); merged.append(mm)
+    merged.extend(_mqtt.messages())
+    merged.sort(key=lambda m: m.get("ts") or 0)
+    return {"messages": merged[-_MSG_RING:], "count": len(merged)}
+
+
+def _pip_install(pkg):
+    for args in (["pip3", "install", "--break-system-packages", pkg],
+                 ["pip3", "install", pkg]):
+        rc, o, e = _run(args, timeout=600)
+        if rc == 0:
+            return (o or "") + (e or "")
+    return (o or "") + (e or "")
 
 
 def install():
-    """One-click install of the meshtastic Python package (pip). Fixed name."""
-    if _have_meshtastic():
-        return {"ok": True, "already": True, "detect": detect()}
-    out = ""
+    """One-click install of meshtastic (serial node) + paho-mqtt (MQTT/transmit)."""
     # Ensure pip3 exists (fresh Pi OS images sometimes ship without it).
     if _run(["pip3", "--version"], timeout=10)[0] == 127:
         env = dict(os.environ, DEBIAN_FRONTEND="noninteractive")
@@ -341,17 +623,19 @@ def install():
                            capture_output=True, text=True, timeout=300, check=False, env=env)
         except Exception:
             pass
-    for args in (["pip3", "install", "--break-system-packages", "meshtastic"],
-                 ["pip3", "install", "meshtastic"]):
-        rc, o, e = _run(args, timeout=600)
-        out = (o or "") + (e or "")
-        if rc == 0 and _have_meshtastic():
-            return {"ok": True, "detect": detect(),
-                    "output": "\n".join(out.strip().splitlines()[-10:])}
-    return {"ok": _have_meshtastic(), "detect": detect(),
-            "output": "\n".join((out or "").strip().splitlines()[-10:]),
-            "error": None if _have_meshtastic()
-            else "pip could not install meshtastic — check network/pip3, or run: pip3 install meshtastic"}
+    out = ""
+    if not _have_meshtastic():
+        out += _pip_install("meshtastic")
+    if _mqtt_client is None:                     # MQTT source/transmit
+        out += "\n" + _pip_install("paho-mqtt")
+    # re-probe paho (import cache): a fresh install won't flip _mqtt_client until
+    # restart, so report success on the pip result rather than the live import.
+    ok = _have_meshtastic() or ("paho-mqtt" in out.lower())
+    err = None
+    if not _have_meshtastic() and _mqtt_client is None:
+        err = "pip could not install meshtastic/paho-mqtt — check network/pip3"
+    return {"ok": ok if err is None else False, "detect": detect(),
+            "output": "\n".join(out.strip().splitlines()[-12:]), "error": err}
 
 
 # --------------------------------------------------------------------------
@@ -405,6 +689,31 @@ def selftest():
     check("usb: nRF52 VID-only match", parse_lsusb_for_mesh(
         "Bus 001 Device 003: ID 239a:8029 Adafruit")[0] == "239a:")
     check("usb: nothing -> None", parse_lsusb_for_mesh("ID 1d6b:0002 root hub") == (None, None))
+
+    # --- MQTT JSON parsing (Meshtastic Internet bridge) ---
+    txt = parse_mqtt_json("msh/US/2/json/LongFast/!33668914",
+                          '{"channel":0,"from":862243668,"sender":"!33668914","to":4294967295,'
+                          '"type":"text","payload":{"text":"Hello mesh"},"timestamp":1700000000}')
+    check("mqtt: text message parsed",
+          txt and txt["type"] == "text" and txt["text"] == "Hello mesh"
+          and txt["sender"] == "!33668914" and txt["src"] == "mqtt", str(txt))
+    pos = parse_mqtt_json("msh/EU/2/json/x/!abcd",
+                          '{"from":1,"sender":"!abcd","type":"position",'
+                          '"payload":{"latitude_i":593293000,"longitude_i":180686000,"altitude":30}}')
+    check("mqtt: position lat/lon (1e-7) decoded",
+          pos and abs(pos["lat"] - 59.3293) < 1e-4 and abs(pos["lon"] - 18.0686) < 1e-4, str(pos))
+    ni = parse_mqtt_json("t", '{"from":2,"type":"nodeinfo","payload":{"id":"!dead","longname":"Base","shortname":"BAS","hardware":31}}')
+    check("mqtt: nodeinfo names read",
+          ni and ni["long_name"] == "Base" and ni["short_name"] == "BAS" and ni["sender"] == "!dead", str(ni))
+    check("mqtt: 'from'-only synthesizes sender id",
+          parse_mqtt_json("t", '{"from":287454020,"type":"text","payload":{"text":"hi"}}')["sender"] == "!11223344")
+    check("mqtt: junk -> None", parse_mqtt_json("t", "not json") is None and parse_mqtt_json("t", "[1,2]") is None)
+
+    # --- transmit routing: nothing connected -> clean error, no crash ---
+    r = send_text("test", via="auto")
+    check("tx: send with no serial/mqtt -> error (no crash)",
+          r.get("ok") is False and "connected" in (r.get("error") or ""), str(r))
+    check("tx: empty message rejected", send_text("   ").get("ok") is False)
 
     passed = sum(1 for r in results if r["pass"])
     return {"pass": passed == len(results), "passed": passed,

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -19042,6 +19042,28 @@ def register_network_diagnostics(app, logger=None):
         _log("net/mesh/install")
         return jsonify(meshtastic_node.install())
 
+    # Meshtastic MQTT (Internet bridge) — independent of the USB node, so it can
+    # run with no device at all (like APRS-IS for APRS).
+    @app.route('/api/net/mesh/mqtt/connect', methods=['POST'])
+    def net_mesh_mqtt_connect():
+        data = request.get_json(silent=True) or {}
+        _log(f"net/mesh/mqtt/connect host={data.get('host')} topic={data.get('topic')}")
+        return jsonify(meshtastic_node.connect_mqtt(host=data.get('host'), port=data.get('port'),
+                                                    user=data.get('user'), password=data.get('password'),
+                                                    topic=data.get('topic')))
+
+    @app.route('/api/net/mesh/mqtt/disconnect', methods=['POST'])
+    def net_mesh_mqtt_disconnect():
+        _log("net/mesh/mqtt/disconnect")
+        return jsonify(meshtastic_node.disconnect_mqtt())
+
+    @app.route('/api/net/mesh/send', methods=['POST'])
+    def net_mesh_send():
+        data = request.get_json(silent=True) or {}
+        _log(f"net/mesh/send to={data.get('to')} via={data.get('via')}")
+        return jsonify(meshtastic_node.send_text(data.get('text'), dest=data.get('to'),
+                                                 channel=data.get('channel', 0), via=data.get('via', 'auto')))
+
     @app.route('/api/net/mesh/selftest', methods=['GET'])
     def net_mesh_selftest():
         return jsonify(meshtastic_node.selftest())

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,7 @@ simple-websocket>=1.0.0
 # WiFi Defense 802.11 frame monitor (wifi_defense.py). Declared here so a fresh
 # clone always has it rather than relying on an ambient install.
 scapy>=2.5.0
+# paho-mqtt drives the Meshtastic MQTT source/transmit (meshtastic_node.py) —
+# receive mesh traffic over the Internet and send via a downlink gateway. The
+# code degrades gracefully when it's absent (MQTT features just disable).
+paho-mqtt>=1.6.0


### PR DESCRIPTION
Extends the Meshtastic module beyond serial receive-only:

- MQTT source (Internet bridge, like APRS-IS for APRS): paho-mqtt client to a broker (default public mqtt.meshtastic.org, JSON topic msh/+/2/json/#) that streams mesh traffic worldwide with NO node — nodes/positions/text parsed by parse_mqtt_json. Runs independently of the USB node and the RTL-SDR.
- Transmit: a Send box puts a text message onto the mesh through the connected node's LoRa (licence-free ISM) when present, else over MQTT via a downlink gateway. Sent messages log to the feed tagged TX; serial/mqtt/tx sources are tagged throughout. send_text(via=auto|serial|mqtt).
- Merged model: nodes() and messages() fuse serial + MQTT; status() reports both links; detect() adds mqtt_available (paho only, no node needed).

Wiring: /api/net/mesh/mqtt/{connect,disconnect} + /api/net/mesh/send. Mesh Nodes page gains the ☁ MQTT button + topic, a compose/send row, and src badges; works with a node, MQTT-only, or both. paho-mqtt added to requirements.txt (installed by both scripts) and the in-app Install button now grabs it alongside meshtastic.

parse_mqtt_json + TX routing selftests: meshtastic 17/17. Graceful-degrades when paho is absent (MQTT features just disable). Docs updated.