### PR TITLE
pager: add POCSAG baud / FLEX demod selector + invert + cleaner FM demod

### DIFF
--- a/demos/pager_decode.html
+++ b/demos/pager_decode.html
@@ -35,6 +35,9 @@
   button.go[aria-pressed="true"]{background:rgba(63,181,107,.14);border-color:rgba(63,181,107,.5);color:var(--live)}
   select.tin,input.tin{font-family:var(--mono);font-size:12px;color:var(--ink);background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:6px 8px}
   input.tin{width:120px}
+  .chk{font-family:var(--mono);font-size:11px;color:var(--ink-dim);display:inline-flex;align-items:center;gap:4px;margin-right:8px;cursor:pointer;user-select:none}
+  .chk input{accent-color:var(--pager);cursor:pointer;margin:0}
+  #demodgrp,#invgrp{flex-wrap:wrap}
   .card{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);overflow:hidden;position:relative}
   .cap{display:flex;align-items:center;justify-content:space-between;padding:11px 14px;border-bottom:1px solid var(--line-soft);background:var(--panel-2)}
   .cap .t{font-family:var(--head);font-weight:600;font-size:14px} .cap .c{font-family:var(--mono);font-size:11px;color:var(--muted)}
@@ -75,6 +78,16 @@
     <div class="grp"><span class="lbl">Protocol</span><select class="tin" id="pmode" title="POCSAG/FLEX use multimon-ng; QCII is Motorola two-tone (decoded in-process)">
       <option value="pocsag_flex">POCSAG / FLEX</option>
       <option value="qcii">Motorola QCII</option></select></div>
+    <div class="grp" id="demodgrp" title="Which demodulators multimon-ng runs. On a FLEX-only channel, leaving POCSAG on makes it slice noise into garbage — narrow to just the protocol that's actually there.">
+      <span class="lbl">Baud</span>
+      <label class="chk"><input type="checkbox" class="dm" value="POCSAG512" checked>POCSAG&nbsp;512</label>
+      <label class="chk"><input type="checkbox" class="dm" value="POCSAG1200" checked>POCSAG&nbsp;1200</label>
+      <label class="chk"><input type="checkbox" class="dm" value="POCSAG2400" checked>POCSAG&nbsp;2400</label>
+      <label class="chk"><input type="checkbox" class="dm" value="FLEX" checked>FLEX</label>
+    </div>
+    <div class="grp" id="invgrp" title="multimon -i: flip the demodulated bitstream. Try this if a channel decodes but the text is gibberish (mis-polarised signal).">
+      <label class="chk"><input type="checkbox" id="invert">Invert</label>
+    </div>
     <div class="grp"><span class="tag idle" id="devtag">detecting…</span></div>
   </div>
 
@@ -92,7 +105,8 @@
   </div>
 
   <footer>
-    <div><b>How it works:</b> rtl_fm FM-demodulates the channel. POCSAG512/1200/2400 + FLEX are decoded by multimon-ng. <b>Motorola QCII</b> (fire/EMS two-tone sequential) has no multimon decoder, so Ragnar detects the ~1 s A-tone and ~3 s B-tone itself (FFT + duration gating) and reports the tone pair — the pager's address. All are unencrypted.</div>
+    <div><b>How it works:</b> rtl_fm FM-demodulates the channel (low-leakage FIR). POCSAG 512/1200/2400 + FLEX are decoded by multimon-ng. <b>Motorola QCII</b> (fire/EMS two-tone sequential) has no multimon decoder, so Ragnar detects the ~1 s A-tone and ~3 s B-tone itself (FFT + duration gating) and reports the tone pair — the pager's address. All are unencrypted.</div>
+    <div style="margin-top:6px"><b>Getting garbage?</b> The <b>Baud</b> boxes pick which demodulators run. POCSAG's three speeds (512/1200/2400) are separate demods; <b>FLEX</b> auto-detects its own speed (1600/3200/6400). On a FLEX-only channel, leaving POCSAG on makes multimon slice noise into junk "POCSAG" pages — <b>uncheck the ones the channel doesn't use</b> and the garbage stops. If a channel decodes but the text is scrambled, try <b>Invert</b> (flips the bitstream for a mis-polarised signal).</div>
     <div style="margin-top:6px"><b>One dongle:</b> this takes the RTL-SDR from the sub-GHz sweep / ADS-B while running. <b>Legality:</b> pager messages are often sensitive (medical, security) — decode third-party traffic only where lawful.</div>
   </footer>
 </div>
@@ -116,7 +130,17 @@
   function chosenFreqHz(){ var v=parseFloat(freqIn.value); if(isFinite(v)) return Math.round(v*1e6); if(presetSel.value) return parseInt(presetSel.value,10); return null; }
   var pmodeSel=document.getElementById('pmode');
   function chosenMode(){ return pmodeSel.value==='qcii'?'qcii':'pocsag_flex'; }
-  pmodeSel.addEventListener('change',function(){ if(running) startRun(); });
+  var demodGrp=document.getElementById('demodgrp'), invGrp=document.getElementById('invgrp'), invertCb=document.getElementById('invert');
+  function chosenDemods(){ return [].slice.call(document.querySelectorAll('.dm')).filter(function(c){return c.checked;}).map(function(c){return c.value;}); }
+  function chosenInvert(){ return !!invertCb.checked; }
+  // POCSAG baud + invert only apply to the multimon (POCSAG/FLEX) path — hide for QCII.
+  function syncDemodUI(){ var pf=chosenMode()==='pocsag_flex'; demodGrp.style.display=pf?'':'none'; invGrp.style.display=pf?'':'none'; }
+  pmodeSel.addEventListener('change',function(){ syncDemodUI(); if(running) startRun(); });
+  [].slice.call(document.querySelectorAll('.dm')).forEach(function(c){ c.addEventListener('change',function(){
+    if(!chosenDemods().length){ c.checked=true; return; }   // never allow zero demods
+    if(running) startRun(); }); });
+  invertCb.addEventListener('change',function(){ if(running) startRun(); });
+  syncDemodUI();
 
   function setMode(m){ mode=m; var el=document.getElementById('s-mode'); el.className='tag '+(m==='live'?'live':(m==='synth'?'synth':'idle')); el.textContent=(m==='live'?'decoding':(m==='synth'?'synthetic':'idle')); }
   function showVeil(t,s,inst){veilT.textContent=t;veilS.textContent=s||'';veil.classList.add('show');veilInstall.style.display=inst?'inline-block':'none';}
@@ -149,7 +173,7 @@
     var hz=chosenFreqHz(); if(!hz){ return; }
     running=true; var b=document.getElementById('startbtn'); b.setAttribute('aria-pressed','true'); b.innerHTML='&#10074;&#10074;&nbsp;Stop';
     seq=0; msgs=[]; freqHz=hz; renderTable();
-    fetch('/api/net/pager/start',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({freq_hz:hz,mode:chosenMode()})})
+    fetch('/api/net/pager/start',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({freq_hz:hz,mode:chosenMode(),demods:chosenDemods(),invert:chosenInvert()})})
       .then(function(r){return r.json();}).then(function(res){ if(res&&res.error){ if(DEMO_ON)synthMode(); else showVeil('Could not start',res.error); } }).catch(function(){});
     if(poll)clearInterval(poll); poll=setInterval(pollLive,1500); pollLive();
   }

--- a/docs/sdr-subghz.md
+++ b/docs/sdr-subghz.md
@@ -342,7 +342,20 @@ decoded in-process (no multimon-ng) — see `qcii_detect` in `pagerdecode.py`.
 > `pager` import name, so the decoder module was renamed to avoid the clash.
 
 - **Channels** — a preset list of common POCSAG/FLEX frequencies plus a
-  free-form MHz box. Uses the current PPM/gain tuning.
+  free-form MHz box. Uses the current PPM/gain tuning. `rtl_fm` runs with its
+  low-leakage downsample filter (`-F 9`) for cleaner narrowband FM, and
+  multimon-ng with `-u` (prune statistically unlikely decodes).
+- **Baud / demod selector** — POCSAG has three on-air baud rates (512 / 1200 /
+  2400), each a *separate* multimon-ng demodulator; **FLEX** is one demodulator
+  that auto-detects its own speed (1600 / 3200 / 6400 baud, 2- or 4-level). The
+  page's **Baud** checkboxes choose which demods run (`{demods:[…]}` on the start
+  API). This is the main cure for **garbage output**: on a FLEX-only channel,
+  leaving the POCSAG demods enabled makes multimon slice noise into junk
+  "POCSAG" pages — untick the protocols the channel doesn't carry and the
+  garbage stops. Defaults to all four (512/1200/2400 + FLEX).
+- **Invert** — the **Invert** toggle adds multimon's `-i` (flip the demodulated
+  bitstream), multimon's own advice for a channel that decodes but comes out
+  scrambled (mis-polarised signal). `{invert:true}` on the start API.
 - **`multimon-ng`** is in the Debian/Pi OS apt repos, so the installer/updater
   install it cleanly; if missing, the page shows an **⬇ Install multimon-ng**
   button (`POST /api/net/pager/install`).
@@ -486,8 +499,8 @@ timestamp), **Mic-E**, messages/acks, objects, status and best-effort weather �
 | `POST /api/net/mesh/start` · `/stop` · `/install` | Connect / disconnect the USB Meshtastic node; install meshtastic + paho-mqtt |
 | `POST /api/net/mesh/mqtt/connect` `{host?,port?,user?,password?,topic?}` · `/mqtt/disconnect` | Connect/disconnect the Meshtastic MQTT Internet feed (no node needed) |
 | `POST /api/net/mesh/send` `{text,to?,channel?,via?}` | Send a mesh text message via the node (LoRa) or MQTT (`via`=auto\|serial\|mqtt) |
-| `GET  /api/net/pager/status` · `/messages?since=` | Pager decode state (`mode`, `qcii_available`) + decoded POCSAG/FLEX/QCII messages |
-| `POST /api/net/pager/start` `{freq_hz, mode?}` · `/stop` · `/install` | Start/stop pager decode (`mode`=`pocsag_flex`\|`qcii`); install multimon-ng |
+| `GET  /api/net/pager/status` · `/messages?since=` | Pager decode state (`mode`, `demods`, `invert`, `qcii_available`) + decoded POCSAG/FLEX/QCII messages |
+| `POST /api/net/pager/start` `{freq_hz, mode?, demods?, invert?}` · `/stop` · `/install` | Start/stop pager decode (`mode`=`pocsag_flex`\|`qcii`; `demods`=subset of POCSAG512/1200/2400/FLEX; `invert`=flip bitstream); install multimon-ng |
 | `GET  /api/net/vor/status` | VOR decode state + latest `fix` (radial/lock/quality) |
 | `POST /api/net/vor/start` `{freq_hz, cal_deg?}` · `/stop` | Start/stop VOR radial decode on a 108–118 MHz station |
 | `GET  /api/net/aprs/status` · `/packets?since=` · `/stations` · `/messages?since=` | APRS state + packet feed + station map + messages |

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -19125,12 +19125,14 @@ def register_network_diagnostics(app, logger=None):
     def net_pager_start():
         data = request.get_json(silent=True) or {}
         mode = data.get('mode') or 'pocsag_flex'
-        _log(f"net/pager/start freq={data.get('freq_hz')} mode={mode}")
+        demods = data.get('demods')        # None -> default POCSAG+FLEX; list/str -> chosen baud set
+        invert = bool(data.get('invert'))  # multimon -i (flip bitstream) for a mis-polarised channel
+        _log(f"net/pager/start freq={data.get('freq_hz')} mode={mode} demods={demods} invert={invert}")
         try:
             rtl_sdr.power_stop(); rtl_sdr.ism_stop(); adsb.stop(); acars.stop(); vdl2.stop();radio.stop(); vor.stop(); aprs.stop()
         except Exception:
             pass
-        return jsonify(pager.start(freq_hz=data.get('freq_hz'), mode=mode))
+        return jsonify(pager.start(freq_hz=data.get('freq_hz'), mode=mode, demods=demods, invert=invert))
 
     @app.route('/api/net/pager/stop', methods=['POST'])
     def net_pager_stop():

--- a/pagerdecode.py
+++ b/pagerdecode.py
@@ -54,6 +54,37 @@ _RTL_FM = _which("rtl_fm")
 _MULTIMON = _which("multimon-ng")
 _MSG_RING = 500
 
+# POCSAG has three on-air baud rates (512 / 1200 / 2400) — each is a *separate*
+# multimon-ng demodulator. FLEX is one demodulator that auto-detects its speed
+# (1600 / 3200 / 6400 baud, 2- or 4-level) from the sync frame, so a single
+# "FLEX" toggle covers all FLEX speeds. Letting the user pick *which* demods run
+# is the "baud rate setting": on a FLEX-only channel, leaving the POCSAG demods
+# on makes multimon slice noise into garbage POCSAG pages, so narrowing to just
+# the protocol actually on the channel is the main cure for gibberish output.
+POCSAG_FLEX_DEMODS = ("POCSAG512", "POCSAG1200", "POCSAG2400", "FLEX", "FLEX_NEXT")
+_DEFAULT_DEMODS = ("POCSAG512", "POCSAG1200", "POCSAG2400", "FLEX")
+
+
+def _clean_demods(demods):
+    """Normalise a requested demod list to the supported set, order preserved.
+
+    Accepts a list/tuple or comma/space string of demod names (case-insensitive).
+    Unknown names are dropped; an empty/None request falls back to the default
+    POCSAG-512/1200/2400 + FLEX set so the decoder is never launched with no
+    demodulators (which multimon rejects)."""
+    if demods is None:
+        return list(_DEFAULT_DEMODS)
+    if isinstance(demods, str):
+        demods = re.split(r"[,\s]+", demods.strip())
+    allow = {d.upper(): d for d in POCSAG_FLEX_DEMODS}
+    out, seen = [], set()
+    for d in demods:
+        key = str(d).strip().upper()
+        if key in allow and key not in seen:
+            seen.add(key)
+            out.append(allow[key])
+    return out or list(_DEFAULT_DEMODS)
+
 # Common pager channels (label -> Hz). Regional and non-exhaustive; the UI also
 # accepts a free-form frequency. POCSAG runs on scattered VHF/UHF channels.
 PAGER_PRESETS = {
@@ -108,6 +139,7 @@ def detect():
     qcii_ok = tools["rtl_fm"] and tools["numpy"] and device
     base = {"tools": tools, "device_present": device, "usb_id": usb,
             "presets": PAGER_PRESETS, "qcii_available": qcii_ok,
+            "demods": list(POCSAG_FLEX_DEMODS), "default_demods": list(_DEFAULT_DEMODS),
             "tools_installed": tools["multimon_ng"] and tools["rtl_fm"]}
     if not tools["rtl_fm"]:
         base.update(available=False, error="rtl_fm not installed (apt install rtl-sdr)")
@@ -321,6 +353,8 @@ class PagerDecoder:
         self._error = None
         self._started = None
         self._mode = "pocsag_flex"
+        self._demods = list(_DEFAULT_DEMODS)
+        self._invert = False
         self._qcii_recent = {}
 
     def status(self):
@@ -328,6 +362,7 @@ class PagerDecoder:
             return {"running": bool(self._thread and self._thread.is_alive()),
                     "freq_hz": self._freq, "messages": self._count,
                     "error": self._error, "mode": self._mode,
+                    "demods": list(self._demods), "invert": self._invert,
                     "seconds": round(time.time() - self._started, 1) if self._started else 0}
 
     def messages(self, since=0):
@@ -339,11 +374,17 @@ class PagerDecoder:
             new = [m for m in self._msgs if m["seq"] > since]
             return {"messages": new, "seq": self._count, "freq_hz": self._freq,
                     "running": bool(self._thread and self._thread.is_alive()),
-                    "mode": self._mode, "error": self._error}
+                    "mode": self._mode, "demods": list(self._demods),
+                    "invert": self._invert, "error": self._error}
 
-    _QCII_SR = 22050        # rtl_fm audio rate for the QCII tone path
+    # rtl_fm audio rate. multimon-ng's raw demodulators require exactly 22050 Hz
+    # 16-bit mono (see rtl_fm's own `-s 22050 | multimon` example); the QCII
+    # tone path reuses the same stream. Do NOT change this without re-checking
+    # multimon — a different rate is a classic cause of garbage decodes.
+    _QCII_SR = 22050
+    _RATE = 22050
 
-    def start(self, freq_hz, mode="pocsag_flex"):
+    def start(self, freq_hz, mode="pocsag_flex", demods=None, invert=False):
         try:
             freq_hz = int(float(freq_hz))
         except (TypeError, ValueError):
@@ -353,6 +394,8 @@ class PagerDecoder:
         mode = "qcii" if str(mode).lower() == "qcii" else "pocsag_flex"
         if mode == "qcii" and np is None:
             return {"ok": False, "error": "QCII decode needs numpy"}
+        demods = _clean_demods(demods)
+        invert = bool(invert)
         with self._lock:
             if self._thread and self._thread.is_alive():
                 self._stop_locked()
@@ -362,6 +405,8 @@ class PagerDecoder:
             self._qcii_recent = {}
             self._freq = freq_hz
             self._mode = mode
+            self._demods = demods
+            self._invert = invert
             self._error = None
             self._started = time.time()
             ppm = 0
@@ -373,13 +418,25 @@ class PagerDecoder:
                 gain = None if t.get("gain_is_auto") else t.get("gain")
             except Exception:
                 pass
+            # -F 9 enables rtl_fm's low-leakage downsample FIR — noticeably
+            # cleaner narrowband FM than the default roll-off, which is exactly
+            # what marginal POCSAG/FLEX needs to slice symbols correctly.
             fm_cmd = [_RTL_FM, "-f", str(freq_hz), "-M", "fm",
-                      "-s", str(self._QCII_SR), "-l", "0", "-p", str(ppm or 0)]
+                      "-s", str(self._RATE), "-F", "9", "-l", "0", "-p", str(ppm or 0)]
             if gain is not None:
                 fm_cmd += ["-g", str(gain)]
             fm_cmd += ["-"]
-            mm_cmd = [_MULTIMON, "-a", "POCSAG512", "-a", "POCSAG1200",
-                      "-a", "POCSAG2400", "-a", "FLEX", "-f", "alpha", "-t", "raw", "-"]
+            # Only the demods the user selected (default: all POCSAG + FLEX).
+            # -u prunes statistically unlikely POCSAG decodes (kills a lot of
+            # noise-into-garbage). -i inverts the bitstream — multimon's own
+            # advice "try this if decoding fails" for a mis-polarised channel.
+            mm_cmd = [_MULTIMON]
+            for d in self._demods:
+                mm_cmd += ["-a", d]
+            mm_cmd += ["-f", "alpha", "-t", "raw", "-u"]
+            if invert:
+                mm_cmd += ["-i"]
+            mm_cmd += ["-"]
             try:
                 self._fm = subprocess.Popen(fm_cmd, stdout=subprocess.PIPE,
                                             stderr=subprocess.DEVNULL)
@@ -492,7 +549,7 @@ class PagerDecoder:
 _decoder = PagerDecoder()
 
 
-def start(freq_hz=None, mode="pocsag_flex"):
+def start(freq_hz=None, mode="pocsag_flex", demods=None, invert=False):
     d = detect()
     mode = "qcii" if str(mode).lower() == "qcii" else "pocsag_flex"
     if mode == "qcii":
@@ -504,7 +561,7 @@ def start(freq_hz=None, mode="pocsag_flex"):
         return {"ok": False, "error": d.get("error", "pager decode unavailable")}
     if freq_hz is None:
         freq_hz = list(PAGER_PRESETS.values())[0]
-    return _decoder.start(freq_hz, mode=mode)
+    return _decoder.start(freq_hz, mode=mode, demods=demods, invert=invert)
 
 
 def stop():
@@ -593,6 +650,18 @@ def selftest():
           str(got))
     check("presets: common pager channels present",
           any("POCSAG" in k for k in PAGER_PRESETS) and all(24e6 <= v <= 1766e6 for v in PAGER_PRESETS.values()))
+
+    # --- demod / baud selector normalisation ---
+    check("demods: None -> default POCSAG+FLEX set",
+          _clean_demods(None) == list(_DEFAULT_DEMODS), str(_clean_demods(None)))
+    check("demods: FLEX-only request kept as-is",
+          _clean_demods(["FLEX"]) == ["FLEX"], str(_clean_demods(["FLEX"])))
+    check("demods: case-insensitive + comma string + dedupe",
+          _clean_demods("flex, pocsag1200, POCSAG1200") == ["FLEX", "POCSAG1200"],
+          str(_clean_demods("flex, pocsag1200, POCSAG1200")))
+    check("demods: unknown names dropped, empty -> default",
+          _clean_demods(["bogus", "NOTAREAL"]) == list(_DEFAULT_DEMODS),
+          str(_clean_demods(["bogus"])))
 
     # --- Motorola QCII two-tone decode (synthesised audio, no hardware) ---
     if np is not None:


### PR DESCRIPTION
The pager decoder always ran every POCSAG demod (512/1200/2400) plus FLEX at once. On a FLEX-only channel that makes multimon-ng slice noise into garbage POCSAG pages — the reported 'FLEX works but the text is gibberish' symptom.

- pagerdecode.py: start() takes demods=[...] (subset of POCSAG512/1200/2400/ FLEX, the 'baud rate setting') and invert=bool. Builds multimon -a flags from the selection, adds -u (prune unlikely decodes), and -i when inverting. rtl_fm now uses -F 9 (low-leakage downsample FIR) for cleaner narrowband FM. Sample rate pinned at 22050 (multimon's required raw rate) with a comment. detect()/ status()/messages() report the demod set + invert. selftest 16/16.
- network_diagnostics.py: pass demods/invert through /api/net/pager/start.
- demos/pager_decode.html: Baud checkboxes (POCSAG 512/1200/2400 + FLEX) and an Invert toggle, hidden in QCII mode; never allows zero demods; restarts live on change. Footer explains the anti-garbage workflow. Mobile-friendly (bar and groups wrap).
- docs/sdr-subghz.md: document the selector, invert, -F 9/-u, and API params.