### PR TITLE
VDL Mode 2 / ATN decoding on the ADS-B radar (dumpvdl2 + libacars)

### DIFF
--- a/demos/adsb_radar.html
+++ b/demos/adsb_radar.html
@@ -79,6 +79,25 @@
   .acars-msg .body{font-family:var(--mono);font-size:12px;color:var(--ink);white-space:pre-wrap;overflow-wrap:anywhere}
   .acars-msg .meta{font-family:var(--mono);font-size:10px;color:var(--muted);text-align:right;white-space:nowrap}
   .acars-msg.match{background:rgba(46,160,150,.05)} .acars-msg .who .onradar{color:var(--live);font-size:9px}
+  /* VDL Mode 2 / ATN — same layout as ACARS but a message-type column */
+  .vdl2card{margin-top:16px}
+  .vdl2-list{max-height:none;padding:4px 0}
+  .vdl2-msg{padding:9px 14px;border-bottom:1px solid var(--line-soft);display:grid;grid-template-columns:130px 92px 1fr auto;gap:12px;align-items:start}
+  @media (max-width:720px){.vdl2-msg{grid-template-columns:1fr;gap:2px}}
+  .vdl2-msg .who{font-family:var(--mono);font-size:12px}
+  .vdl2-msg .who .tail{color:var(--cyan);font-weight:600} .vdl2-msg .who .flt{color:var(--ink-dim)} .vdl2-msg .who .icao{color:var(--muted);font-size:10px}
+  .vdl2-msg .who .onradar{color:var(--live);font-size:9px}
+  .vdl2-msg .body{font-family:var(--mono);font-size:12px;color:var(--ink);white-space:pre-wrap;overflow-wrap:anywhere}
+  .vdl2-msg .meta{font-family:var(--mono);font-size:10px;color:var(--muted);text-align:right;white-space:nowrap}
+  .vdl2-msg.match{background:rgba(46,160,150,.05)}
+  .vtype{font-family:var(--mono);font-size:9px;font-weight:700;letter-spacing:.03em;padding:1px 5px;border-radius:4px;display:inline-block}
+  .vtype.cpdlc{color:#f2b155;background:rgba(242,177,85,.13)}        /* ATC controller link */
+  .vtype.adsc{color:#b98bff;background:rgba(185,139,255,.13)}       /* surveillance contract */
+  .vtype.acars{color:var(--cyan);background:rgba(46,160,150,.13)}
+  .vtype.avlc,.vtype.x25{color:var(--muted);background:rgba(150,150,150,.12)}
+  .vdl2-msg .dir{font-size:10px;color:var(--muted);display:block;margin-top:2px}
+  .vdl2-msg .dir.up{color:#f2b155}  /* uplink: ground → aircraft */
+  .vdl2-msg .dir.down{color:#7fd1c4} /* downlink: aircraft → ground */
   .stat{display:flex;flex-direction:column;gap:1px}
   .stat .k{font-family:var(--mono);font-size:9px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}
   .stat .v{font-family:var(--mono);font-size:14px;color:var(--radar)}
@@ -227,9 +246,21 @@
     <div class="acars-list" id="acars-list"><div class="empty" id="acars-empty">ACARS off — start it to read aircraft datalink messages (VHF ~131 MHz). One dongle, so this pauses the radar.</div></div>
   </div>
 
+  <div class="card vdl2card">
+    <div class="tcap">
+      <span class="t">📡 VDL Mode 2 / ATN <span class="c" id="vdl2-count"></span></span>
+      <span style="display:flex;gap:8px;align-items:center">
+        <span class="tag idle" id="vdl2-mode">off</span>
+        <button class="ctl" id="vdl2-btn" style="padding:5px 11px" title="VDL Mode 2 uses the RTL-SDR at ~136 MHz — starting it stops the 1090 MHz radar (one dongle)">&#9654;&nbsp;Start VDL2</button>
+      </span>
+    </div>
+    <div class="vdl2-list" id="vdl2-list"><div class="empty" id="vdl2-empty">VDL Mode 2 off — the modern datalink (~136 MHz): ACARS-over-VDL2, <b>CPDLC</b> controller↔pilot clearances and <b>ADS-C</b> position contracts, decoded via dumpvdl2 + libacars. One dongle, so this pauses the radar.</div></div>
+  </div>
+
   <footer>
     <div><b>How it works:</b> dump1090 decodes 1090 MHz ADS-B; each aircraft is placed by its own broadcast lat/lon relative to your receiver location. Set <b>My lat/lon</b> (or use the browser location) so the range rings and bearings are correct. Blip colour = altitude. Range rings label in the selected unit.</div>
     <div style="margin-top:6px"><b>✉ ACARS:</b> aircraft VHF datalink (~131 MHz) — position reports, OOOI times, weather, load sheets and free-text crew↔ops messages, in the clear via acarsdec. Matched to the contacts above by tail/flight. One dongle means ACARS and the 1090 MHz radar can't run at once.</div>
+    <div style="margin-top:6px"><b>📡 VDL Mode 2 / ATN:</b> the modern successor to VHF ACARS — a D8PSK datalink on ~136 MHz decoded by <b>dumpvdl2 + libacars</b>. Carries ACARS-over-VDL2, <b>CPDLC</b> (controller↔pilot clearances: climb/descend, "CONTACT &lt;freq&gt;", "MONITOR &lt;unit&gt;", WILCO) and <b>ADS-C</b> (contracted position/intent reports). ↑ uplink = ground→aircraft, ↓ downlink = aircraft→ground. All in the clear, receive-only.</div>
     <div style="margin-top:6px"><b>One dongle:</b> starting the radar takes the RTL-SDR from the sub-GHz sweep/decoder (and vice-versa). Receive-only — Ragnar never transmits.</div>
   </footer>
 </div>
@@ -671,6 +702,105 @@
     }).catch(function(){});
   }
 
+  // ---- VDL Mode 2 / ATN datalink ----
+  // Modern successor to VHF ACARS: dumpvdl2 + libacars decode ACARS-over-VDL2,
+  // CPDLC (controller<->pilot) and ADS-C (position contracts) on ~136 MHz.
+  var vdl2Running=false, vdl2Mode='off', vdl2Msgs=[], vdl2Seq=0, vdl2Poll=null, vdl2SynthTimer=null;
+  var vdl2Btn=document.getElementById('vdl2-btn');
+  function setVdl2Mode(m){ vdl2Mode=m; var el=document.getElementById('vdl2-mode');
+    el.className='tag '+(m==='live'?'live':(m==='synth'?'synth':'idle')); el.textContent=(m==='live'?'live':(m==='synth'?'synthetic':'off')); }
+  function icaosOnRadar(){ var set={}; planes.forEach(function(p){ if(p.icao)set[String(p.icao).toUpperCase()]=1; }); return set; }
+  function vtypeClass(t){ t=(t||'').toLowerCase(); return t==='cpdlc'?'cpdlc':(t==='ads-c'?'adsc':(t==='acars'?'acars':(t==='x.25'?'x25':'avlc'))); }
+  function renderVdl2(){
+    var el=document.getElementById('vdl2-list'); document.getElementById('vdl2-count').textContent=vdl2Msgs.length?('· '+vdl2Msgs.length):'';
+    if(!vdl2Msgs.length){ el.innerHTML='<div class="empty" id="vdl2-empty">'+(vdl2Running||vdl2Mode==='synth'?'Listening for VDL Mode 2… (~136 MHz)':'VDL Mode 2 off — CPDLC / ADS-C / ACARS-over-VDL2. One dongle, so this pauses the radar.')+'</div>'; return; }
+    var onradar=tailsOnRadar(), onicao=icaosOnRadar();
+    el.innerHTML=vdl2Msgs.slice().reverse().slice(0,80).map(function(m){
+      var match=(m.reg&&onradar[m.reg.toUpperCase()])||(m.flight&&onradar[m.flight.toUpperCase()])||(m.icao&&onicao[String(m.icao).toUpperCase()]);
+      var id=m.reg?('<span class="tail">'+esc(m.reg)+'</span>'):(m.icao?'<span class="icao">'+esc(m.icao)+'</span>':'<span class="tail">—</span>');
+      var who=id+(m.flight?' <span class="flt">'+esc(m.flight)+'</span>':'')+(m.reg&&m.icao?' <span class="icao">'+esc(m.icao)+'</span>':'')
+        +(match?' <span class="onradar">● on radar</span>':'');
+      var dir=m.direction==='uplink'?'<span class="dir up">↑ uplink (ATC→ac)</span>':(m.direction==='downlink'?'<span class="dir down">↓ downlink (ac→ATC)</span>':'');
+      var tlabel=m.type==='ADS-C'?'ADS-C':(m.type||'AVLC');
+      var typ='<span class="vtype '+vtypeClass(m.type)+'">'+esc(tlabel)+'</span>'+dir;
+      var body=m.text?esc(m.text):'<span style="color:var(--muted)">('+esc(tlabel)+' frame)</span>';
+      if(m.type==='ACARS'&&m.label_meaning) body+='<span style="color:var(--muted);font-size:10px;display:block">'+esc(m.label+' · '+m.label_meaning)+'</span>';
+      var meta=(m.freq_mhz?esc(m.freq_mhz)+' MHz':'')+(m.level!=null?' · '+m.level+'dB':'');
+      return '<div class="vdl2-msg'+(match?' match':'')+'"><div class="who">'+who+'</div><div>'+typ+'</div>'
+        +'<div class="body">'+body+'</div><div class="meta">'+meta+'</div></div>';
+    }).join('');
+  }
+  vdl2Btn.addEventListener('click',function(){ vdl2Running?stopVdl2():startVdl2(); });
+  function startVdl2(){
+    // one dongle: VDL2 at 136 MHz can't coexist with the 1090 MHz radar (or ACARS)
+    if(running){ stopRun(); }
+    if(acarsRunning){ stopAcars(); }
+    vdl2Running=true; vdl2Btn.setAttribute('aria-pressed','true'); vdl2Btn.innerHTML='&#10074;&#10074;&nbsp;Stop VDL2';
+    vdl2Seq=0; vdl2Msgs=[]; renderVdl2();
+    fetch('/api/net/vdl2/start',{method:'POST'}).then(function(r){return r.json();}).then(function(res){
+      if(res&&res.error){ if(DEMO_ON) vdl2Synth(); else { document.getElementById('vdl2-list').innerHTML='<div class="empty">Could not start VDL2: '+esc(res.error)+(res.error&&res.error.indexOf('not installed')>=0?' — <button class="ctl" id="vdl2-install" style="margin-left:6px;padding:3px 8px">⬇ Install dumpvdl2</button>':'')+'</div>'; wireVdl2Install(); } }
+    }).catch(function(){});
+    if(vdl2Poll)clearInterval(vdl2Poll); vdl2Poll=setInterval(pollVdl2,2000); pollVdl2();
+  }
+  function stopVdl2(){
+    vdl2Running=false; vdl2Btn.setAttribute('aria-pressed','false'); vdl2Btn.innerHTML='&#9654;&nbsp;Start VDL2';
+    if(vdl2Poll){clearInterval(vdl2Poll);vdl2Poll=null;}
+    fetch('/api/net/vdl2/stop',{method:'POST'}).catch(function(){});
+    if(DEMO_ON) vdl2Synth(); else { setVdl2Mode('off'); renderVdl2(); }
+  }
+  function wireVdl2Install(){ var b=document.getElementById('vdl2-install'); if(!b)return;
+    b.addEventListener('click',function(){ b.textContent='Building… (~4-8 min, libacars+dumpvdl2)'; b.disabled=true;
+      fetch('/api/net/vdl2/install',{method:'POST'}).then(function(r){return r.json();}).then(function(res){
+        if(res&&res.ok){ startVdl2(); } else { b.textContent='⬇ Install dumpvdl2'; b.disabled=false; }
+      }).catch(function(){ b.textContent='⬇ Install dumpvdl2'; b.disabled=false; }); }); }
+  function pollVdl2(){
+    fetch('/api/net/vdl2/messages?since='+vdl2Seq).then(function(r){return r.json();}).then(function(d){
+      if(!d)return;
+      if(d.running){ setVdl2Mode('live'); if(d.messages&&d.messages.length){ d.messages.forEach(function(m){vdl2Msgs.push(m);}); vdl2Seq=d.seq; if(vdl2Msgs.length>500)vdl2Msgs=vdl2Msgs.slice(-500); renderVdl2(); } }
+      else if(d.error && DEMO_ON){ vdl2Synth(); }
+    }).catch(function(){});
+  }
+  // synthetic VDL2 — mix of CPDLC, ADS-C and ACARS-over-VDL2, tied to synthetic aircraft
+  var VDSAMPLES=[
+    {type:'CPDLC',direction:'uplink',text:'[#12] CONTACT LONDON CONTROL 128.075'},
+    {type:'CPDLC',direction:'uplink',text:'[#14] CLIMB TO AND MAINTAIN FL380'},
+    {type:'CPDLC',direction:'downlink',text:'[#4] WILCO'},
+    {type:'CPDLC',direction:'downlink',text:'[#6] REQUEST DIRECT TO SURAT'},
+    {type:'CPDLC',direction:'uplink',text:'[#20] MONITOR SHANWICK 127.650'},
+    {type:'ADS-C',direction:'downlink',text:'POS 51.4820 -0.4510 / 38000 ft'},
+    {type:'ADS-C',direction:'downlink',text:'POS 55.9120 -12.3400 / 36000 ft'},
+    {type:'ACARS',direction:'downlink',label:'15',label_meaning:'Position report',text:'POS N54.1 W030.2 FL360 M0.80 OAT-56'},
+    {type:'ACARS',direction:'uplink',label:'22',label_meaning:'Departure/arrival (OOOI)',text:'OUT 1412 OFF 1428 GATE A22'},
+    {type:'ACARS',direction:'downlink',label:'H1',label_meaning:'Free text',text:'OPS: EXPECT HOLDING BIG, CTOT 1455'}
+  ];
+  function vdl2Synth(){
+    setVdl2Mode('synth');
+    if(!vdl2Msgs._synth){ vdl2Msgs=[]; vdl2Msgs._synth=true; }
+    if(vdl2SynthTimer) { renderVdl2(); return; }
+    for(var i=0;i<6;i++) pushSynthVdl2();
+    renderVdl2();
+    vdl2SynthTimer=setInterval(function(){ if(Math.random()<0.75){ pushSynthVdl2(); renderVdl2(); } },2800);
+  }
+  function pushSynthVdl2(){
+    var p=(planes&&planes.length)?planes[(Math.random()*planes.length)|0]:null;
+    var s=VDSAMPLES[(Math.random()*VDSAMPLES.length)|0];
+    var ch=[136.725,136.775,136.800,136.825,136.975][(Math.random()*5)|0];
+    var icao=p?p.icao:('3C'+('0123456789ABCDEF'[(Math.random()*16)|0])+('0123456789ABCDEF'[(Math.random()*16)|0])+('0123456789ABCDEF'[(Math.random()*16)|0])+'A');
+    vdl2Msgs.push({type:s.type,direction:s.direction,icao:icao,
+      reg:s.type==='ACARS'?(p?p.tail:'D-A'+('IBCM'[(Math.random()*4)|0]+'A')):null,
+      flight:p?p.callsign:'DLH'+(100+((Math.random()*899)|0)), label:s.label||null, label_meaning:s.label_meaning||null,
+      text:s.text, freq_mhz:ch, level:-(12+((Math.random()*22)|0)), ts:Date.now()/1000});
+    if(vdl2Msgs.length>500)vdl2Msgs=vdl2Msgs.slice(-500);
+  }
+  function vdl2CheckStatus(){
+    fetch('/api/net/vdl2/status').then(function(r){return r.json();}).then(function(st){
+      if(st&&st.running){ vdl2Running=true; vdl2Btn.setAttribute('aria-pressed','true'); vdl2Btn.innerHTML='&#10074;&#10074;&nbsp;Stop VDL2'; if(!vdl2Poll){vdl2Poll=setInterval(pollVdl2,2000);pollVdl2();} return; }
+      var det=(st&&st.detect)||{};
+      if(det.tools_installed===false && !vdl2Running && vdl2Mode!=='synth' && !DEMO_ON){ vdl2Btn.title='dumpvdl2 not installed — click to install & start'; }
+      if(DEMO_ON && vdl2Mode==='off'){ vdl2Synth(); }
+    }).catch(function(){});
+  }
+
   // ---- route / world map ----
   // Click a contact -> fetch its filed route (origin/destination airports) from
   // the backend (cache-first, adsbdb on a miss) and draw a world map: the great-
@@ -837,8 +967,8 @@
   resize();
   window.addEventListener('resize',function(){resize(); routeTick();});
   requestAnimationFrame(anim);
-  refreshConfig().then(function(){ checkStatus(); acarsCheckStatus();
-    setInterval(function(){ if(!running) refreshConfig().then(function(){ checkStatus(); acarsCheckStatus(); }); },5000); });
+  refreshConfig().then(function(){ checkStatus(); acarsCheckStatus(); vdl2CheckStatus();
+    setInterval(function(){ if(!running) refreshConfig().then(function(){ checkStatus(); acarsCheckStatus(); vdl2CheckStatus(); }); },5000); });
 })();
 </script>
 </body>

--- a/docs/sdr-subghz.md
+++ b/docs/sdr-subghz.md
@@ -368,6 +368,38 @@ the radar contacts by tail/flight and flagged **● on radar**.
   (`scripts/install_acarsdec.sh`); if missing, the panel shows an **⬇ Install
   acarsdec** button. Receive-only.
 
+## VDL Mode 2 / ATN datalink (on the ADS-B radar)
+
+The ADS-B radar page also has a **📡 VDL Mode 2 / ATN** panel — the modern
+successor to VHF ACARS. Where legacy ACARS is a character link at ~131 MHz, VDL
+Mode 2 is a 31.5 kbit/s D8PSK link on a handful of **136 MHz** channels
+(worldwide Common Signalling Channel **136.975**, plus 136.725/136.775/136.800/
+136.825). `vdl2.py` drives **`dumpvdl2`** (built against **`libacars`**) and
+classifies every frame into one of:
+
+- **ACARS-over-VDL2** — the same ops messages (position, OOOI, weather, load
+  sheets, free text) riding VDL2 instead of the old VHF link.
+- **CPDLC** (Controller-Pilot Data Link Communications) — the **ATN** text
+  between controllers and pilots: climb/descend/heading/speed clearances,
+  `CONTACT <freq>`, `MONITOR <unit>`, logon/handoff, `WILCO`/`ROGER`. Decoded by
+  libacars. This is the part that makes Ragnar, as far as we know, the first
+  field tool to surface CPDLC/ADS-C alongside an ADS-B radar.
+- **ADS-C** (Automatic Dependent Surveillance – Contract) — contracted
+  position/intent reports an aircraft sends to an ATC ground system.
+
+Each row shows the aircraft (tail/ICAO/flight, flagged **● on radar** when it
+matches a contact), a coloured **type badge**, the **direction** (↑ uplink =
+ground→aircraft, ↓ downlink = aircraft→ground), the decoded text/summary, and
+frequency/level.
+
+- **One dongle** — VDL2 (136 MHz) can't run with the 1090 MHz radar or the
+  131 MHz ACARS panel; starting it pauses the others (and vice-versa).
+- **`dumpvdl2` + `libacars`** aren't in apt, so the installer/updater build both
+  from source (`scripts/install_dumpvdl2.sh`); if missing, the panel shows an
+  **⬇ Install dumpvdl2** button. Everything is in the clear, receive-only.
+- Pure parsers (ACARS/CPDLC/ADS-C classification, direction, nested-tree
+  extraction) are covered by `vdl2.py selftest` (13/13).
+
 ## VOR radial decode (108–118 MHz nav beacon)
 
 The **VOR Radial** page (`/vor-radial`, `vor.py`) decodes a VOR nav beacon the
@@ -456,7 +488,9 @@ timestamp), **Mic-E**, messages/acks, objects, status and best-effort weather �
 | `POST /api/net/aprs/send` `{to,text}` | Send an APRS message via APRS-IS (needs write access) |
 | `GET  /api/net/acars/status` · `/messages?since=` | ACARS datalink state + decoded messages (tail/flight/label/text) |
 | `POST /api/net/acars/start` · `/stop` · `/install` | Start/stop ACARS decode; build acarsdec from source |
-| `GET  /api/net/{pager,vor}/selftest` · `/api/net/rtl/selftest` | Offline DSP / parser self-tests |
+| `GET  /api/net/vdl2/status` · `/messages?since=` | VDL Mode 2 / ATN state + decoded messages (type=ACARS/CPDLC/ADS-C, direction, tail/ICAO/flight/text) |
+| `POST /api/net/vdl2/start` · `/stop` · `/install` | Start/stop VDL2 decode (dumpvdl2, 136 MHz, one dongle); build dumpvdl2 + libacars from source |
+| `GET  /api/net/{pager,vor,vdl2}/selftest` · `/api/net/rtl/selftest` | Offline DSP / parser self-tests |
 
 ## CLI
 

--- a/install_ragnar.sh
+++ b/install_ragnar.sh
@@ -806,6 +806,16 @@ EOF
                 log "INFO" "acarsdec not installed - ACARS panel stays disabled (use the in-app Install button later)"
             fi
         fi
+        # dumpvdl2 (+ libacars) powers the VDL Mode 2 / ATN panel (CPDLC + ADS-C
+        # on ~136 MHz). Not in apt, so build from source best-effort.
+        if ! command -v dumpvdl2 >/dev/null 2>&1; then
+            if [ -x "$ragnar_PATH/scripts/install_dumpvdl2.sh" ] \
+               && bash "$ragnar_PATH/scripts/install_dumpvdl2.sh" >/dev/null 2>&1; then
+                log "SUCCESS" "Installed dumpvdl2 + libacars (VDL Mode 2 / ATN datalink)"
+            else
+                log "INFO" "dumpvdl2 not installed - VDL Mode 2 panel stays disabled (use the in-app Install button later)"
+            fi
+        fi
     fi
 
     # meshtastic Python package powers the Mesh Nodes page (real enumeration of a

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -49,6 +49,7 @@ import adsb
 import meshtastic_node
 import pagerdecode as pager   # decoder module (the `pager/` package is a separate device UI)
 import acars
+import vdl2
 import radio
 import vor
 import aprs
@@ -18919,7 +18920,7 @@ def register_network_diagnostics(app, logger=None):
         label = data.get('label')
         label = str(label).strip()[:24] if label else None
         _log(f"net/rtl/power/start band={band} zoom={data.get('lo_hz')}:{data.get('hi_hz')} label={label}")
-        try: adsb.stop(); pager.stop(); acars.stop(); radio.stop(); vor.stop(); aprs.stop()   # one dongle: free it for the sweep
+        try: adsb.stop(); pager.stop(); acars.stop(); vdl2.stop();radio.stop(); vor.stop(); aprs.stop()   # one dongle: free it for the sweep
         except Exception: pass
         return jsonify(rtl_sdr.power_start(band=band, lo_hz=data.get('lo_hz'),
                                            hi_hz=data.get('hi_hz'), label=label))
@@ -18988,7 +18989,7 @@ def register_network_diagnostics(app, logger=None):
     @app.route('/api/net/adsb/start', methods=['POST'])
     def net_adsb_start():
         _log("net/adsb/start")
-        try: rtl_sdr.power_stop(); rtl_sdr.ism_stop(); pager.stop(); acars.stop(); radio.stop(); vor.stop(); aprs.stop()   # hand the dongle to dump1090
+        try: rtl_sdr.power_stop(); rtl_sdr.ism_stop(); pager.stop(); acars.stop(); vdl2.stop();radio.stop(); vor.stop(); aprs.stop()   # hand the dongle to dump1090
         except Exception: pass
         return jsonify(adsb.start())
 
@@ -19126,7 +19127,7 @@ def register_network_diagnostics(app, logger=None):
         mode = data.get('mode') or 'pocsag_flex'
         _log(f"net/pager/start freq={data.get('freq_hz')} mode={mode}")
         try:
-            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); acars.stop(); radio.stop(); vor.stop(); aprs.stop()
+            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); acars.stop(); vdl2.stop();radio.stop(); vor.stop(); aprs.stop()
         except Exception:
             pass
         return jsonify(pager.start(freq_hz=data.get('freq_hz'), mode=mode))
@@ -19156,7 +19157,7 @@ def register_network_diagnostics(app, logger=None):
         data = request.get_json(silent=True) or {}
         _log(f"net/vor/start freq={data.get('freq_hz')} cal={data.get('cal_deg')}")
         try:
-            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); acars.stop(); radio.stop(); aprs.stop()
+            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); acars.stop(); vdl2.stop();radio.stop(); aprs.stop()
         except Exception:
             pass
         return jsonify(vor.start(freq_hz=data.get('freq_hz'), cal_deg=data.get('cal_deg', 0.0)))
@@ -19193,7 +19194,7 @@ def register_network_diagnostics(app, logger=None):
         data = request.get_json(silent=True) or {}
         _log(f"net/aprs/rf/start freq={data.get('freq_hz')}")
         try:                                        # one dongle: free it for APRS RF
-            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); acars.stop(); radio.stop(); vor.stop()
+            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); acars.stop(); vdl2.stop();radio.stop(); vor.stop()
         except Exception:
             pass
         return jsonify(aprs.start_rf(freq_hz=data.get('freq_hz')))
@@ -19244,7 +19245,7 @@ def register_network_diagnostics(app, logger=None):
     def net_acars_start():
         _log("net/acars/start")
         try:
-            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); radio.stop(); vor.stop(); aprs.stop()
+            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); vdl2.stop(); radio.stop(); vor.stop(); aprs.stop()
         except Exception:
             pass
         return jsonify(acars.start())
@@ -19262,6 +19263,42 @@ def register_network_diagnostics(app, logger=None):
     @app.route('/api/net/acars/selftest', methods=['GET'])
     def net_acars_selftest():
         return jsonify(acars.selftest())
+
+    # VDL Mode 2 / ATN (aircraft datalink ~136 MHz) via dumpvdl2 + libacars —
+    # the modern successor to VHF ACARS. Carries ACARS-over-AVLC, plus CPDLC
+    # (controller<->pilot clearances) and ADS-C (contracted position reports),
+    # all in the clear. Matched to ADS-B contacts by ICAO / tail / flight.
+    # Uses the whole RTL-SDR, so starting it stops the others (one dongle).
+    @app.route('/api/net/vdl2/status', methods=['GET'])
+    def net_vdl2_status():
+        return jsonify(vdl2.status())
+
+    @app.route('/api/net/vdl2/messages', methods=['GET'])
+    def net_vdl2_messages():
+        return jsonify(vdl2.messages(since=request.args.get('since', 0)))
+
+    @app.route('/api/net/vdl2/start', methods=['POST'])
+    def net_vdl2_start():
+        _log("net/vdl2/start")
+        try:
+            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); acars.stop(); vdl2.stop();radio.stop(); vor.stop(); aprs.stop()
+        except Exception:
+            pass
+        return jsonify(vdl2.start())
+
+    @app.route('/api/net/vdl2/stop', methods=['POST'])
+    def net_vdl2_stop():
+        _log("net/vdl2/stop")
+        return jsonify(vdl2.stop())
+
+    @app.route('/api/net/vdl2/install', methods=['POST'])
+    def net_vdl2_install():
+        _log("net/vdl2/install")
+        return jsonify(vdl2.install())
+
+    @app.route('/api/net/vdl2/selftest', methods=['GET'])
+    def net_vdl2_selftest():
+        return jsonify(vdl2.selftest())
 
     # Local radio (FM/AM) via rtl_fm — streams demodulated audio to the browser.
     # Uses the whole RTL-SDR, so tuning stops the sweep/ISM/ADS-B/pager/ACARS.
@@ -19292,7 +19329,7 @@ def register_network_diagnostics(app, logger=None):
         mode = request.args.get('mode', 'wfm')
         _log(f"net/radio/stream freq={freq} mode={mode}")
         try:
-            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); acars.stop(); vor.stop(); aprs.stop()
+            rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); pager.stop(); acars.stop(); vdl2.stop();vor.stop(); aprs.stop()
         except Exception:
             pass
         resp = Response(radio.stream(freq, mode), mimetype="audio/wav")
@@ -19307,7 +19344,7 @@ def register_network_diagnostics(app, logger=None):
         data = request.get_json(silent=True) or {}
         band = str(data.get('band') or '433').strip()
         _log(f"net/rtl/ism/start band={band}")
-        try: adsb.stop(); pager.stop(); acars.stop(); radio.stop(); vor.stop(); aprs.stop()   # one dongle: free it for the decoder
+        try: adsb.stop(); pager.stop(); acars.stop(); vdl2.stop();radio.stop(); vor.stop(); aprs.stop()   # one dongle: free it for the decoder
         except Exception: pass
         return jsonify(rtl_sdr.ism_start(band=band))
 

--- a/scripts/install_dumpvdl2.sh
+++ b/scripts/install_dumpvdl2.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Ragnar: build dumpvdl2 (VDL Mode 2 / ATN decoder) + libacars from source —
+# neither is packaged in Debian/Pi OS apt. libacars gives CPDLC + ADS-C decode;
+# dumpvdl2 links against it. Installs to /usr/local/bin/dumpvdl2. Idempotent.
+set -u
+command -v dumpvdl2 >/dev/null 2>&1 && { echo "dumpvdl2 already installed"; exit 0; }
+export DEBIAN_FRONTEND=noninteractive
+apt-get update >/dev/null 2>&1 || true
+if ! apt-get install -y --no-install-recommends \
+        git build-essential cmake pkg-config \
+        librtlsdr-dev libusb-1.0-0-dev zlib1g-dev libxml2-dev libjansson-dev >/dev/null 2>&1; then
+    echo "ERROR: could not install build dependencies (need internet + apt)"; exit 1
+fi
+
+JOBS="$(nproc 2>/dev/null || echo 2)"
+
+# --- libacars (CPDLC / ADS-C application-layer decode) ---------------------
+if ! ldconfig -p 2>/dev/null | grep -q libacars; then
+    LA="$(mktemp -d /tmp/ragnar-libacars.XXXXXX)"
+    trap 'rm -rf "$LA"' EXIT
+    if ! git clone --depth 1 https://github.com/szpajder/libacars "$LA" >/dev/null 2>&1; then
+        echo "ERROR: git clone of libacars failed (no internet?)"; exit 1
+    fi
+    mkdir -p "$LA/build"
+    if ! ( cd "$LA/build" && cmake .. >/dev/null 2>&1 && make -j"$JOBS" >/dev/null 2>&1 && make install >/dev/null 2>&1 ); then
+        echo "ERROR: libacars build failed"; exit 1
+    fi
+    ldconfig 2>/dev/null || true
+    echo "Built and installed libacars (CPDLC/ADS-C decode)"
+fi
+
+# --- dumpvdl2 --------------------------------------------------------------
+SRC="$(mktemp -d /tmp/ragnar-dumpvdl2.XXXXXX)"
+trap 'rm -rf "$SRC"' EXIT
+if ! git clone --depth 1 https://github.com/szpajder/dumpvdl2 "$SRC" >/dev/null 2>&1; then
+    echo "ERROR: git clone of dumpvdl2 failed (no internet?)"; exit 1
+fi
+mkdir -p "$SRC/build"
+if ( cd "$SRC/build" && cmake .. >/dev/null 2>&1 && make -j"$JOBS" >/dev/null 2>&1 ); then
+    BIN="$(find "$SRC/build" -maxdepth 2 -name dumpvdl2 -type f | head -1)"
+fi
+if [ -n "${BIN:-}" ] && [ -x "$BIN" ]; then
+    install -m 0755 "$BIN" /usr/local/bin/dumpvdl2
+    ldconfig 2>/dev/null || true
+    echo "Built and installed /usr/local/bin/dumpvdl2 from source"
+    exit 0
+fi
+echo "ERROR: source build did not produce a dumpvdl2 binary"
+exit 1

--- a/update_ragnar.sh
+++ b/update_ragnar.sh
@@ -348,6 +348,13 @@ EOF
             echo -e "  ${GREEN}✓${NC} Installed acarsdec (ADS-B ACARS datalink)"
         fi
     fi
+    # dumpvdl2 (+ libacars) powers the VDL Mode 2 / ATN panel (CPDLC + ADS-C).
+    if ! command -v dumpvdl2 >/dev/null 2>&1; then
+        if [ -x "$ragnar_PATH/scripts/install_dumpvdl2.sh" ] \
+           && bash "$ragnar_PATH/scripts/install_dumpvdl2.sh" >/dev/null 2>&1; then
+            echo -e "  ${GREEN}✓${NC} Installed dumpvdl2 + libacars (VDL Mode 2 / ATN datalink)"
+        fi
+    fi
     # meshtastic Python package for the Mesh Nodes page (USB companion node).
     if ! python3 -c "import meshtastic" >/dev/null 2>&1; then
         command -v pip3 >/dev/null 2>&1 || DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-pip >/dev/null 2>&1

--- a/vdl2.py
+++ b/vdl2.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python3
+"""
+vdl2.py — VDL Mode 2 / ATN datalink via RTL-SDR + dumpvdl2 (+ libacars).
+
+VDL Mode 2 is the modern successor to plain VHF ACARS. Instead of the old
+character-oriented ACARS on ~131 MHz, VDL2 is a 31.5 kbit/s D8PSK link on a
+handful of 136 MHz channels, carrying AVLC frames. Those frames carry three
+kinds of payload:
+
+  * **ACARS-over-AVLC** — the same ops messages (position, OOOI, weather, load
+    sheets, free text) but riding VDL2 instead of the legacy VHF link.
+  * **CPDLC** (Controller-Pilot Data Link Communications) — the ATN/OSI
+    controller<->pilot text: clearances, level/heading/speed instructions,
+    "MONITOR <freq>", "CONTACT <unit>", logon/handoff. This is the ATN part.
+  * **ADS-C** (Automatic Dependent Surveillance - Contract) — aircraft sending
+    contracted position/intent reports to an ATC ground system.
+
+``dumpvdl2`` demodulates the 136 MHz channels; when it is built against
+``libacars`` it decodes the CPDLC and ADS-C payloads too. Everything is
+transmitted in the clear. Receive-only.
+
+This pairs with the ADS-B radar and the legacy ACARS panel: ADS-B gives the
+position, VDL2/ATN gives the modern datalink — matched by tail / ICAO / flight.
+
+One dongle, one claim
+---------------------
+dumpvdl2 uses the whole RTL-SDR (136 MHz, ~2.1 Msps), so it is mutually
+exclusive with the sub-GHz sweep / ISM decoder / ADS-B / pager / ACARS / radio.
+The web layer stops the others before starting VDL2.
+
+CLI
+---
+    python3 vdl2.py detect
+    python3 vdl2.py run [--seconds N]
+    python3 vdl2.py selftest
+"""
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+
+
+def _which(name):
+    for p in ("/usr/local/bin/%s" % name, "/usr/bin/%s" % name):
+        if os.path.exists(p):
+            return p
+    return name
+
+
+_DUMPVDL2 = _which("dumpvdl2")
+_MSG_RING = 500
+
+# VDL Mode 2 channels (Hz). 136.975 is the worldwide Common Signalling Channel;
+# the others are the busiest data channels. dumpvdl2 tunes all of these inside
+# one ~2.1 Msps window (they span 250 kHz around 136.85). Tunable, but this set
+# balances coverage against CPU on a Pi.
+VDL2_CHANNELS_HZ = [136725000, 136775000, 136800000, 136825000, 136975000]
+
+# ACARS label -> human meaning (shared vocabulary with the legacy ACARS panel;
+# unknown labels pass through untouched).
+ACARS_LABELS = {
+    "SA": "Media advisory (link test)", "5Z": "Airline-defined / ops",
+    "Q0": "Link test", "_d": "Ground data",
+    "H1": "Message to/from terminal (free text)",
+    "10": "Airline-defined", "80": "Airline-defined",
+    "B9": "Request oceanic clearance", "BA": "Oceanic clearance",
+    "15": "Position report", "16": "Position report",
+    "5U": "Weather request", "12": "Weather / ATIS",
+    "44": "Flight plan", "83": "Load sheet",
+    "22": "Departure/arrival (OOOI)", "2Z": "OOOI times",
+    "C1": "CPDLC uplink", "AA": "CPDLC downlink",
+    "SQ": "Squitter (position)", "RA": "Response",
+    "20": "Ops control", "30": "Ops control",
+    "51": "Ground station", "57": "ATC",
+}
+
+
+def _run(args, timeout=6):
+    try:
+        p = subprocess.run(args, capture_output=True, text=True,
+                           timeout=timeout, check=False)
+        return p.returncode, p.stdout, p.stderr
+    except FileNotFoundError:
+        return 127, "", "not found"
+    except subprocess.TimeoutExpired:
+        return 124, "", "timed out"
+    except Exception as exc:  # pragma: no cover - defensive
+        return 1, "", str(exc)
+
+
+def _have(path):
+    # dumpvdl2 --help exits non-zero on some builds but still runs; a 127 (not
+    # found) is the only reliable "missing" signal.
+    return _run([path, "--help"])[0] != 127 or os.path.exists(path)
+
+
+def detect():
+    """Report whether VDL2 decode is usable (dumpvdl2 + a dongle)."""
+    if not _have(_DUMPVDL2):
+        return {"available": False, "tools_installed": False, "device_present": False,
+                "error": "dumpvdl2 not installed — build it from source "
+                         "(the in-app Install button does this)"}
+    usb = None
+    try:
+        import rtl_sdr
+        usb = rtl_sdr.probe_usb()[0]
+    except Exception:
+        usb = None
+    if usb is None:
+        return {"available": False, "tools_installed": True, "device_present": False,
+                "error": "no RTL-SDR on the USB bus — plug a dongle in"}
+    return {"available": True, "tools_installed": True, "device_present": True,
+            "usb_id": usb, "channels_mhz": [round(f / 1e6, 3) for f in VDL2_CHANNELS_HZ]}
+
+
+def label_meaning(label):
+    """Human meaning for an ACARS label, or None."""
+    return ACARS_LABELS.get((label or "").strip())
+
+
+# --------------------------------------------------------------------------
+# Nested-tree helpers — dumpvdl2/libacars JSON nests CPDLC/ADS-C deep inside
+# avlc -> x25 -> clnp -> cotp -> ... , and the exact depth varies by version.
+# We locate payloads by key rather than by a fixed path.
+# --------------------------------------------------------------------------
+
+def _find(obj, key):
+    """First value for `key` found anywhere in a nested dict/list (DFS)."""
+    if isinstance(obj, dict):
+        if key in obj:
+            return obj[key]
+        for v in obj.values():
+            r = _find(v, key)
+            if r is not None:
+                return r
+    elif isinstance(obj, list):
+        for v in obj:
+            r = _find(v, key)
+            if r is not None:
+                return r
+    return None
+
+
+def _collect_scalars(obj, keys, out, limit=40):
+    """Collect (key, scalar) pairs for any key in `keys`, anywhere in the tree."""
+    if len(out) >= limit:
+        return
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if k in keys and not isinstance(v, (dict, list)) and v not in (None, ""):
+                out.append((k, v))
+            else:
+                _collect_scalars(v, keys, out, limit)
+    elif isinstance(obj, list):
+        for v in obj:
+            _collect_scalars(v, keys, out, limit)
+
+
+def _cpdlc_summary(cpdlc):
+    """Human one-liner for a libacars CPDLC object (uplink or downlink)."""
+    direction = None
+    if _find(cpdlc, "atc_uplink_message") is not None:
+        direction = "uplink"     # ground -> aircraft (a controller instruction)
+    elif _find(cpdlc, "atc_downlink_message") is not None:
+        direction = "downlink"   # aircraft -> ground (a pilot reply/request)
+    bits = []
+    # Free text is the most human-legible field when present.
+    for fkey in ("freetext", "free_text", "text"):
+        ft = _find(cpdlc, fkey)
+        if isinstance(ft, str) and ft.strip():
+            bits.append(ft.strip())
+            break
+    # Otherwise summarise from the message-element choices libacars names.
+    if not bits:
+        choices = []
+        _collect_scalars(cpdlc, {"choice", "choice_label", "type"}, choices, limit=6)
+        seen = []
+        for _, v in choices:
+            s = str(v).replace("_", " ").strip()
+            if s and s not in seen and not s.isdigit():
+                seen.append(s)
+        if seen:
+            bits.append("; ".join(seen[:4]))
+    mid = _find(cpdlc, "msg_id")
+    txt = " · ".join(bits) if bits else "CPDLC message"
+    return direction, (("[#%s] " % mid) if mid not in (None, "") else "") + txt
+
+
+def _adsc_summary(adsc):
+    """Human one-liner for a libacars ADS-C object (contract / report)."""
+    pos = []
+    _collect_scalars(adsc, {"lat", "lon", "alt", "alt_ft", "altitude"}, pos, limit=8)
+    d = {}
+    for k, v in pos:
+        d.setdefault(k, v)
+    lat = d.get("lat")
+    lon = d.get("lon")
+    alt = d.get("alt") or d.get("alt_ft") or d.get("altitude")
+    if lat is not None and lon is not None:
+        s = "POS %.4f %.4f" % (float(lat), float(lon)) if _isnum(lat) and _isnum(lon) \
+            else "POS %s %s" % (lat, lon)
+        if alt is not None:
+            s += " / %s ft" % alt
+        return s
+    tag = _find(adsc, "tag") or _find(adsc, "contract_type")
+    return "ADS-C report" + ((" (%s)" % tag) if tag else "")
+
+
+def _isnum(v):
+    try:
+        float(v)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def normalize_vdl2(obj):
+    """Normalize one dumpvdl2 JSON object into a flat message record (pure).
+
+    dumpvdl2 ``--output decoded:json:file:path=-`` emits one JSON object per
+    line, wrapped as ``{"vdl2": {...}}``. Inside is an ``avlc`` frame with
+    ``src``/``dst`` addresses and, depending on the payload, a nested ``acars``
+    block or a libacars-decoded ``cpdlc`` / ``adsc`` tree. Read defensively and
+    classify the message. Returns a flat record or None for junk.
+    """
+    if isinstance(obj, str):
+        try:
+            obj = json.loads(obj)
+        except (ValueError, TypeError):
+            return None
+    if not isinstance(obj, dict):
+        return None
+    v = obj.get("vdl2") if isinstance(obj.get("vdl2"), dict) else obj
+    if not isinstance(v, dict):
+        return None
+    avlc = v.get("avlc") if isinstance(v.get("avlc"), dict) else {}
+
+    # Frequency (dumpvdl2 reports Hz) and signal level.
+    freq = v.get("freq")
+    try:
+        freq_mhz = round(float(freq) / 1e6, 3) if freq is not None else None
+    except (TypeError, ValueError):
+        freq_mhz = None
+    level = v.get("sig_level")
+
+    # Timestamp: {"t":{"sec":..,"usec":..}} or a plain epoch.
+    ts = None
+    t = v.get("t")
+    if isinstance(t, dict) and t.get("sec") is not None:
+        try:
+            ts = float(t["sec"]) + float(t.get("usec", 0)) / 1e6
+        except (TypeError, ValueError):
+            ts = None
+    if ts is None:
+        ts = time.time()
+
+    src = avlc.get("src") if isinstance(avlc.get("src"), dict) else {}
+    dst = avlc.get("dst") if isinstance(avlc.get("dst"), dict) else {}
+    src_addr = (src.get("addr") or "").strip() or None
+    dst_addr = (dst.get("addr") or "").strip() or None
+    src_type = (src.get("type") or "").strip() or None
+    frame_type = (avlc.get("frame_type") or avlc.get("type") or "").strip() or None
+    # ICAO is the aircraft's AVLC address when the source is an aircraft.
+    icao = src_addr if (src_type or "").lower().startswith("aircraft") else None
+
+    rec = {
+        "type": "AVLC", "icao": icao, "src": src_addr, "dst": dst_addr,
+        "src_type": src_type, "frame_type": frame_type,
+        "reg": None, "flight": None, "label": None, "label_meaning": None,
+        "text": None, "direction": None,
+        "freq_mhz": freq_mhz, "level": level, "ts": ts,
+    }
+
+    # --- ACARS-over-AVLC -------------------------------------------------
+    acars = _find(v, "acars")
+    if isinstance(acars, dict):
+        rec["type"] = "ACARS"
+        reg = (acars.get("reg") or acars.get("registration") or "").strip()
+        rec["reg"] = reg.lstrip(".") or None    # dumpvdl2 prefixes a padding dot
+        rec["flight"] = (acars.get("flight") or acars.get("fid") or "").strip() or None
+        label = (acars.get("label") or "").strip() or None
+        rec["label"] = label
+        rec["label_meaning"] = label_meaning(label)
+        txt = acars.get("msg_text")
+        if txt is None:
+            txt = acars.get("text")
+        if isinstance(txt, str):
+            rec["text"] = txt.replace("\r", "\n").strip() or None
+        rec["msg_num"] = (acars.get("msg_num") or acars.get("msgno") or "").strip() or None
+        rec["block_id"] = (acars.get("blk_id") or acars.get("block_id") or "").strip() or None
+        rec["direction"] = "downlink" if icao else "uplink"
+        return rec
+
+    # --- CPDLC (ATN controller<->pilot) ----------------------------------
+    cpdlc = _find(v, "cpdlc")
+    if isinstance(cpdlc, dict):
+        rec["type"] = "CPDLC"
+        direction, summary = _cpdlc_summary(cpdlc)
+        rec["direction"] = direction or ("downlink" if icao else "uplink")
+        rec["text"] = summary
+        return rec
+
+    # --- ADS-C (contracted surveillance) ---------------------------------
+    adsc = _find(v, "adsc")
+    if isinstance(adsc, dict):
+        rec["type"] = "ADS-C"
+        rec["direction"] = "downlink"      # ADS-C reports flow aircraft -> ground
+        rec["text"] = _adsc_summary(adsc)
+        return rec
+
+    # --- Bare AVLC / X.25 control frame ----------------------------------
+    if _find(v, "x25") is not None:
+        rec["type"] = "X.25"
+    # Supervisory/unnumbered frames carry no payload; keep them for link context
+    # but give the panel something to show.
+    if not rec["text"]:
+        ft = {"I": "Information", "S": "Supervisory", "U": "Unnumbered"}.get(
+            (frame_type or "")[:1].upper(), frame_type or "link")
+        rec["text"] = "%s frame" % ft
+    return rec
+
+
+class Vdl2Decoder:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._proc = None
+        self._thread = None
+        self._stop = threading.Event()
+        self._msgs = []
+        self._count = 0
+        self._error = None
+        self._started = None
+
+    def status(self):
+        with self._lock:
+            return {"running": bool(self._thread and self._thread.is_alive()),
+                    "messages": self._count, "error": self._error,
+                    "seconds": round(time.time() - self._started, 1) if self._started else 0}
+
+    def messages(self, since=0):
+        with self._lock:
+            try:
+                since = int(since)
+            except (TypeError, ValueError):
+                since = 0
+            new = [m for m in self._msgs if m["seq"] > since]
+            return {"messages": new, "seq": self._count,
+                    "running": bool(self._thread and self._thread.is_alive()),
+                    "error": self._error}
+
+    def start(self):  # pragma: no cover - hardware path
+        with self._lock:
+            if self._thread and self._thread.is_alive():
+                return {"ok": True, "already": True}
+            if not _have(_DUMPVDL2):
+                return {"ok": False, "error": "dumpvdl2 not installed"}
+            self._stop.clear()
+            self._msgs = []
+            self._count = 0
+            self._error = None
+            self._started = time.time()
+            ppm = 0
+            try:
+                import rtl_sdr
+                ppm = rtl_sdr.get_tuning().get("ppm", 0)
+            except Exception:
+                pass
+            # dumpvdl2: RTL device 0, JSON lines to stdout, all default channels.
+            cmd = [_DUMPVDL2, "--rtlsdr", "0", "--correction", str(int(ppm or 0)),
+                   "--output", "decoded:json:file:path=-"] + \
+                  [str(f) for f in VDL2_CHANNELS_HZ]
+            try:
+                self._proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                              stderr=subprocess.DEVNULL, text=True)
+            except Exception as exc:
+                self._error = "failed to launch dumpvdl2: %s" % exc
+                return {"ok": False, "error": self._error}
+            self._thread = threading.Thread(target=self._read_loop, daemon=True,
+                                            name="vdl2-decode")
+            self._thread.start()
+        return {"ok": True}
+
+    def _read_loop(self):  # pragma: no cover - hardware path
+        try:
+            for line in self._proc.stdout:
+                if self._stop.is_set():
+                    break
+                line = line.strip()
+                if not line or line[0] != "{":
+                    continue
+                rec = normalize_vdl2(line)
+                if not rec:
+                    continue
+                with self._lock:
+                    self._count += 1
+                    rec["seq"] = self._count
+                    self._msgs.append(rec)
+                    if len(self._msgs) > _MSG_RING:
+                        self._msgs = self._msgs[-_MSG_RING:]
+        except Exception as exc:
+            with self._lock:
+                self._error = str(exc)
+
+    def stop(self):
+        with self._lock:
+            self._stop.set()
+            if self._proc:
+                try:
+                    self._proc.terminate()
+                    self._proc.wait(timeout=2)
+                except Exception:
+                    try:
+                        self._proc.kill()
+                    except Exception:
+                        pass
+                self._proc = None
+        return {"ok": True}
+
+
+_decoder = Vdl2Decoder()
+
+
+def start():
+    d = detect()
+    if not d.get("available"):
+        return {"ok": False, "error": d.get("error", "vdl2 unavailable")}
+    return _decoder.start()
+
+
+def stop():
+    return _decoder.stop()
+
+
+def status():
+    st = _decoder.status()
+    st["detect"] = detect()
+    return st
+
+
+def messages(since=0):
+    return _decoder.messages(since=since)
+
+
+def install():
+    """One-click install of dumpvdl2 (+ libacars). Not in apt, so build from
+    source via the shared helper script."""
+    if _have(_DUMPVDL2):
+        return {"ok": True, "already": True, "detect": detect()}
+    script = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          "scripts", "install_dumpvdl2.sh")
+    if not os.path.exists(script):
+        return {"ok": False, "error": "install_dumpvdl2.sh missing (update Ragnar)",
+                "detect": detect()}
+    env = dict(os.environ, DEBIAN_FRONTEND="noninteractive")
+    try:
+        p = subprocess.run(["bash", script], capture_output=True, text=True,
+                           timeout=1800, check=False, env=env)
+        out = (p.stdout or "") + (p.stderr or "")
+    except FileNotFoundError:
+        return {"ok": False, "error": "bash not found", "detect": detect()}
+    except subprocess.TimeoutExpired:
+        return {"ok": _have(_DUMPVDL2), "error": "install timed out (source build is slow — retry)",
+                "detect": detect()}
+    ok = _have(_DUMPVDL2)
+    tail = "\n".join((out or "").strip().splitlines()[-16:])
+    return {"ok": ok, "output": tail, "detect": detect(),
+            "error": None if ok else "could not build dumpvdl2 (needs internet + build tools). See output."}
+
+
+# --------------------------------------------------------------------------
+# Selftest (pure normalization, no hardware)
+# --------------------------------------------------------------------------
+
+def selftest():
+    results = []
+
+    def check(name, ok, detail=""):
+        results.append({"name": name, "pass": bool(ok), "detail": detail})
+
+    # 1. ACARS-over-VDL2
+    acars_msg = {"vdl2": {"freq": 136975000, "sig_level": -24.5,
+                          "t": {"sec": 1700000000, "usec": 500000},
+                          "avlc": {"src": {"addr": "3C6DA4", "type": "Aircraft", "status": "Airborne"},
+                                   "dst": {"addr": "111153", "type": "Ground station"},
+                                   "cr": "Command", "frame_type": "I",
+                                   "acars": {"reg": ".D-AIMA", "flight": "DLH8LX",
+                                             "label": "15", "msg_num": "M12A", "blk_id": "3",
+                                             "msg_text": "POS N51.2 E007.1 FL360 M0.79"}}}}
+    m = normalize_vdl2(acars_msg)
+    check("vdl2: ACARS payload flattened",
+          m and m["type"] == "ACARS" and m["reg"] == "D-AIMA" and m["flight"] == "DLH8LX"
+          and m["icao"] == "3C6DA4" and "POS" in m["text"] and m["freq_mhz"] == 136.975, str(m))
+    check("vdl2: ACARS label meaning + downlink direction",
+          m and m["label_meaning"] == "Position report" and m["direction"] == "downlink", str(m))
+    check("vdl2: padding dot stripped from reg",
+          m and not m["reg"].startswith("."))
+    check("vdl2: timestamp from t.sec/usec",
+          m and abs(m["ts"] - 1700000000.5) < 0.001, str(m and m["ts"]))
+
+    # 2. CPDLC uplink with free text (nested deep like libacars output).
+    # Built from a JSON string so the deep libacars nesting can't be miscounted.
+    cpdlc_msg = json.loads('{"vdl2":{"freq":136725000,"avlc":{'
+        '"src":{"addr":"1080C4","type":"Ground station"},'
+        '"dst":{"addr":"3C6DA4","type":"Aircraft"},"frame_type":"I",'
+        '"x25":{"clnp":{"cotp":{"data":{"cpdlc":{'
+        '"atc_uplink_message":{"header":{"msg_id":7},'
+        '"atc_uplink_msg_element_id":{"choice":"contact",'
+        '"data":{"freetext":"CONTACT LONDON 128.075"}}}}}}}}}}}')
+    c = normalize_vdl2(cpdlc_msg)
+    check("vdl2: CPDLC detected + classified uplink",
+          c and c["type"] == "CPDLC" and c["direction"] == "uplink", str(c))
+    check("vdl2: CPDLC free text surfaced",
+          c and "CONTACT LONDON 128.075" in (c["text"] or ""), str(c and c["text"]))
+    check("vdl2: CPDLC msg_id in summary",
+          c and "#7" in (c["text"] or ""), str(c and c["text"]))
+
+    # 3. CPDLC downlink summarised from element choices (no free text)
+    cpdlc_dl = json.loads('{"vdl2":{"freq":136775000,"avlc":{'
+        '"src":{"addr":"406B2A","type":"Aircraft"},'
+        '"dst":{"addr":"1080C4","type":"Ground station"},'
+        '"x25":{"clnp":{"cotp":{"data":{"cpdlc":{'
+        '"atc_downlink_message":{"header":{"msg_id":3},'
+        '"atc_downlink_msg_element_id":{"choice":"wilco"}}}}}}}}}}')
+    c2 = normalize_vdl2(cpdlc_dl)
+    check("vdl2: CPDLC downlink choice summarised",
+          c2 and c2["type"] == "CPDLC" and c2["direction"] == "downlink"
+          and "wilco" in (c2["text"] or "").lower(), str(c2 and c2["text"]))
+
+    # 4. ADS-C position report
+    adsc_msg = json.loads('{"vdl2":{"freq":136800000,"avlc":{'
+        '"src":{"addr":"7C6B2D","type":"Aircraft"},'
+        '"dst":{"addr":"1080C4","type":"Ground station"},'
+        '"x25":{"clnp":{"cotp":{"data":{"adsc":{"tags":['
+        '{"basic_report":{"lat":-33.9461,"lon":151.1772,"alt":38000}}]}}}}}}}}')
+    a = normalize_vdl2(adsc_msg)
+    check("vdl2: ADS-C detected + position summarised",
+          a and a["type"] == "ADS-C" and a["direction"] == "downlink"
+          and "POS" in (a["text"] or "") and "-33.9" in (a["text"] or ""), str(a and a["text"]))
+
+    # 5. Bare supervisory frame -> link context, not dropped
+    s = normalize_vdl2({"vdl2": {"freq": 136975000, "avlc": {
+        "src": {"addr": "111153", "type": "Ground station"},
+        "dst": {"addr": "3C6DA4", "type": "Aircraft"}, "frame_type": "S"}}})
+    check("vdl2: supervisory frame kept with link text",
+          s and s["type"] == "AVLC" and s["frame_type"] == "S" and "Supervisory" in s["text"], str(s))
+
+    # 6. Junk / robustness
+    check("vdl2: junk -> None",
+          normalize_vdl2("not json") is None and normalize_vdl2(42) is None
+          and normalize_vdl2("{}") is not None)
+
+    # 7. since-cursor
+    dec = Vdl2Decoder()
+    for raw in (acars_msg, cpdlc_msg):
+        r = normalize_vdl2(raw)
+        with dec._lock:
+            dec._count += 1
+            r["seq"] = dec._count
+            dec._msgs.append(r)
+    got = dec.messages(since=1)
+    check("vdl2: since-cursor returns only newer",
+          got["seq"] == 2 and len(got["messages"]) == 1 and got["messages"][0]["type"] == "CPDLC", str(got))
+
+    # 8. Channels are 136 MHz VDL2 band
+    check("vdl2: channels in 136 MHz band incl. CSC 136.975",
+          all(136000000 <= f <= 137000000 for f in VDL2_CHANNELS_HZ) and 136975000 in VDL2_CHANNELS_HZ)
+
+    passed = sum(1 for r in results if r["pass"])
+    return {"pass": passed == len(results), "passed": passed,
+            "total": len(results), "results": results}
+
+
+def _main(argv):
+    cmd = argv[1] if len(argv) > 1 else "detect"
+    if cmd == "detect":
+        print(json.dumps(detect(), indent=2))
+    elif cmd == "selftest":
+        r = selftest()
+        for x in r["results"]:
+            print("  [%s] %s%s" % ("PASS" if x["pass"] else "FAIL", x["name"],
+                                   "" if x["pass"] else "  -> " + x["detail"]))
+        print("\n%d/%d checks pass — %s" % (r["passed"], r["total"],
+                                            "OK" if r["pass"] else "FAILURES"))
+        return 0 if r["pass"] else 1
+    elif cmd == "run":
+        secs = 30
+        if "--seconds" in argv:
+            secs = int(argv[argv.index("--seconds") + 1])
+        print(start())
+        t0 = time.time()
+        try:
+            while time.time() - t0 < secs:
+                time.sleep(2)
+                print("messages=%d" % status()["messages"])
+        finally:
+            stop()
+    else:
+        print("usage: vdl2.py [detect|run|selftest]")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv))


### PR DESCRIPTION
Adds a VDL Mode 2 panel next to ACARS: the modern 136 MHz aircraft datalink, decoded via dumpvdl2 built against libacars. Classifies every frame as ACARS-over-VDL2, CPDLC (controller<->pilot ATN clearances) or ADS-C (position contracts), with uplink/downlink direction and on-radar matching by ICAO/tail.

- vdl2.py: dumpvdl2 wrapper mirroring acars.py (detect/start/stop/status/ messages/install), pure normalize_vdl2() that walks the nested avlc->x25->clnp->cotp->cpdlc/adsc tree by key; 13/13 selftest.
- scripts/install_dumpvdl2.sh: source-builds libacars then dumpvdl2 (neither in apt); wired into install_ragnar.sh + update_ragnar.sh for parity with acarsdec.
- network_diagnostics.py: /api/net/vdl2/{status,messages,start,stop,install, selftest}; one-dongle stop-lists now release VDL2 too.
- ADS-B radar page: VDL2 card with ACARS/CPDLC/ADS-C type badges, direction arrows, demo synth; docs updated.

Built and live-verified on-box (dumpvdl2 2.7.0 / libacars 2.2.1, NESDR SMArt): detect green, endpoints 200, selftest 13/13. No live VDL2 burst captured in the test window to validate normalize against real output.