### PR TITLE
Signal Intelligence tools: '← Ragnar' returns to the Signal Intellige…

### DIFF
--- a/demos/adsb_radar.html
+++ b/demos/adsb_radar.html
@@ -98,7 +98,7 @@
   </header>
 
   <div class="bar">
-    <div class="grp"><a href="/" class="ctl back" title="Return to the Ragnar dashboard">&#8592;&nbsp;Ragnar</a></div>
+    <div class="grp"><a href="/#network/wifi" class="ctl back" title="Return to the Ragnar dashboard">&#8592;&nbsp;Ragnar</a></div>
     <div class="grp"><a href="/vor-radial" class="ctl" title="VOR Radial — decode a VOR nav beacon's bearing (108–118 MHz)">&#127760;&nbsp;VOR Radial</a></div>
     <div class="grp"><button class="ctl go" id="startbtn" aria-pressed="false" title="Start / stop dump1090 (uses the RTL-SDR — stops the sub-GHz sweep)">&#9654;&nbsp;Start</button></div>
     <div class="grp"><span class="lbl">My&nbsp;lat</span><input class="tin" id="rx-lat" type="number" step="0.0001" placeholder="51.5074"></div>

--- a/demos/aprs.html
+++ b/demos/aprs.html
@@ -81,7 +81,7 @@
   </header>
 
   <div class="bar">
-    <div class="grp"><a href="/" class="ctl back">&#8592;&nbsp;Ragnar</a></div>
+    <div class="grp"><a href="/#network/wifi" class="ctl back">&#8592;&nbsp;Ragnar</a></div>
     <div class="grp"><a href="/rf-waterfall" class="ctl">〜&nbsp;RF Waterfall</a></div>
     <div class="grp"><span class="lbl">Region</span><select class="tin" id="region" style="width:auto"></select></div>
     <div class="grp"><span class="tag idle" id="rftag">RF idle</span></div>

--- a/demos/mesh_nodes.html
+++ b/demos/mesh_nodes.html
@@ -81,7 +81,7 @@
   </header>
 
   <div class="bar">
-    <div class="grp"><a href="/" class="ctl back">&#8592;&nbsp;Ragnar</a></div>
+    <div class="grp"><a href="/#network/wifi" class="ctl back">&#8592;&nbsp;Ragnar</a></div>
     <div class="grp"><a href="/rf-waterfall" class="ctl" title="LoRa spectrum overlay (energy view)">〜&nbsp;RF Waterfall</a></div>
     <div class="grp"><a href="/mesh-map" class="ctl" title="Full-screen map of the mesh (Leaflet)" style="border-color:rgba(123,140,210,.5);color:var(--mesh)">&#128506;&nbsp;Full map view</a></div>
     <div class="grp"><button class="ctl go" id="startbtn" aria-pressed="false" title="Connect to the USB Meshtastic node (real LoRa RF)">&#9654;&nbsp;Node</button></div>

--- a/demos/pager_decode.html
+++ b/demos/pager_decode.html
@@ -67,7 +67,7 @@
   </header>
 
   <div class="bar">
-    <div class="grp"><a href="/" class="ctl back">&#8592;&nbsp;Ragnar</a></div>
+    <div class="grp"><a href="/#network/wifi" class="ctl back">&#8592;&nbsp;Ragnar</a></div>
     <div class="grp"><a href="/rf-waterfall" class="ctl">〜&nbsp;RF Waterfall</a></div>
     <div class="grp"><button class="ctl go" id="startbtn" aria-pressed="false" title="Start / stop decoding (uses the RTL-SDR)">&#9654;&nbsp;Start</button></div>
     <div class="grp"><span class="lbl">Channel</span><select class="tin" id="preset"></select></div>

--- a/demos/rf_waterfall.html
+++ b/demos/rf_waterfall.html
@@ -167,7 +167,7 @@
   </header>
 
   <div class="bar">
-    <div class="grp"><a href="/" class="ctl back" id="back" title="Return to the Ragnar dashboard">&#8592;&nbsp;Ragnar</a></div>
+    <div class="grp"><a href="/#network/wifi" class="ctl back" id="back" title="Return to the Ragnar dashboard">&#8592;&nbsp;Ragnar</a></div>
     <div class="grp"><a href="/adsb-radar" class="ctl" id="radarlink" title="ADS-B radar — live aircraft at 1090 MHz (dump1090)">&#9992;&nbsp;ADS-B Radar</a></div>
     <div class="grp"><a href="/mesh-nodes" class="ctl" id="meshlink" title="Mesh Nodes — real Meshtastic enumeration via a USB companion node">&#9741;&nbsp;Mesh Nodes</a></div>
     <div class="grp"><a href="/pager-decode" class="ctl" id="pagerlink" title="Pager Decode — POCSAG/FLEX + Motorola QCII (rtl_fm)">&#128244;&nbsp;Pager Decode</a></div>

--- a/demos/vor_radial.html
+++ b/demos/vor_radial.html
@@ -71,7 +71,7 @@
   </header>
 
   <div class="bar">
-    <div class="grp"><a href="/" class="ctl back">&#8592;&nbsp;Ragnar</a></div>
+    <div class="grp"><a href="/#network/wifi" class="ctl back">&#8592;&nbsp;Ragnar</a></div>
     <div class="grp"><a href="/adsb-radar" class="ctl">&#9992;&nbsp;ADS-B Radar</a></div>
     <div class="grp"><button class="ctl go" id="startbtn" aria-pressed="false" title="Start / stop decoding (uses the RTL-SDR)">&#9654;&nbsp;Start</button></div>
     <div class="grp"><span class="lbl">Station</span><select class="tin" id="preset"></select></div>


### PR DESCRIPTION
…nce tab

The back link on every SI tool page (RF Waterfall, ADS-B, Mesh Nodes, Pager, VOR, APRS) went to '/', landing on the default dashboard tab. Point it at '/#network/wifi' instead: the existing hash router (routeFromHash) opens the Network tab and its Signal Intelligence subtab on load, so you land back where you came from. (mesh_map's '← Nodes' still returns to the Mesh Nodes page.)