### PR TITLE
web: bump JS cache-buster + show PineAP card on tab open

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -8484,7 +8484,7 @@
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260822-mobile-opacity"></script>
     <script src="/web/scripts/skyview_vr.js?v=20260822-rich-info-panel"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260906-ptp-watch-v2-idfix"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260907-pineap-panel"></script>
 
 
 

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -4817,6 +4817,14 @@ function _wifidefFillIfaces() {
         _wifidefFillPanelIface('wifidef-at-iface', ifs);
         _wifidefFillPanelIface('wifidef-iso-iface', ifs);
         _wifidefUpdateMonBtn();
+        // Show the PineAP card on tab open so the Active-probe button is always
+        // reachable; the passive verdict fills in after a WiFi Defense scan.
+        const paBox = document.getElementById('wifidef-pa-inline');
+        const paBody = document.getElementById('wifidef-pa-body');
+        if (paBox) paBox.hidden = false;
+        if (paBody && !paBody.innerHTML.trim()) {
+            paBody.innerHTML = '<div class="text-[12px] text-gray-400">Run a WiFi Defense scan for the passive verdict, or click <b>Active probe</b> for the definitive test.</div>';
+        }
         // Reflect the headless 24/7 watch's current state (it may already be
         // running from a previous session — the daemon persists "if enabled").
         wifidefHaleHoundWatchStatus();


### PR DESCRIPTION
The PineAP panel shipped but two things hid it: the index_modern.html script tag still carried the old ?v= cache-buster, so browsers served the cached JS without the new functions; and the card only un-hid after a scan. Bump the cache-buster to 20260907-pineap-panel and reveal the card on WiFi Defense tab open so the Active-probe button is always reachable (the passive verdict fills in on scan).