### PR TITLE
docs(ptp): document PTP Watch in Watchtower feed list + cross-link th…

### DIFF
--- a/docs/nettools.md
+++ b/docs/nettools.md
@@ -663,7 +663,9 @@ general UDP ports and the 802.1AS ethertype and reports whether a grandmaster is
 announcing, the message types, and the domain(s). This is a field "is PTP here?"
 check; precise clock-offset measurement needs a running `ptp4l`. (Standardised
 TWAMP/OWAMP SLA testing is a natural next step but needs a cooperating reflector
-on the far end.)
+on the far end.) For the passive **security** monitor of the same timing plane —
+grandmaster takeover, time injection, gPTP peer-delay attacks — see
+[PTP Watch](#ptp-watch).
 
 - Endpoint: `POST /api/net/ptp` `{interface, seconds}` · binary: `tcpdump`
 
@@ -2050,7 +2052,9 @@ segments — was silently dropped, so no findings fired at all. **API:**
 ### PTP Watch
 A **passive** IEEE-1588 / PTPv2 / gPTP **timing-plane manipulation** monitor —
 **detection-only**, it has no transmit primitives (the upstream engine's conformance tier
-greps its own source to prove that, rather than trusting the claim). The precision-time
+greps its own source to prove that, rather than trusting the claim). This is the **security**
+monitor; for the simpler "is a grandmaster present on this segment?" inventory check see
+[PTP Timing Detection](#ptp-timing-detection). The precision-time
 plane carries the phase reference for 5G radios, power-grid PMUs, broadcast, finance and
 industrial control, and it is almost never authenticated — a forged Announce or an injected
 `correctionField` does not crash anything, it quietly drags the time base and everything

--- a/docs/watchtower.md
+++ b/docs/watchtower.md
@@ -74,6 +74,14 @@ regression** that induces routing reconvergence lands as **critical**, and no-au
 GTSM violation / malformed-or-truncated header (**CVE-2018-0155**) / auth downgrade /
 session flap as **high**.
 
+[`ptp_watch`](nettools.md#ptp-watch) (PTP Watch) appends its **HIGH/CRITICAL**
+timing-plane-manipulation findings to `/var/log/ragnar/ptp_watch.jsonl` (deduplicated per
+code + port-identity) — a grandmaster **takeover** / two sources claiming one GM identity,
+a `correctionField` or origin-timestamp **injection**, a mid-session `currentUtcOffset`
+flip, a management **SET/WRITE**, a unicast-cancel forgery, or a gPTP **multi-peer-delay
+responder** (denial-of-timing) lands as **critical**, and Announce/Sync flooding, sequence
+regression and identity-from-two-MACs as **high**.
+
 [`sr_mpls_watch`](nettools.md#sr-mpls-watch) (SR-MPLS Watch) appends its **HIGH/CRITICAL**
 label & segment-manipulation findings to `/var/log/ragnar/sr_mpls_watch.jsonl`
 (deduplicated per code + key) — a label or **SRH on a customer-facing port**


### PR DESCRIPTION


PTP Watch emits HIGH/CRITICAL findings to /var/log/ragnar/ptp_watch.jsonl but was only documented in nettools.md. Add its entry to the Watchtower feed catalogue (docs/watchtower.md), mirroring the bfd_watch/sr_mpls_watch entries, so its grandmaster-takeover / time-injection / gPTP peer-delay alerts are documented as part of the unified pane + Pushover path.

Also cross-link the two distinct PTP features in nettools.md so they aren't confused: "PTP Timing Detection" (POST /api/net/ptp — the do_ptp_detect presence check) and "PTP Watch" (GET /api/net/ptp-watch — the passive security monitor).