### PR TITLE
wifi_defense: deep scan opt-in + capture only EAPOL, not all data

### DIFF
--- a/web/index_modern.html
+++ b/web/index_modern.html
@@ -3110,7 +3110,7 @@
                     <button onclick="wifidefScan()" id="wifidef-scan-btn" class="bg-Ragnar-600 hover:bg-Ragnar-700 text-white px-4 py-2 rounded text-sm font-semibold">Scan</button>
                     <button onclick="wifidefStopContinuous()" id="wifidef-stop-btn" class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded text-sm font-semibold hidden">■ Stop</button>
                     <label class="flex items-center gap-2 text-xs text-gray-400 cursor-pointer select-none"><input type="checkbox" id="wifidef-auto" class="accent-Ragnar-600"> Continuous</label>
-                    <label class="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer select-none" title="Deep scan: also capture data frames and fold in wifiwatch's client/handshake-layer detectors — PMKID harvest, deauth-and-capture handshakes, and PNL leak. Heavier (captures all frames)."><input type="checkbox" id="wifidef-deep" class="accent-rose-500" checked> +handshake/PNL</label>
+                    <label class="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer select-none" title="Deep scan: also capture data frames and fold in wifiwatch's client/handshake-layer detectors — PMKID harvest, deauth-and-capture handshakes, and PNL leak. Heavier (captures all frames)."><input type="checkbox" id="wifidef-deep" class="accent-rose-500"> +handshake/PNL</label>
                     <label class="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer select-none" title="Each scan also sweeps 300-439 MHz off the RTL-SDR for replay/brute (adds ~20s, briefly uses the SDR). Manual scans only, not the continuous loop."><input type="checkbox" id="wifidef-hh-subghz" class="accent-fuchsia-500"> +SubGHz</label>
                     <label class="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer select-none" title="Headless background watch: keeps fusing Wi-Fi + BLE on a slow, Pi-friendly loop with no browser open, and alerts via Watchtower/Pushover. Survives restart. Needs monitor mode enabled."><input type="checkbox" id="wifidef-hh-watch" onchange="wifidefHaleHoundWatch(this.checked)" class="accent-emerald-500"> 24/7 watch</label>
                     <button onclick="wifidefTrust()" class="bg-slate-700 hover:bg-slate-600 text-gray-200 px-3 py-2 rounded text-sm whitespace-nowrap" title="Add the currently-visible APs to the trusted baseline (accumulates) for evil-twin detection. Run a few times / across bands to capture every BSSID of each SSID.">Trust current APs</button>
@@ -8485,7 +8485,7 @@
     <!-- JavaScript -->
     <script src="/web/scripts/skyview.js?v=20260822-mobile-opacity"></script>
     <script src="/web/scripts/skyview_vr.js?v=20260822-rich-info-panel"></script>
-    <script src="/web/scripts/ragnar_modern.js?v=20260908-wifiwatch-deep"></script>
+    <script src="/web/scripts/ragnar_modern.js?v=20260908-deep-optin"></script>
 
 
 

--- a/web/scripts/ragnar_modern.js
+++ b/web/scripts/ragnar_modern.js
@@ -4946,10 +4946,12 @@ function wifidefScan() {
     const prog = _wifidefProgress(st, parseInt(secs) || 15,
         (_wifidef.continuous ? 'Continuous — capturing' : 'Capturing') + (chParam !== 'auto' ? ' ch ' + chParam : ''));
     if (btn) btn.disabled = true;
-    // Deep scan (default on): also capture data frames + fold in wifiwatch's
+    // Deep scan (opt-in): also capture EAPOL frames + fold in wifiwatch's
     // client/handshake-layer detectors (PMKID, handshake-after-deauth, PNL leak).
+    // Off by default — it's heavier, so a normal scan stays light and the AP
+    // survey is never starved.
     const deepEl = document.getElementById('wifidef-deep');
-    const deep = deepEl ? (deepEl.checked ? 1 : 0) : 1;
+    const deep = deepEl && deepEl.checked ? 1 : 0;
     return fetch(`/api/wifidef/scan?interface=${encodeURIComponent(iface)}&seconds=${secs}&channel=${chParam}&deep=${deep}`,
         { signal: ctrl.signal })
         .then(r => r.json()).then(d => {

--- a/wifi_defense.py
+++ b/wifi_defense.py
@@ -1717,9 +1717,12 @@ def _capture(mon_iface, seconds, channel=None, watch=None):
                 stop.wait(0.35)
         threading.Thread(target=_hopper, daemon=True).start()
 
-    # Mgmt-only keeps the sniffer cheap; a deep scan (watch set) needs data
-    # frames (EAPOL) too, so it captures everything and lets wifiwatch sort it.
-    _flt = None if watch is not None else "type mgt"
+    # Mgmt-only keeps the sniffer cheap. A deep scan (watch set) also needs EAPOL
+    # (data) frames for the client/handshake detectors — but capturing ALL data
+    # frames saturates the callback on a Pi and starves beacon capture, so the AP
+    # survey comes back empty. Capture mgmt + EAPOL (ethertype 0x888e) only; if a
+    # driver rejects that BPF the except-retry below falls back to unfiltered.
+    _flt = "type mgt or ether proto 0x888e" if watch is not None else "type mgt"
     try:
         sniff(iface=mon_iface, prn=_cb, timeout=seconds, store=False,
               filter=_flt, monitor=True)


### PR DESCRIPTION
Two regressions from the deep-scan default:
- The "+handshake/PNL" deep scan was ON by default and captured ALL frames. On a busy network that saturated the sniff callback and starved beacon capture, so the AP survey came back empty ("won't do wifi survey"), and the heavy scan made the tab feel stuck (hard to untick the box).

Fixes:
- Deep is now OPT-IN (checkbox unchecked by default) — a normal scan stays light and the AP survey is never starved.
- When deep IS on, capture mgmt + EAPOL (ether proto 0x888e) only instead of all data frames, so beacons still come through; the existing except-retry falls back to unfiltered if a driver rejects the BPF.
- Cache-buster bump so the new JS loads.

Note: the Signal-Intelligence survey still (correctly) refuses on a radio that's in monitor mode — a single radio can't survey and monitor at once; survey on the other adapter (e.g. wlan0), which the error already suggests.