### PR TITLE
install_dumpvdl2: surface real build errors + auto -j1 fallback for l…

### DIFF
--- a/docs/sdr-subghz.md
+++ b/docs/sdr-subghz.md
@@ -394,9 +394,17 @@ frequency/level.
 
 - **One dongle** — VDL2 (136 MHz) can't run with the 1090 MHz radar or the
   131 MHz ACARS panel; starting it pauses the others (and vice-versa).
-- **`dumpvdl2` + `libacars`** aren't in apt, so the installer/updater build both
-  from source (`scripts/install_dumpvdl2.sh`); if missing, the panel shows an
-  **⬇ Install dumpvdl2** button. Everything is in the clear, receive-only.
+- **`dumpvdl2` + `libacars`** aren't in apt (not even on Debian trixie), so the
+  installer/updater build both from source (`scripts/install_dumpvdl2.sh`); if
+  missing, the panel shows an **⬇ Install dumpvdl2** button. Everything is in the
+  clear, receive-only.
+- **If the build fails**, the script now prints the real cmake/compiler error and
+  which step failed (deps → libacars → dumpvdl2), so you can tell a Pi problem
+  from a package problem. The usual culprit on a small Pi is the parallel compile
+  running the board **out of RAM** (the OOM killer kills `cc1`): the script
+  auto-retries single-threaded, but if that still fails, add a swap file
+  (`sudo dphys-swapfile ...` or a 1 GB `/swapfile`) and retry. Other causes it
+  reports plainly: no internet (git clone fails) or a failed `apt-get update`.
 - Pure parsers (ACARS/CPDLC/ADS-C classification, direction, nested-tree
   extraction) are covered by `vdl2.py selftest` (13/13).
 

--- a/scripts/install_dumpvdl2.sh
+++ b/scripts/install_dumpvdl2.sh
@@ -2,48 +2,87 @@
 # Ragnar: build dumpvdl2 (VDL Mode 2 / ATN decoder) + libacars from source —
 # neither is packaged in Debian/Pi OS apt. libacars gives CPDLC + ADS-C decode;
 # dumpvdl2 links against it. Installs to /usr/local/bin/dumpvdl2. Idempotent.
+#
+# On failure this prints the REAL build output (cmake/compiler errors), so a
+# user can tell whether it's their Pi (missing dep, no internet, out of RAM) or
+# the package. Every step logs to $LOG and the tail is echoed when a step fails.
 set -u
 command -v dumpvdl2 >/dev/null 2>&1 && { echo "dumpvdl2 already installed"; exit 0; }
+
+LOG="$(mktemp /tmp/ragnar-dumpvdl2-build.XXXXXX.log)"
+say(){ echo ">> $*"; }
+fail(){ echo "ERROR: $*"; echo "----- last build output -------------------------------------"; tail -n 40 "$LOG" 2>/dev/null; echo "-------------------------------------------------------------"; exit 1; }
+
+# dumpvdl2 links libacars from /usr/local — make sure this build (and the final
+# binary) can find it regardless of the distro's default search paths.
+export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/local/lib/aarch64-linux-gnu/pkgconfig:${PKG_CONFIG_PATH:-}"
+export LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH:-}"
+
 export DEBIAN_FRONTEND=noninteractive
-apt-get update >/dev/null 2>&1 || true
+say "Installing build dependencies via apt…"
+apt-get update >>"$LOG" 2>&1 || echo ">> apt-get update failed (stale mirror / offline?) — continuing, deps may already be present"
+# git/cmake/compiler + librtlsdr (SDR) + libjansson (JSON output, REQUIRED) +
+# libxml2/zlib (libacars formatting/compression).
 if ! apt-get install -y --no-install-recommends \
         git build-essential cmake pkg-config \
-        librtlsdr-dev libusb-1.0-0-dev zlib1g-dev libxml2-dev libjansson-dev >/dev/null 2>&1; then
-    echo "ERROR: could not install build dependencies (need internet + apt)"; exit 1
+        librtlsdr-dev libusb-1.0-0-dev zlib1g-dev libxml2-dev libjansson-dev >>"$LOG" 2>&1; then
+    fail "could not install build dependencies (need internet + apt). Try: sudo apt-get update"
 fi
+command -v cmake >/dev/null 2>&1 || fail "cmake missing after apt install"
+command -v git   >/dev/null 2>&1 || fail "git missing after apt install"
 
 JOBS="$(nproc 2>/dev/null || echo 2)"
 
+# make with the parallel job count, and if that fails (the usual cause on a
+# small Pi is the OOM killer killing cc1 mid-compile) retry single-threaded,
+# which needs far less RAM. Returns non-zero only if -j1 also fails.
+make_build(){  # $1 = build dir
+    make -C "$1" -j"$JOBS" >>"$LOG" 2>&1 && return 0
+    echo ">> parallel build failed — retrying single-threaded (low-RAM Pi?)…"
+    make -C "$1" -j1 >>"$LOG" 2>&1
+}
+
 # --- libacars (CPDLC / ADS-C application-layer decode) ---------------------
-if ! ldconfig -p 2>/dev/null | grep -q libacars; then
+if ! pkg-config --exists libacars-2 2>/dev/null && ! ldconfig -p 2>/dev/null | grep -q libacars; then
     LA="$(mktemp -d /tmp/ragnar-libacars.XXXXXX)"
-    trap 'rm -rf "$LA"' EXIT
-    if ! git clone --depth 1 https://github.com/szpajder/libacars "$LA" >/dev/null 2>&1; then
-        echo "ERROR: git clone of libacars failed (no internet?)"; exit 1
-    fi
+    say "Building libacars (CPDLC/ADS-C decode)…"
+    git clone --depth 1 https://github.com/szpajder/libacars "$LA" >>"$LOG" 2>&1 \
+        || fail "git clone of libacars failed (no internet?)"
     mkdir -p "$LA/build"
-    if ! ( cd "$LA/build" && cmake .. >/dev/null 2>&1 && make -j"$JOBS" >/dev/null 2>&1 && make install >/dev/null 2>&1 ); then
-        echo "ERROR: libacars build failed"; exit 1
+    if ! ( cd "$LA/build" && cmake .. >>"$LOG" 2>&1 ) || ! make_build "$LA/build" \
+         || ! ( make -C "$LA/build" install >>"$LOG" 2>&1 ); then
+        rm -rf "$LA"; fail "libacars build failed (see output above — if it was killed mid-compile the Pi ran out of RAM: add a swap file and retry)"
     fi
+    rm -rf "$LA"
     ldconfig 2>/dev/null || true
-    echo "Built and installed libacars (CPDLC/ADS-C decode)"
+    say "libacars installed"
+else
+    say "libacars already present — reusing"
 fi
 
 # --- dumpvdl2 --------------------------------------------------------------
 SRC="$(mktemp -d /tmp/ragnar-dumpvdl2.XXXXXX)"
-trap 'rm -rf "$SRC"' EXIT
-if ! git clone --depth 1 https://github.com/szpajder/dumpvdl2 "$SRC" >/dev/null 2>&1; then
-    echo "ERROR: git clone of dumpvdl2 failed (no internet?)"; exit 1
-fi
+say "Building dumpvdl2…"
+git clone --depth 1 https://github.com/szpajder/dumpvdl2 "$SRC" >>"$LOG" 2>&1 \
+    || { rm -rf "$SRC"; fail "git clone of dumpvdl2 failed (no internet?)"; }
 mkdir -p "$SRC/build"
-if ( cd "$SRC/build" && cmake .. >/dev/null 2>&1 && make -j"$JOBS" >/dev/null 2>&1 ); then
-    BIN="$(find "$SRC/build" -maxdepth 2 -name dumpvdl2 -type f | head -1)"
+if ! ( cd "$SRC/build" && cmake .. >>"$LOG" 2>&1 ) || ! make_build "$SRC/build"; then
+    rm -rf "$SRC"; fail "dumpvdl2 build failed (see output above — if it was killed mid-compile the Pi ran out of RAM: add a swap file and retry)"
 fi
-if [ -n "${BIN:-}" ] && [ -x "$BIN" ]; then
-    install -m 0755 "$BIN" /usr/local/bin/dumpvdl2
-    ldconfig 2>/dev/null || true
-    echo "Built and installed /usr/local/bin/dumpvdl2 from source"
-    exit 0
+BIN="$(find "$SRC/build" -maxdepth 2 -name dumpvdl2 -type f | head -1)"
+if [ -z "${BIN:-}" ] || [ ! -x "$BIN" ]; then
+    rm -rf "$SRC"; fail "source build did not produce a dumpvdl2 binary"
 fi
-echo "ERROR: source build did not produce a dumpvdl2 binary"
-exit 1
+install -m 0755 "$BIN" /usr/local/bin/dumpvdl2
+rm -rf "$SRC"
+ldconfig 2>/dev/null || true
+
+# Verify it runs and links libacars (so CPDLC/ADS-C + JSON output actually work).
+VER="$(/usr/local/bin/dumpvdl2 --version 2>&1 | head -1)"
+say "Installed /usr/local/bin/dumpvdl2 — $VER"
+case "$VER" in
+    *libacars*) : ;;  # good: CPDLC/ADS-C decode present
+    *) echo ">> WARNING: dumpvdl2 reports no libacars — CPDLC/ADS-C won't decode. Rerun after 'sudo ldconfig'." ;;
+esac
+rm -f "$LOG"
+exit 0


### PR DESCRIPTION
…ow-RAM Pis

Users hit opaque dependency-install failures because the script swallowed all build output behind >/dev/null and only echoed a generic "ERROR". Now it:
- logs every step and prints the real cmake/compiler tail on failure, plus which stage failed (deps -> libacars -> dumpvdl2), so a Pi problem is distinguishable from a package problem;
- prints progress markers as it goes;
- auto-retries the compile single-threaded when the parallel build fails (the usual small-Pi cause is the OOM killer killing cc1), with a swap-file hint;
- exports PKG_CONFIG_PATH/LD_LIBRARY_PATH so dumpvdl2 finds the freshly-built libacars regardless of distro defaults, and verifies the binary links libacars.

Validated by two clean from-scratch rebuilds on-box (libacars 2.2.1 + dumpvdl2 2.7.0). Docs note the RAM/swap and offline failure modes.