### PR TITLE
scorers: stop a duplicate-SSID swarm faking a HaleHound/PineAP verdict

### DIFF
--- a/halehound_watch.py
+++ b/halehound_watch.py
@@ -50,7 +50,11 @@ _WIFI_WEIGHTS = {
     ("rogue_ap", "esp32_open_ap"): 16,   # open AP on an Espressif radio (name-independent)
     ("rogue_ap", "evil_twin"): 20,
     ("rogue_ap", "spoofed_bssid"): 20,   # group/multicast-bit BSSID = spoofed AP
-    ("rogue_ap", "duplicate_ssid"): 8,
+    # NOTE: duplicate_ssid is intentionally NOT scored here. It's a low-confidence,
+    # baseline-less "same SSID on several BSSIDs" signal (mesh, repeaters, or a
+    # PineAP pool) — not an ESP32-multitool tell — and a swarm of them (e.g. a
+    # Pineapple SSID pool) otherwise maxed the wifi domain into a false "possible".
+    # It belongs to pineap_watch (the cross-BSSID pool metric).
     ("rogue_ap", "rogue_lure"): 6,       # open free-Wi-Fi lure name (low-confidence)
     ("karma", "karma"): 18,
     ("beacon_flood", "flood"): 14,
@@ -487,9 +491,15 @@ def score(signals):
     reasons = []
     domain_raw = {"wifi": 0, "lan": 0, "ble": 0, "portal": 0, "subghz": 0}
 
+    # Dedupe by (type, severity): a swarm of the same signal (a beacon flood's many
+    # spoofed BSSIDs, a pool's many duplicate SSIDs) is one phenomenon, not N — it
+    # must not stack the wifi domain to its cap on its own.
+    _wifi_seen = set()
     for det in signals.get("wifi", []) or []:
-        w = _WIFI_WEIGHTS.get((det.get("type"), det.get("severity")))
-        if w:
+        key = (det.get("type"), det.get("severity"))
+        w = _WIFI_WEIGHTS.get(key)
+        if w and key not in _wifi_seen:
+            _wifi_seen.add(key)
             domain_raw["wifi"] += w
             reasons.append({"domain": "wifi", "signal": det.get("type"),
                             "weight": w, "detail": det.get("detail", "")})

--- a/pineap_watch.py
+++ b/pineap_watch.py
@@ -160,9 +160,17 @@ def _rf_tells(detections):
     high-confidence ``pineapple_name`` tell, and a run of ``duplicate_ssid``
     detections becomes the cross-BSSID (randomized-pool) tell.
     """
-    tells = []
+    # Dedupe by tell key: a swarm of the SAME signal (e.g. dozens of duplicate
+    # SSIDs, or many spoofed BSSIDs from a beacon flood) is ONE phenomenon, not N
+    # independent tells — otherwise it stacks into a false verdict. First-seen
+    # detail wins.
+    tells = {}
     dup_ssids = set()          # for the cross-BSSID pool metric
     spoofed_present = False
+
+    def _add(key, w, detail):
+        if key not in tells:
+            tells[key] = (w, detail)
 
     for d in detections or []:
         dtype = d.get("type")
@@ -173,12 +181,10 @@ def _rf_tells(detections):
             if n < _POOL_MIN:
                 continue
             band = "pool_large" if n >= _POOL_LARGE else "pool_small"
-            w = _RF_WEIGHTS[("karma", band)]
-            tells.append(("karma:" + band, w,
-                          f"{d.get('bssid')} answered {n} distinct SSIDs — "
-                          + ("large PineAP-class pool (past any legit multi-SSID AP)"
-                             if band == "pool_large"
-                             else "KARMA/PineAP-class SSID pool")))
+            _add("karma:" + band, _RF_WEIGHTS[("karma", band)],
+                 f"{d.get('bssid')} answered {n} distinct SSIDs — "
+                 + ("large PineAP-class pool (past any legit multi-SSID AP)"
+                    if band == "pool_large" else "KARMA/PineAP-class SSID pool"))
             continue
 
         if dtype == "rogue_ap":
@@ -186,40 +192,48 @@ def _rf_tells(detections):
                 # Split the generic attack-tool name from the Pineapple-specific
                 # management SSID — the latter is a near-certain Hak5 tell.
                 if _norm_ssid(d.get("ssid")) in _PINEAPPLE_MGMT_SSIDS:
-                    tells.append(("rogue_ap:pineapple_name",
-                                  _RF_WEIGHTS[("rogue_ap", "pineapple_name")],
-                                  f"SSID '{d.get('ssid')}' is the Wi-Fi Pineapple's "
-                                  "default management AP name"))
+                    _add("rogue_ap:pineapple_name",
+                         _RF_WEIGHTS[("rogue_ap", "pineapple_name")],
+                         f"SSID '{d.get('ssid')}' is the Wi-Fi Pineapple's "
+                         "default management AP name")
                 else:
-                    tells.append(("rogue_ap:attack_tool_ssid",
-                                  _RF_WEIGHTS[("rogue_ap", "attack_tool_ssid")],
-                                  d.get("detail", "attack-tool SSID name")))
+                    _add("rogue_ap:attack_tool_ssid",
+                         _RF_WEIGHTS[("rogue_ap", "attack_tool_ssid")],
+                         d.get("detail", "attack-tool SSID name"))
                 continue
-            if sev == "duplicate_ssid" and d.get("ssid"):
-                dup_ssids.add(d.get("ssid"))
+            if sev == "duplicate_ssid":
+                # Collected for the pool metric below; NOT scored per detection
+                # (a pile of duplicate SSIDs must not stack — that was the swarm
+                # false positive).
+                if d.get("ssid"):
+                    dup_ssids.add(d.get("ssid"))
+                continue
             if sev == "spoofed_bssid":
                 spoofed_present = True
             w = _RF_WEIGHTS.get(("rogue_ap", sev))
             if w:
-                tells.append(("rogue_ap:" + sev, w, d.get("detail", "")))
+                _add("rogue_ap:" + sev, w, d.get("detail", ""))
             continue
 
         w = _RF_WEIGHTS.get((dtype, sev))
         if w:
-            tells.append((f"{dtype}:{sev}", w, d.get("detail", "")))
+            _add(f"{dtype}:{sev}", w, d.get("detail", ""))
 
-    # Derived: a cross-BSSID pool. Several distinct SSIDs each appearing under
-    # multiple BSSIDs is the shape of a randomized-MAC PineAP pool (Pager) that
-    # the single-BSSID karma test can't catch. Require a spoofed/LA BSSID too, so
-    # a couple of ordinary duplicate SSIDs (mesh a baseline hasn't cleared) don't
-    # trip it.
+    # Derived from the duplicate-SSID set: a cross-BSSID pool. Several distinct
+    # SSIDs each appearing under multiple BSSIDs is the shape of a randomized-MAC
+    # PineAP pool (Pager) that the single-BSSID karma test can't catch. Require a
+    # spoofed/LA BSSID too, so an ordinary messy-SSID environment (many duplicate
+    # SSIDs, no spoofed BSSID) is a single weak duplicate tell, not a pool.
     if len(dup_ssids) >= _XBSSID_POOL_MIN and spoofed_present:
-        tells.append(("rogue_ap:xbssid_pool",
-                      _RF_WEIGHTS[("rogue_ap", "xbssid_pool")],
-                      f"{len(dup_ssids)} SSIDs each advertised by multiple "
-                      "BSSIDs alongside a spoofed BSSID — randomized-MAC PineAP "
-                      "pool (Pager-style)"))
-    return tells
+        _add("rogue_ap:xbssid_pool", _RF_WEIGHTS[("rogue_ap", "xbssid_pool")],
+             f"{len(dup_ssids)} SSIDs each advertised by multiple BSSIDs "
+             "alongside a spoofed BSSID — randomized-MAC PineAP pool (Pager-style)")
+    elif dup_ssids:
+        _add("rogue_ap:duplicate_ssid", _RF_WEIGHTS[("rogue_ap", "duplicate_ssid")],
+             f"{len(dup_ssids)} SSID(s) advertised by multiple BSSIDs "
+             "(possible evil twin — set a baseline to confirm)")
+
+    return [(k, w, det) for k, (w, det) in tells.items()]
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_scorer_swarm_dedup.py
+++ b/tests/test_scorer_swarm_dedup.py
@@ -1,0 +1,52 @@
+"""A swarm of identical low-confidence rogue-AP detections (e.g. a Pineapple SSID
+pool: 'bloop21'..'bloop31' each on many BSSIDs) must not stack into a verdict."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import halehound_watch as hh          # noqa: E402
+import pineap_watch as pa             # noqa: E402
+
+
+def _dups(n, start=21):
+    return [{"type": "rogue_ap", "severity": "duplicate_ssid", "ssid": "bloop%d" % i}
+            for i in range(start, start + n)]
+
+
+def test_halehound_duplicate_ssid_not_scored():
+    # duplicate_ssid is not an ESP32-multitool tell — contributes nothing.
+    assert hh.score({"wifi": _dups(20)})["verdict"] == "none"
+
+
+def test_halehound_pool_swarm_plus_stray_deauth_not_possible():
+    v = hh.score({"wifi": _dups(10) + [{"type": "deauth", "severity": "seen"}]})
+    assert v["verdict"] in ("none", "trace") and v["score"] < 25
+
+
+def test_halehound_wifi_signals_deduped_by_severity():
+    # Ten spoofed BSSIDs (a beacon-flood shape) count once, not ten times.
+    ten = [{"type": "rogue_ap", "severity": "spoofed_bssid", "bssid": "02:0:0:0:0:%d" % i}
+           for i in range(10)]
+    v = hh.score({"wifi": ten})
+    assert v["domain_scores"]["wifi"] == 20   # one spoofed_bssid weight, not 200
+
+
+def test_pineap_duplicate_swarm_without_spoof_stays_low():
+    v = pa.score({"rf": _dups(10)})
+    assert "rogue_ap:xbssid_pool" not in v["signals"]
+    assert v["score"] < 25
+
+
+def test_pineap_swarm_with_spoof_is_xbssid_pool():
+    rf = _dups(5) + [{"type": "rogue_ap", "severity": "spoofed_bssid",
+                      "ssid": "bloop21", "bssid": "02:00:00:00:00:01"}]
+    assert "rogue_ap:xbssid_pool" in pa.score({"rf": rf})["signals"]
+
+
+def test_pineap_messy_env_below_incident_threshold():
+    # Dozens of duplicate SSIDs + one evil twin + a stray deauth (no spoofed BSSID)
+    # stays under the >=50 Watchtower-incident threshold.
+    rf = _dups(30) + [{"type": "rogue_ap", "severity": "evil_twin", "ssid": "X"},
+                      {"type": "deauth", "severity": "seen"}]
+    assert pa.score({"rf": rf})["score"] < 50


### PR DESCRIPTION
A Pineapple-style SSID pool (bloop21..bloop31, each on 9-11 BSSIDs) produced a swarm of low-confidence duplicate_ssid detections that stacked into a false "POSSIBLE 45%" HaleHound ESP32-attack-tool verdict.

- halehound_watch: dedupe wifi signals by (type, severity) so a swarm counts once, and drop duplicate_ssid entirely (it's a mesh/PineAP signal, not an ESP32-multitool tell). The reported scan now scores 'trace' (23), below alert.
- pineap_watch: dedupe tells by key and score duplicate_ssid ONCE (feeding the cross-BSSID pool metric) instead of per-detection, so a messy-SSID environment no longer stacks. A real randomized pool (>=4 duplicates + a spoofed BSSID) still fires xbssid_pool; a swarm without a spoofed BSSID stays a weak single tell (well under the >=50 incident threshold).

Adds tests/test_scorer_swarm_dedup.py.