### PR TITLE
Signal Intelligence: fix invisible VOR button + always show Mesh Nodes

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -2664,7 +2664,7 @@
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"/></svg>
                             Pager Decode
                         </a>
-                        <a href="/vor-radial" target="_blank" rel="noopener" id="wifi-vor-btn" title="VOR Radial — decode a VOR nav beacon's radial/bearing (needs an RTL-SDR tuned to 108–118 MHz)" class="hidden items-center gap-1.5 bg-sky-700 hover:bg-sky-600 text-white px-3 py-2 rounded text-sm font-semibold">
+                        <a href="/vor-radial" target="_blank" rel="noopener" id="wifi-vor-btn" title="VOR Radial — decode a VOR nav beacon's radial/bearing (needs an RTL-SDR tuned to 108–118 MHz)" class="hidden items-center gap-1.5 bg-sky-600 hover:bg-sky-700 text-white px-3 py-2 rounded text-sm font-semibold">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 0v10l6-3"/></svg>
                             VOR Radial
                         </a>
@@ -8361,7 +8361,7 @@
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260822-mobile-opacity"></script>
     <script src="/web/scripts/skyview_vr.js?v=20260822-rich-info-panel"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260826-aprs"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260827-btnfix"></script>
 
 
 

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -2052,14 +2052,13 @@ function _wifiRfwfShow() {
         adsb.classList.toggle('hidden', !showA);
         adsb.classList.toggle('inline-flex', showA);
     }
-    // Mesh Nodes uses a separate USB Meshtastic node. Show it alongside the other
-    // SDR tools whenever an SDR is present, a Meshtastic node is detected, or the
-    // demo is on — the page itself guides plugging in a node / installing the pkg.
+    // Mesh Nodes reads a USB Meshtastic node, but its MQTT source works over the
+    // Internet with no node at all (like APRS-IS), so always offer it — the page
+    // guides plugging in a node / connecting MQTT / installing the packages.
     const mesh = document.getElementById('wifi-mesh-btn');
     if (mesh) {
-        const showM = rtl || hackrf || !!_wifiState.meshAvailable || demo;
-        mesh.classList.toggle('hidden', !showM);
-        mesh.classList.toggle('inline-flex', showM);
+        mesh.classList.remove('hidden');
+        mesh.classList.add('inline-flex');
     }
     // Pager decode needs an RTL-SDR (rtl_fm|multimon-ng); show when RTL present
     // or demo on (synthetic feed).


### PR DESCRIPTION
- VOR Radial button used bg-sky-700 / hover:bg-sky-600, both of which the Tailwind purge dropped from the committed web/css/tailwind.css — so the button had no background at all (white text on the dark bar). Switched to bg-sky-600 / hover:bg-sky-700 (both survive the purge), a visible sky-blue distinct from ADS-B's cyan. Same class of bug as the old teal-purge issue.
- Mesh Nodes button: always show it. Its MQTT source works over the Internet with no node/SDR at all (like APRS-IS), so gating it on hardware hid it from the exact users who could still use it. Mirrors the APRS button.

Cache-bust bumped.