### PR TITLE
Signal Intelligence tools: open in the same tab, not a new one

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -2648,27 +2648,27 @@
                             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4h4M20 8V4h-4M4 16v4h4M20 16v4h-4"/></svg>
                             Full screen
                         </button>
-                        <a href="/rf-waterfall" target="_blank" rel="noopener" id="wifi-rfwf-btn" title="Open the full-screen RF Waterfall page — true-RF sub-GHz (RTL-SDR) + Wi-Fi bands (HackRF), stacked" class="hidden items-center gap-1.5 bg-indigo-600 hover:bg-indigo-700 text-white px-3 py-2 rounded text-sm font-semibold">
+                        <a href="/rf-waterfall" id="wifi-rfwf-btn" title="Open the full-screen RF Waterfall page — true-RF sub-GHz (RTL-SDR) + Wi-Fi bands (HackRF), stacked" class="hidden items-center gap-1.5 bg-indigo-600 hover:bg-indigo-700 text-white px-3 py-2 rounded text-sm font-semibold">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
                             RF Waterfall page
                         </a>
-                        <a href="/adsb-radar" target="_blank" rel="noopener" id="wifi-adsb-btn" title="ADS-B Radar — live aircraft at 1090 MHz (needs an RTL-SDR + dump1090)" class="hidden items-center gap-1.5 bg-cyan-700 hover:bg-cyan-600 text-white px-3 py-2 rounded text-sm font-semibold">
+                        <a href="/adsb-radar" id="wifi-adsb-btn" title="ADS-B Radar — live aircraft at 1090 MHz (needs an RTL-SDR + dump1090)" class="hidden items-center gap-1.5 bg-cyan-700 hover:bg-cyan-600 text-white px-3 py-2 rounded text-sm font-semibold">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg>
                             ADS-B Radar
                         </a>
-                        <a href="/mesh-nodes" target="_blank" rel="noopener" id="wifi-mesh-btn" title="Mesh Nodes — real Meshtastic mesh enumeration via a USB companion node" class="hidden items-center gap-1.5 bg-indigo-800 hover:bg-indigo-700 text-white px-3 py-2 rounded text-sm font-semibold">
+                        <a href="/mesh-nodes" id="wifi-mesh-btn" title="Mesh Nodes — real Meshtastic mesh enumeration via a USB companion node" class="hidden items-center gap-1.5 bg-indigo-800 hover:bg-indigo-700 text-white px-3 py-2 rounded text-sm font-semibold">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4a2 2 0 100 4 2 2 0 000-4zM5 16a2 2 0 100 4 2 2 0 000-4zm14 0a2 2 0 100 4 2 2 0 000-4zM12 8v4m0 0l-5 4m5-4l5 4"/></svg>
                             Mesh Nodes
                         </a>
-                        <a href="/pager-decode" target="_blank" rel="noopener" id="wifi-pager-btn" title="Pager Decode — POCSAG/FLEX messages (needs an RTL-SDR + multimon-ng)" class="hidden items-center gap-1.5 bg-orange-700 hover:bg-orange-600 text-white px-3 py-2 rounded text-sm font-semibold">
+                        <a href="/pager-decode" id="wifi-pager-btn" title="Pager Decode — POCSAG/FLEX messages (needs an RTL-SDR + multimon-ng)" class="hidden items-center gap-1.5 bg-orange-700 hover:bg-orange-600 text-white px-3 py-2 rounded text-sm font-semibold">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"/></svg>
                             Pager Decode
                         </a>
-                        <a href="/vor-radial" target="_blank" rel="noopener" id="wifi-vor-btn" title="VOR Radial — decode a VOR nav beacon's radial/bearing (needs an RTL-SDR tuned to 108–118 MHz)" class="hidden items-center gap-1.5 bg-sky-600 hover:bg-sky-700 text-white px-3 py-2 rounded text-sm font-semibold">
+                        <a href="/vor-radial" id="wifi-vor-btn" title="VOR Radial — decode a VOR nav beacon's radial/bearing (needs an RTL-SDR tuned to 108–118 MHz)" class="hidden items-center gap-1.5 bg-sky-600 hover:bg-sky-700 text-white px-3 py-2 rounded text-sm font-semibold">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 0v10l6-3"/></svg>
                             VOR Radial
                         </a>
-                        <a href="/aprs" target="_blank" rel="noopener" id="wifi-aprs-btn" title="APRS — ham packet positions &amp; messages, off-air (RTL-SDR) and worldwide via APRS-IS (works without a dongle)" class="hidden items-center gap-1.5 bg-emerald-700 hover:bg-emerald-600 text-white px-3 py-2 rounded text-sm font-semibold">
+                        <a href="/aprs" id="wifi-aprs-btn" title="APRS — ham packet positions &amp; messages, off-air (RTL-SDR) and worldwide via APRS-IS (works without a dongle)" class="hidden items-center gap-1.5 bg-emerald-700 hover:bg-emerald-600 text-white px-3 py-2 rounded text-sm font-semibold">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
                             APRS
                         </a>


### PR DESCRIPTION
The six SI tool buttons (RF Waterfall, ADS-B, Mesh Nodes, Pager, VOR, APRS) used target=_blank, spawning a new browser tab each. Removed it so they navigate in place — combined with the '← Ragnar' link (-> #network/wifi) that's a clean same-tab there-and-back flow.