### PR TITLE
Fix epd2in13b_V4 (tri-color) e-Paper display not working (#585)

### DIFF
--- a/resources/waveshare_epd/epd2in13b_V4.py
+++ b/resources/waveshare_epd/epd2in13b_V4.py
@@ -163,12 +163,21 @@ class EPD:
 
     # display image
     def display(self, imageblack, imagered=None):
-        self.send_command(0x24)
-        self.send_data2(imagered)
+        # 0x24 = B/W RAM, 0x26 = RED RAM. Ragnar renders a single 1-bit image
+        # and calls display(buffer) with no red plane, so send imageblack to the
+        # B/W RAM and a blank (white) red plane — otherwise the black content is
+        # never written and the panel shows stale/garbage red RAM.
+        if self.width % 8 == 0:
+            linewidth = int(self.width / 8)
+        else:
+            linewidth = int(self.width / 8) + 1
+        blank = [0xff] * int(self.height * linewidth)
 
-        if not None==imagered:
-            self.send_command(0x26)
-            self.send_data2(imageblack)
+        self.send_command(0x24)
+        self.send_data2(imageblack)
+
+        self.send_command(0x26)
+        self.send_data2(imagered if imagered is not None else blank)
 
         self.ondisplay()
 


### PR DESCRIPTION
The vendored 2.13" V4 tri-color driver never loaded at runtime and, even once loaded, never wrote the image to the panel. Two bugs:

1. The driver file was committed as resources/waveshare_epd/epd2in13b_V4 with NO .py extension, so importlib could not import resources.waveshare_epd.epd2in13b_V4. EPDHelper(epd_type) raised, shared.py logged "Configured EPD driver failed to load, switching to auto-detect", and auto-detect (whose KNOWN_EPD_TYPES has no tri-color variant) fell back to the mono epd2in13_V4 — silently rewriting epd_type in the config. Renamed the file to epd2in13b_V4.py so the configured driver loads.

2. EPD.display() sent imagered (None on Ragnars single-buffer calls) to the B/W RAM (0x24) and only wrote imageblack to the RED RAM (0x26) when a red image was passed — so the actual black content was never sent and None hit the wire. Fixed to send imageblack to 0x24 and a blank (white) red plane to 0x26 when no red image is supplied.

Result: a fresh clone with epd_type=epd2in13b_V4 loads the correct driver and renders Ragnar in black/white on the tri-color panel (red plane left blank).