### PR TITLE
fix(bfd,guards): handle IPv6 Authentication Header (AH, proto 51) in …

### DIFF
--- a/bfdwatch.py
+++ b/bfdwatch.py
@@ -438,7 +438,9 @@ ETH_P_8021AD = 0x88A8
 IPPROTO_UDP = 17
 
 # Extension headers we will walk past to reach UDP in IPv6.
-V6_SKIPPABLE = {0: True, 43: True, 60: True}  # hop-by-hop, routing, dest-opts
+# Protocol 51 (AH) and 60 (Dest Opts) use different length encodings;
+# see _decode_ipv6 for special handling of AH.
+V6_SKIPPABLE = {0: True, 43: True, 51: True, 60: True}  # hop-by-hop, routing, AH, dest-opts
 
 
 @dataclass
@@ -528,7 +530,12 @@ def _decode_ipv6(buf, off, ts, src_mac, dst_mac, vlan) -> Optional[PacketMeta]:
     while nxt in V6_SKIPPABLE and hops < 6:
         if len(buf) < cur + 2:
             return None
-        ext_len = (buf[cur + 1] + 1) * 8
+        # RFC 2402 (AH, protocol 51) uses (len + 2) * 4 byte units.
+        # RFC 2460 (HopOpt, Routing, DestOpts: 0, 43, 60) use (len + 1) * 8 byte units.
+        if nxt == 51:  # AH
+            ext_len = (buf[cur + 1] + 2) * 4
+        else:  # 0, 43, 60
+            ext_len = (buf[cur + 1] + 1) * 8
         nxt = buf[cur]
         cur += ext_len
         hops += 1

--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -2033,8 +2033,12 @@ records its discriminators and state and emits inventory only, and observation g
 treated as **resyncs**, so deploying mid-flight on a lossy SPAN never manufactures a
 phantom teardown. The engine is pure-Python — the Ethernet/IPv4/IPv6/UDP decode, the BFD
 parser and the pcap reader are all hand-rolled (Scapy is used only by the upstream CLI's
-live mode, which the in-app path does not use). **API:** `GET /api/net/bfd-watch` (query:
-`interface`, `seconds`).
+live mode, which the in-app path does not use). The IPv6 decoder walks the full
+extension-header chain, **including the Authentication Header (AH, protocol 51)** — which
+uses a different length encoding than the RFC 8200 headers (`(len+2)×4` per RFC 2402, not
+`(len+1)×8`); before this fix a BFD frame behind AH — as seen on IPsec/AH-hardened
+segments — was silently dropped, so no findings fired at all. **API:**
+`GET /api/net/bfd-watch` (query: `interface`, `seconds`).
 
 > **Watchtower feed.** HIGH/CRITICAL BFD findings (spoofed teardown, forced AdminDown,
 > state regression, malformed/truncated header, GTSM violation, auth downgrade, session

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -17327,6 +17327,26 @@ _JUNIPER_GUARD_BPF = (
     'tcp port 8443 or ' + _GUARD_IP6_EXTHDR_BPF)
 
 
+# IPv6 extension headers the chain walkers step over to reach the transport —
+# the same set the capture admits (_GUARD_IP6_EXTHDR_BPF). AH (51) is the tell:
+# it uses a DIFFERENT length encoding than the RFC 8200 headers, so a naive
+# (len+1)*8 walk misaligns and drops the frame (the bfdwatch/ptpwatch AH bug).
+_IPV6_EXT_HDRS = frozenset((0, 43, 44, 51, 60))  # HopOpt, Routing, Frag, AH, DestOpt
+
+
+def _ipv6_ext_len(buf, off, nh):
+    """Byte length of the IPv6 extension header of type `nh` at `off`, or None if
+    truncated. Fragment (44) is a fixed 8 bytes; AH (51) is (len+2)*4 per RFC 2402
+    (4-byte units, bias 2); the rest (0/43/60) are (len+1)*8 per RFC 8200."""
+    if off + 2 > len(buf):
+        return None
+    if nh == 44:
+        return 8
+    if nh == 51:
+        return (buf[off + 1] + 2) * 4
+    return (buf[off + 1] + 1) * 8
+
+
 def _guard_ip_payload(block_lines):
     """Reconstruct the L4 payload bytes from a tcpdump `-x`/`-X` hex-dump block.
     tcpdump prints packet bytes from the IP header on (link layer stripped); we
@@ -17356,15 +17376,15 @@ def _guard_ip_payload(block_lines):
         if len(data) < 40:
             return (None, None, None, b'')
         # Walk the IPv6 extension-header chain to the true upper-layer protocol —
-        # a single Hop-by-Hop/Routing/Dest-Opts header is enough to hide the TCP
-        # header from a naive `data[6]`/`data[40:]` read (and from a `tcp port N`
-        # BPF, which is why the capture admits all IPv6). Fragment (44) is a fixed
-        # 8-byte header; the others are (hdr-ext-len + 1) * 8.
+        # a single Hop-by-Hop/Routing/Dest-Opts/AH header is enough to hide the
+        # TCP header from a naive `data[6]`/`data[40:]` read (and from a `tcp
+        # port N` BPF). _ipv6_ext_len handles AH's RFC 2402 length encoding.
         proto, off, hops = data[6], 40, 0
-        while proto in (0, 43, 44, 60) and off + 2 <= len(data) and hops < 16:
-            nxt = data[off]
-            off += 8 if proto == 44 else (data[off + 1] + 1) * 8
-            proto, hops = nxt, hops + 1
+        while proto in _IPV6_EXT_HDRS and hops < 16:
+            step = _ipv6_ext_len(data, off, proto)
+            if not step:
+                break
+            proto, off, hops = data[off], off + step, hops + 1
         l4 = data[off:] if off <= len(data) else b''
     else:
         return (None, None, None, b'')
@@ -17401,10 +17421,11 @@ def _guard_l3l4_from_raw(data):
             if len(data) < 40:
                 return none5
             proto, off, hops = data[6], 40, 0
-            while proto in (0, 43, 44, 60) and off + 2 <= len(data) and hops < 16:
-                nxt = data[off]
-                off += 8 if proto == 44 else (data[off + 1] + 1) * 8
-                proto, hops = nxt, hops + 1
+            while proto in _IPV6_EXT_HDRS and hops < 16:
+                step = _ipv6_ext_len(data, off, proto)
+                if not step:
+                    break
+                proto, off, hops = data[off], off + step, hops + 1
             src = socket.inet_ntop(socket.AF_INET6, data[8:24])
             dst = socket.inet_ntop(socket.AF_INET6, data[24:40])
         else:
@@ -17822,16 +17843,16 @@ def _ipv6_rh0(ip_raw):
     if len(ip_raw) < 40 or (ip_raw[0] >> 4) != 6:
         return False
     nh, off, hops = ip_raw[6], 40, 0
-    while nh in (0, 43, 60) and off + 2 <= len(ip_raw) and hops < 16:
+    while nh in _IPV6_EXT_HDRS and off + 2 <= len(ip_raw) and hops < 16:
         if nh == 43:                              # Routing Header
             if off + 3 >= len(ip_raw):
                 return False
             if ip_raw[off + 2] == 0:              # routing type 0 == RH0
                 return True
-        nxt = ip_raw[off]
-        off += (ip_raw[off + 1] + 1) * 8
-        nh = nxt
-        hops += 1
+        step = _ipv6_ext_len(ip_raw, off, nh)     # AH-aware length (RFC 2402)
+        if not step:
+            return False
+        nh, off, hops = ip_raw[off], off + step, hops + 1
     return False
 
 
@@ -18803,6 +18824,21 @@ def _cisco_selftest():
                       'got': _cbpf,
                       'pass': ('udp port 546' in _cbpf and 'udp port 547' in _cbpf
                                and 'ip6[6]' in _cbpf and '(ip and' not in _cbpf)})
+
+    # AH (protocol 51) length encoding (RFC 2402): a payload-len field of 4 means
+    # (4 + 2) * 4 = 24 bytes, NOT the (4 + 1) * 8 = 40 of the RFC 8200 headers.
+    scenarios.append({'name': 'cisco-ah-extlen',
+                      'expect': '24', 'got': str(_ipv6_ext_len(b'\x2b\x04' + b'\x00' * 22, 0, 51)),
+                      'pass': _ipv6_ext_len(b'\x2b\x04' + b'\x00' * 22, 0, 51) == 24})
+    # RH0 hidden BEHIND an AH header must still be found — the walker has to skip
+    # AH with the right length or the frame is silently dropped (the AH bug class).
+    _ah = b'\x2b\x04' + b'\x00' * 22                         # next=Routing(43), len=4 -> 24B
+    _rh0 = bytes([59, 0, 0, 0, 0, 0, 0, 0])                  # next=NoNext, type 0 (RH0)
+    _v6ah = (b'\x60\x00\x00\x00' + struct.pack('!H', len(_ah) + len(_rh0))
+             + bytes([51, 64]) + ipaddress.IPv6Address('2001:db8::1').packed
+             + ipaddress.IPv6Address('2001:db8::2').packed + _ah + _rh0)
+    scenarios.append({'name': 'cisco-ipv6-rh0-behind-ah', 'expect': 'RH0 found behind AH',
+                      'got': str(_ipv6_rh0(_v6ah)), 'pass': _ipv6_rh0(_v6ah) is True})
 
     # BER parse: SNMPv2c GetRequest, default community.
     snmp = _snmp_ber_parse(_snmp_v2c_get(b'public'))


### PR DESCRIPTION
BFD Watch v2 is "the AH fix". A BFD frame encapsulated with an IPv6 Authentication Header (protocol 51, RFC 2402 — used on IPsec/AH-hardened segments) was silently dropped: AH was absent from the extension-header skip-set, and even if added it uses a different length encoding than the RFC 8200 headers -- (len+2)*4 in 4-byte units, not (len+1)*8 in 8-byte units -- so a naive walk misaligns and loses the UDP/BFD payload. Applied the upstream v2 fix to the vendored bfdwatch.py (V6_SKIPPABLE gains 51; _decode_ipv6 special-cases AH length), preserving the appended Ragnar in-app adapter. An IPv6+AH+UDP+BFD frame now decodes (was None); BFD self-test 7/7.

The same bug was present in the in-app vendor-guard extension-header walkers I added recently: the capture clause admits ip6[6]=51 (AH) but _guard_ip_payload / _guard_l3l4_from_raw / _ipv6_rh0 walked only {0,43,44,60} with the (len+1)*8 formula, so a guard packet behind AH misparsed. Added a shared _IPV6_EXT_HDRS set and _ipv6_ext_len() helper (AH -> (len+2)*4, fragment -> 8, else (len+1)*8) and routed all three walkers through it. New self-tests: AH ext-length math (=24) and RH0 detection behind an AH header.

cisco 18/18, aggregate green. Docs note the AH handling in the BFD section.