### PR TITLE
wifi_defense: detect WPA3-strip downgrade in the panel scan

### DIFF
--- a/tests/test_wifi_defense_downgrade.py
+++ b/tests/test_wifi_defense_downgrade.py
@@ -1,0 +1,58 @@
+"""WPA3 downgrade / transition-mode detection in wifi_defense.analyze()."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import wifi_defense as wd            # noqa: E402
+
+
+def _beacon(bssid, ssid, security):
+    return {"kind": "beacon", "src": bssid, "ssid": ssid, "security": security}
+
+
+def _downgrade(res, sev=None):
+    return [d for d in res["detections"]
+            if d["type"] == "wpa3_downgrade" and (sev is None or d["severity"] == sev)]
+
+
+def test_wpa3_strip_evil_twin_detected():
+    # Real WPA3 net on one vendor; a DIFFERENT-OUI BSSID clones it as WPA2-only.
+    events = [_beacon("00:11:22:00:00:01", "CorpWiFi", "WPA3")] * 2 \
+        + [_beacon("66:77:88:00:00:09", "CorpWiFi", "WPA2")] * 2
+    res = wd.analyze(events)
+    strip = _downgrade(res, "wpa3_strip")
+    assert strip, res["detections"]
+    assert "66:77:88:00:00:09" in strip[0]["rogue_bssids"]
+    assert res["threat"] == "critical"
+
+
+def test_transition_mode_is_informational():
+    res = wd.analyze([_beacon("aa:aa:aa:00:00:01", "HomeNet", "WPA2/3")] * 2)
+    trans = _downgrade(res, "wpa3_transition")
+    assert trans and trans[0]["bssid"] == "aa:aa:aa:00:00:01"
+    # Transition mode alone is not critical (config choice, not an attack).
+    assert res["threat"] != "critical"
+    # And a lone transition AP is NOT a strip.
+    assert not _downgrade(res, "wpa3_strip")
+
+
+def test_same_vendor_mixed_mode_not_flagged_critical():
+    # One vendor's gear: WPA3 SSID on one BSSID, a WPA2 SSID of the same name on
+    # a sibling BSSID sharing the OUI => mixed-mode, not an evil twin.
+    events = [_beacon("00:11:22:00:00:01", "MyNet", "WPA3"),
+              _beacon("00:11:22:00:00:02", "MyNet", "WPA2")]
+    res = wd.analyze(events)
+    assert _downgrade(res, "wpa3_mixed")
+    assert not _downgrade(res, "wpa3_strip")
+
+
+def test_clean_wpa3_only_no_downgrade():
+    res = wd.analyze([_beacon("aa:aa:aa:00:00:01", "SecureNet", "WPA3")] * 3)
+    assert not _downgrade(res)
+
+
+def test_plain_wpa2_network_not_flagged():
+    # No SAE ever advertised => nothing to strip, no finding.
+    res = wd.analyze([_beacon("aa:aa:aa:00:00:01", "OldNet", "WPA2")] * 3)
+    assert not _downgrade(res)

--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -3084,7 +3084,7 @@
                 <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-3">
                     <div>
                         <h2 class="text-xl font-semibold flex items-center gap-2">🛡️ WiFi Defense <span class="text-xs font-normal px-2 py-0.5 rounded bg-slate-700 text-slate-300">802.11 WIDS</span></h2>
-                        <p class="text-sm text-gray-400 mt-1 max-w-3xl">A passive <strong>wireless intrusion-detection</strong> monitor. Listens on a <strong>monitor-mode</strong> adapter for 802.11 management frames and flags <strong>deauth/disassoc floods</strong>, <strong>beacon floods</strong> (fake-AP storms), <strong>rogue APs / evil twins</strong>, <strong>KARMA/MANA</strong>, and <strong>Wi-Fi Pineapple / PineAP-family</strong> rogue APs (Mark VII, Enterprise, Pager) — plus a <strong>client-isolation observer</strong> that audits whether an AP/mesh really isolates its clients. The continuous monitor is <strong>receive-only</strong> — it never transmits a frame or deauths anyone back; the one exception is the opt-in <strong>PineAP active probe</strong> button, which transmits only when you click it. Needs an adapter that supports monitor mode (e.g. the Alfa AWUS036AXM); the Pi's onboard radio does not.</p>
+                        <p class="text-sm text-gray-400 mt-1 max-w-3xl">A passive <strong>wireless intrusion-detection</strong> monitor. Listens on a <strong>monitor-mode</strong> adapter for 802.11 management frames and flags <strong>deauth/disassoc floods</strong>, <strong>beacon floods</strong> (fake-AP storms), <strong>rogue APs / evil twins</strong>, <strong>KARMA/MANA</strong>, and <strong>Wi-Fi Pineapple / PineAP-family</strong> rogue APs (Mark VII, Enterprise, Pager), and <strong>WPA3-strip downgrades</strong> (an evil twin re-advertising a WPA3 SSID as WPA2-only) — plus a <strong>client-isolation observer</strong> that audits whether an AP/mesh really isolates its clients. The continuous monitor is <strong>receive-only</strong> — it never transmits a frame or deauths anyone back; the one exception is the opt-in <strong>PineAP active probe</strong> button, which transmits only when you click it. Needs an adapter that supports monitor mode (e.g. the Alfa AWUS036AXM); the Pi's onboard radio does not.</p>
                     </div>
                     <span id="wifidef-threat" class="shrink-0 px-4 py-2 rounded-lg text-sm font-bold bg-slate-700 text-slate-300">— idle —</span>
                 </div>
@@ -8484,7 +8484,7 @@
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260822-mobile-opacity"></script>
     <script src="/web/scripts/skyview_vr.js?v=20260822-rich-info-panel"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260906-ptp-watch-v2-idfix"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260907-wpa3-downgrade"></script>
 
 
 

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -5248,8 +5248,8 @@ function wifidefRender() {
         det.innerHTML = '<div class="glass rounded-xl p-4 text-sm text-green-300 md:col-span-2">✓ No wireless attacks detected in this capture.</div>';
     } else {
         det.innerHTML = d.detections.map(x => {
-            const crit = ['flood', 'evil_twin', 'karma', 'spoofed_bssid', 'attack_tool_ssid'].includes(x.severity);
-            const info = x.severity === 'band_steering';
+            const crit = ['flood', 'evil_twin', 'karma', 'spoofed_bssid', 'attack_tool_ssid', 'wpa3_strip'].includes(x.severity);
+            const info = ['band_steering', 'wpa3_transition', 'wpa3_mixed'].includes(x.severity);
             const border = crit ? 'border-l-4 border-red-500'
                 : info ? 'border-l-4 border-emerald-500' : 'border-l-4 border-amber-500';
             let title = '', body = '';
@@ -5284,6 +5284,15 @@ function wifidefRender() {
                 title = x.severity === 'flood' ? '🌊 Auth flood (client-table exhaustion)' : '⚠ Auth frames seen';
                 const laTag = (x.la_ratio != null) ? ` · <span class="${x.la_ratio >= 0.5 ? 'text-red-300' : 'text-gray-500'}">${Math.round(x.la_ratio * 100)}% randomized MACs</span>` : '';
                 body = `<div>${x.count} auth frames from ${x.sources} MACs${laTag}.</div><div class="font-mono text-[11px] text-gray-400">target ${_wifidefMacLink(x.bssid)}</div>`;
+            } else if (x.type === 'wpa3_downgrade') {
+                title = x.severity === 'wpa3_strip' ? '🔓 WPA3-strip downgrade (evil twin)'
+                    : x.severity === 'wpa3_transition' ? '🔁 WPA3 transition mode (downgradeable)'
+                    : '📶 WPA3/WPA2 mixed-mode (same vendor — benign)';
+                body = `<div>SSID <b>${_esc(x.ssid || '')}</b></div>`;
+                const sae = x.sae_bssids || [];
+                const psk = x.rogue_bssids || (x.bssid ? [x.bssid] : []);
+                if (sae.length) body += `<div class="text-[11px] text-emerald-300">WPA3-SAE: <span class="font-mono">${sae.map(b => _wifidefMacLink(b, x.ssid)).join(', ')}</span></div>`;
+                if (psk.length) body += `<div class="text-[11px] ${x.severity === 'wpa3_strip' ? 'text-red-300' : 'text-gray-400'}">PSK-only: <span class="font-mono">${psk.map(b => _wifidefMacLink(b, x.ssid)).join(', ')}</span></div>`;
             }
             return `<div class="glass rounded-xl p-4 ${border}"><div class="font-semibold text-sm mb-1">${title}</div><div class="text-sm text-gray-300">${body}</div><div class="text-[11px] text-gray-500 mt-1">${x.detail || ''}${body.indexOf('wifiPivotFromDefense') >= 0 ? ' <span class="text-gray-600">· click a MAC to inspect it in Signal Intelligence</span>' : ''}</div></div>`;
         }).join('');

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -2085,6 +2085,55 @@ def analyze(events, baseline=None, window_secs=None, thresholds=None):
                           "— possible evil-twin captive portal; probe it to confirm",
             })
 
+    # --- WPA3 downgrade / transition-mode exposure (ported from wifiwatch) ---
+    # Read straight from the advertised security suite (_classify_security):
+    #   * transition mode — one BSSID offering SAE + PSK together (WPA2/3). A
+    #     WPA3 client can be forced down to WPA2-PSK; informational (it's a config
+    #     choice a lot of routers ship with, not an attack).
+    #   * active downgrade / WPA3 strip — an SSID seen offering SAE (WPA3 or
+    #     WPA2/3) from one BSSID that ALSO appears PSK-only (no SAE) from another:
+    #     an evil twin stripping WPA3 to make the 4-way handshake crackable.
+    #     Critical — UNLESS every BSSID involved shares one vendor OUI, which is a
+    #     benign mixed-mode deployment (one AP running WPA3 + a WPA2 SSID), not a
+    #     clone; that is down-ranked to an informational note.
+    _SAE_SECS = {"WPA3", "WPA2/3"}
+    _PSK_ONLY_SECS = {"WPA", "WPA2", "WPA/WPA2"}
+    sae_by_ssid, psk_by_ssid = {}, {}
+    _transition_seen = set()
+    for e in beacons + presp:
+        ssid, src, sec = e.get("ssid"), e.get("src"), e.get("security")
+        if not ssid or not src or _is_blank_ssid(ssid):
+            continue
+        if sec == "WPA2/3" and src not in _transition_seen:
+            _transition_seen.add(src)
+            detections.append({
+                "type": "wpa3_downgrade", "severity": "wpa3_transition",
+                "ssid": ssid, "bssid": src,
+                "detail": f"SSID '{ssid}' ({src}) advertises WPA3-SAE and "
+                          "WPA2-PSK together — downgradeable transition mode",
+            })
+        if sec in _SAE_SECS:
+            sae_by_ssid.setdefault(ssid, set()).add(src)
+        elif sec in _PSK_ONLY_SECS:
+            psk_by_ssid.setdefault(ssid, set()).add(src)
+    for ssid in set(sae_by_ssid) & set(psk_by_ssid):
+        sae_b = sae_by_ssid[ssid]
+        strippers = sorted(psk_by_ssid[ssid] - sae_b)
+        if not strippers:
+            continue
+        union = sae_b | psk_by_ssid[ssid]
+        if _is_band_steering(union):
+            sev, kind = "wpa3_mixed", "mixed-mode on one vendor's gear — not an evil twin"
+        else:
+            sev, kind = "wpa3_strip", "WPA3-strip downgrade / evil twin"
+        detections.append({
+            "type": "wpa3_downgrade", "severity": sev, "ssid": ssid,
+            "rogue_bssids": strippers, "sae_bssids": sorted(sae_b),
+            "detail": f"SSID '{ssid}' offers WPA3-SAE from "
+                      f"{', '.join(sorted(sae_b))} but PSK-only (no SAE) from "
+                      f"{', '.join(strippers)} — {kind}",
+        })
+
     # Access-point inventory (for the UI table + baseline building)
     aps = {}
     for e in beacons:
@@ -2101,10 +2150,11 @@ def analyze(events, baseline=None, window_secs=None, thresholds=None):
             ap["channel"] = e["channel"]
 
     sev_rank = {"flood": 3, "evil_twin": 3, "karma": 3, "spoofed_bssid": 3,
-                "attack_tool_ssid": 3,
+                "attack_tool_ssid": 3, "wpa3_strip": 3,
                 "duplicate_ssid": 2, "beacon_warn": 2, "auth_warn": 2,
                 "esp32_open_ap": 2,
-                "band_steering": 1, "rogue_lure": 1, "seen": 1}
+                "band_steering": 1, "rogue_lure": 1, "seen": 1,
+                "wpa3_transition": 1, "wpa3_mixed": 1}
     threat = "clear"
     if detections:
         worst = max(sev_rank.get(d["severity"], 1) for d in detections)


### PR DESCRIPTION
Ports wifiwatch's WPA3 downgrade detection into wifi_defense.analyze() so a one-shot WiFi Defense scan flags it inline (not just the continuous daemon). Read from the advertised RSN AKM suites:
- wpa3_transition (info): one BSSID offering SAE + PSK together (WPA2/3) — a downgradeable transition-mode config.
- wpa3_strip (critical): an SSID seen offering WPA3-SAE from one BSSID and PSK-only (no SAE) from another — an evil twin stripping WPA3. Down-ranked to wpa3_mixed (info) when every BSSID shares one vendor OUI (benign mixed-mode deployment, not a clone).

Adds sev_rank entries, a UI render branch (+ cache-buster bump and panel text), and tests/test_wifi_defense_downgrade.py (5 cases).