### PR TITLE
wifi_defense: stop WPA3 downgrade false positives

### DIFF
--- a/tests/test_wifi_defense_downgrade.py
+++ b/tests/test_wifi_defense_downgrade.py
@@ -1,4 +1,8 @@
-"""WPA3 downgrade / transition-mode detection in wifi_defense.analyze()."""
+"""WPA3-strip downgrade detection in wifi_defense.analyze().
+
+Only a genuine evil-twin clone (a WPA3 SSID re-advertised PSK-only from a
+foreign/randomized BSSID) is flagged. Plain transition mode and same-vendor
+mixed-mode are configuration, not attacks, and must stay silent."""
 import os
 import sys
 
@@ -11,48 +15,60 @@ def _beacon(bssid, ssid, security):
     return {"kind": "beacon", "src": bssid, "ssid": ssid, "security": security}
 
 
-def _downgrade(res, sev=None):
+def _downgrade(res, sev="wpa3_strip"):
     return [d for d in res["detections"]
             if d["type"] == "wpa3_downgrade" and (sev is None or d["severity"] == sev)]
 
 
-def test_wpa3_strip_evil_twin_detected():
+def test_wpa3_strip_from_foreign_oui_detected():
     # Real WPA3 net on one vendor; a DIFFERENT-OUI BSSID clones it as WPA2-only.
     events = [_beacon("00:11:22:00:00:01", "CorpWiFi", "WPA3")] * 2 \
         + [_beacon("66:77:88:00:00:09", "CorpWiFi", "WPA2")] * 2
     res = wd.analyze(events)
-    strip = _downgrade(res, "wpa3_strip")
+    strip = _downgrade(res)
     assert strip, res["detections"]
     assert "66:77:88:00:00:09" in strip[0]["rogue_bssids"]
     assert res["threat"] == "critical"
 
 
-def test_transition_mode_is_informational():
+def test_wpa3_strip_from_randomized_bssid_detected():
+    # Evil twin re-advertising as WPA2 from a locally-administered (randomized) MAC.
+    events = [_beacon("00:11:22:00:00:01", "CorpWiFi", "WPA3"),
+              _beacon("02:00:00:00:00:09", "CorpWiFi", "WPA2")]
+    res = wd.analyze(events)
+    assert _downgrade(res)
+
+
+def test_transition_mode_not_flagged():
+    # WPA2/3 transition mode is the default on most routers — not an attack.
     res = wd.analyze([_beacon("aa:aa:aa:00:00:01", "HomeNet", "WPA2/3")] * 2)
-    trans = _downgrade(res, "wpa3_transition")
-    assert trans and trans[0]["bssid"] == "aa:aa:aa:00:00:01"
-    # Transition mode alone is not critical (config choice, not an attack).
+    assert not _downgrade(res, sev=None)
     assert res["threat"] != "critical"
-    # And a lone transition AP is NOT a strip.
-    assert not _downgrade(res, "wpa3_strip")
 
 
-def test_same_vendor_mixed_mode_not_flagged_critical():
-    # One vendor's gear: WPA3 SSID on one BSSID, a WPA2 SSID of the same name on
-    # a sibling BSSID sharing the OUI => mixed-mode, not an evil twin.
+def test_same_vendor_mixed_mode_not_flagged():
+    # One operator's gear: WPA3 on one radio, WPA2 SSID of the same name on a
+    # sibling BSSID sharing the OUI => band-steering, not a clone.
     events = [_beacon("00:11:22:00:00:01", "MyNet", "WPA3"),
               _beacon("00:11:22:00:00:02", "MyNet", "WPA2")]
     res = wd.analyze(events)
-    assert _downgrade(res, "wpa3_mixed")
-    assert not _downgrade(res, "wpa3_strip")
+    assert not _downgrade(res, sev=None)
+
+
+def test_trusted_baseline_psk_bssid_not_flagged():
+    # If both BSSIDs are trusted, a mixed-mode pairing is a known-good deployment.
+    events = [_beacon("00:11:22:00:00:01", "CorpWiFi", "WPA3"),
+              _beacon("66:77:88:00:00:09", "CorpWiFi", "WPA2")]
+    baseline = {"CorpWiFi": ["00:11:22:00:00:01", "66:77:88:00:00:09"]}
+    res = wd.analyze(events, baseline=baseline)
+    assert not _downgrade(res, sev=None)
 
 
 def test_clean_wpa3_only_no_downgrade():
-    res = wd.analyze([_beacon("aa:aa:aa:00:00:01", "SecureNet", "WPA3")] * 3)
-    assert not _downgrade(res)
+    res = wd.analyze([_beacon("00:11:22:00:00:01", "SecureNet", "WPA3")] * 3)
+    assert not _downgrade(res, sev=None)
 
 
 def test_plain_wpa2_network_not_flagged():
-    # No SAE ever advertised => nothing to strip, no finding.
-    res = wd.analyze([_beacon("aa:aa:aa:00:00:01", "OldNet", "WPA2")] * 3)
-    assert not _downgrade(res)
+    res = wd.analyze([_beacon("00:11:22:00:00:01", "OldNet", "WPA2")] * 3)
+    assert not _downgrade(res, sev=None)

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -2116,53 +2116,52 @@ def analyze(events, baseline=None, window_secs=None, thresholds=None):
                           "— possible evil-twin captive portal; probe it to confirm",
             })
 
-    # --- WPA3 downgrade / transition-mode exposure (ported from wifiwatch) ---
-    # Read straight from the advertised security suite (_classify_security):
-    #   * transition mode — one BSSID offering SAE + PSK together (WPA2/3). A
-    #     WPA3 client can be forced down to WPA2-PSK; informational (it's a config
-    #     choice a lot of routers ship with, not an attack).
-    #   * active downgrade / WPA3 strip — an SSID seen offering SAE (WPA3 or
-    #     WPA2/3) from one BSSID that ALSO appears PSK-only (no SAE) from another:
-    #     an evil twin stripping WPA3 to make the 4-way handshake crackable.
-    #     Critical — UNLESS every BSSID involved shares one vendor OUI, which is a
-    #     benign mixed-mode deployment (one AP running WPA3 + a WPA2 SSID), not a
-    #     clone; that is down-ranked to an informational note.
+    # --- WPA3-strip downgrade (evil twin re-advertising a WPA3 SSID as WPA2) ---
+    # Flags ONLY the attack: an SSID seen offering WPA3-SAE from a real/anchor
+    # BSSID that ALSO appears PSK-only (no SAE) from a DIFFERENT, foreign or
+    # randomized BSSID — an evil twin stripping WPA3 so the 4-way handshake
+    # cracks offline.
+    #
+    # Deliberately NOT flagged, because they are configuration, not attacks, and
+    # flagging them lit up every scan:
+    #   * plain transition mode (one BSSID offering SAE+PSK, "WPA2/3") — the
+    #     default a huge share of routers ship with; downgradeable by design.
+    #   * mixed-mode on ONE operator's gear — the same SSID as WPA3 on one radio
+    #     and WPA2 on another, when the WPA2 BSSID shares a vendor OUI with a
+    #     WPA3 one (band-steering) or is in the trusted baseline. Not a clone.
     _SAE_SECS = {"WPA3", "WPA2/3"}
     _PSK_ONLY_SECS = {"WPA", "WPA2", "WPA/WPA2"}
     sae_by_ssid, psk_by_ssid = {}, {}
-    _transition_seen = set()
     for e in beacons + presp:
         ssid, src, sec = e.get("ssid"), e.get("src"), e.get("security")
         if not ssid or not src or _is_blank_ssid(ssid):
             continue
-        if sec == "WPA2/3" and src not in _transition_seen:
-            _transition_seen.add(src)
-            detections.append({
-                "type": "wpa3_downgrade", "severity": "wpa3_transition",
-                "ssid": ssid, "bssid": src,
-                "detail": f"SSID '{ssid}' ({src}) advertises WPA3-SAE and "
-                          "WPA2-PSK together — downgradeable transition mode",
-            })
         if sec in _SAE_SECS:
             sae_by_ssid.setdefault(ssid, set()).add(src)
         elif sec in _PSK_ONLY_SECS:
             psk_by_ssid.setdefault(ssid, set()).add(src)
     for ssid in set(sae_by_ssid) & set(psk_by_ssid):
         sae_b = sae_by_ssid[ssid]
-        strippers = sorted(psk_by_ssid[ssid] - sae_b)
-        if not strippers:
+        sae_ouis = {_oui(b) for b in sae_b}
+        trusted = set(baseline.get(ssid, []))
+        rogue = []
+        for b in sorted(psk_by_ssid[ssid] - sae_b):
+            # Same-vendor second radio (shared global OUI) = band-steering, and a
+            # trusted-baseline BSSID = a known-good AP — neither is a clone.
+            if not _is_locally_administered(b) and _oui(b) in sae_ouis:
+                continue
+            if trusted and b in trusted:
+                continue
+            rogue.append(b)
+        if not rogue:
             continue
-        union = sae_b | psk_by_ssid[ssid]
-        if _is_band_steering(union):
-            sev, kind = "wpa3_mixed", "mixed-mode on one vendor's gear — not an evil twin"
-        else:
-            sev, kind = "wpa3_strip", "WPA3-strip downgrade / evil twin"
         detections.append({
-            "type": "wpa3_downgrade", "severity": sev, "ssid": ssid,
-            "rogue_bssids": strippers, "sae_bssids": sorted(sae_b),
+            "type": "wpa3_downgrade", "severity": "wpa3_strip", "ssid": ssid,
+            "rogue_bssids": rogue, "sae_bssids": sorted(sae_b),
             "detail": f"SSID '{ssid}' offers WPA3-SAE from "
-                      f"{', '.join(sorted(sae_b))} but PSK-only (no SAE) from "
-                      f"{', '.join(strippers)} — {kind}",
+                      f"{', '.join(sorted(sae_b))} but PSK-only (no SAE) from a "
+                      f"foreign/randomized BSSID {', '.join(rogue)} — WPA3-strip "
+                      "downgrade / evil twin",
         })
 
     # Access-point inventory (for the UI table + baseline building)


### PR DESCRIPTION
The panel lit up "downgrade" on normal networks: wpa3_transition fired on every WPA2/WPA3 transition-mode AP (the shipping default on most routers), and wpa3_mixed added more. Neither is an attack.

Now only wpa3_strip is emitted, and only for a genuine evil-twin clone: an SSID offering WPA3-SAE that also appears PSK-only from a DIFFERENT BSSID that is foreign-OUI or locally-administered (randomized) and not in the trusted baseline. Same-vendor band-steering (shared OUI) and trusted-baseline BSSIDs are skipped; plain transition mode is no longer surfaced at all. Tests updated to assert the quiet behavior plus the randomized-BSSID and trusted-baseline paths.