### PR TITLE
feat(rf-waterfall): selectable waterfall colour palettes (Aurora defa…

### DIFF
--- a/demos/rf_waterfall.html
+++ b/demos/rf_waterfall.html
@@ -182,6 +182,10 @@
         <button data-hz="24" aria-pressed="false">Fast</button>
       </div>
     </div>
+    <div class="grp">
+      <span class="lbl">Palette</span>
+      <div class="seg" id="palette" role="group" aria-label="Waterfall colour palette"></div>
+    </div>
     <div class="spacer"></div>
     <div class="legend"><span>&minus;110&nbsp;dBm</span><span class="grad" aria-hidden="true"></span><span>&minus;20&nbsp;dBm</span></div>
     <span class="clock" id="clock">--:--:--</span>
@@ -212,16 +216,46 @@
 <script>
 (function(){
   "use strict";
-  // Aurora colormap — cool, no warm tones: navy→blue→teal→periwinkle→lavender.
-  // Kinder on the eyes than the old amber/white hot end; strong bursts glow soft
-  // violet instead of glaring yellow.
-  var STOPS=[[0.00,[7,26,44]],[0.28,[22,90,130]],[0.52,[46,160,150]],[0.78,[123,140,210]],[1.00,[206,196,230]]];
-  var CEIL=-20, LUT=new Array(256);
-  (function(){for(var i=0;i<256;i++){var t=i/255,a=STOPS[0],b=STOPS[STOPS.length-1];
-    for(var s=0;s<STOPS.length-1;s++){if(t>=STOPS[s][0]&&t<=STOPS[s+1][0]){a=STOPS[s];b=STOPS[s+1];break;}}
-    var f=(t-a[0])/((b[0]-a[0])||1);
-    LUT[i]="rgb("+Math.round(a[1][0]+(b[1][0]-a[1][0])*f)+","+Math.round(a[1][1]+(b[1][1]-a[1][1])*f)+","+Math.round(a[1][2]+(b[1][2]-a[1][2])*f)+")";}})();
+  // Waterfall colour palettes. Each is a list of [position 0..1, [r,g,b]] stops
+  // interpolated into a 256-entry LUT. Add one by dropping an entry in PALETTES +
+  // PALETTE_ORDER — the selector builds itself from these. Aurora is the default
+  // (cool, no warm tones: navy→blue→teal→periwinkle→lavender — kind on the eyes,
+  // strong bursts glow soft violet instead of glaring yellow).
+  var PALETTES={
+    aurora:{name:'Aurora', stops:[[0.00,[7,26,44]],[0.28,[22,90,130]],[0.52,[46,160,150]],[0.78,[123,140,210]],[1.00,[206,196,230]]]},
+    // Inferno — the classic "hot" SDR waterfall: black→purple→red→orange→pale.
+    inferno:{name:'Inferno', stops:[[0.00,[4,3,18]],[0.25,[87,16,110]],[0.50,[188,55,84]],[0.75,[249,142,9]],[1.00,[252,255,164]]]},
+    // Viridis — perceptually-uniform, colour-blind friendly: purple→teal→green→yellow.
+    viridis:{name:'Viridis', stops:[[0.00,[68,1,84]],[0.25,[59,82,139]],[0.50,[33,145,140]],[0.75,[94,201,98]],[1.00,[253,231,37]]]},
+    // Classic — the traditional SDR#/GQRX rainbow: black→blue→cyan→green→yellow→red.
+    classic:{name:'Classic', stops:[[0.00,[0,0,12]],[0.20,[0,40,150]],[0.40,[0,180,200]],[0.60,[40,200,70]],[0.80,[240,220,40]],[1.00,[230,40,30]]]},
+    // Mono — clean grayscale, no hue: near-black→white.
+    mono:{name:'Mono', stops:[[0.00,[6,8,12]],[0.50,[120,124,132]],[1.00,[240,242,246]]]}
+  };
+  var PALETTE_ORDER=['aurora','inferno','viridis','classic','mono'];
+  var CEIL=-20;
+  function buildLUT(stops){var lut=new Array(256);
+    for(var i=0;i<256;i++){var t=i/255,a=stops[0],b=stops[stops.length-1];
+      for(var s=0;s<stops.length-1;s++){if(t>=stops[s][0]&&t<=stops[s+1][0]){a=stops[s];b=stops[s+1];break;}}
+      var f=(t-a[0])/((b[0]-a[0])||1);
+      lut[i]="rgb("+Math.round(a[1][0]+(b[1][0]-a[1][0])*f)+","+Math.round(a[1][1]+(b[1][1]-a[1][1])*f)+","+Math.round(a[1][2]+(b[1][2]-a[1][2])*f)+")";}
+    return lut;}
+  function gradCss(stops){return "linear-gradient(90deg,"+stops.map(function(s){
+    return "rgb("+s[1][0]+","+s[1][1]+","+s[1][2]+") "+Math.round(s[0]*100)+"%";}).join(",")+")";}
+  // Active palette — remembered per-browser, defaults to Aurora.
+  var activePalette='aurora';
+  try{var _sp=localStorage.getItem('ragnar_rf_palette'); if(_sp&&PALETTES[_sp]) activePalette=_sp;}catch(e){}
+  var LUT=buildLUT(PALETTES[activePalette].stops);
   function color(db,floor){var t=(db-floor)/(CEIL-floor);if(t<0)t=0;if(t>1)t=1;return LUT[(t*255)|0];}
+  function setPalette(id){
+    if(!PALETTES[id]) return;
+    activePalette=id; LUT=buildLUT(PALETTES[id].stops);
+    var g=document.querySelector('.legend .grad'); if(g) g.style.background=gradCss(PALETTES[id].stops);
+    var seg=document.getElementById('palette');
+    if(seg) Array.prototype.forEach.call(seg.querySelectorAll('button'),function(x){
+      x.setAttribute('aria-pressed', x.getAttribute('data-pal')===id?'true':'false');});
+    try{localStorage.setItem('ragnar_rf_palette',id);}catch(e){}
+  }
 
   var NSYN=512;
   function gauss(){return (Math.random()+Math.random()+Math.random()-1.5)*0.9;}
@@ -955,6 +989,17 @@
     HZ=parseFloat(b.getAttribute('data-hz'));
     speedSeg.querySelectorAll('button').forEach(function(x){x.setAttribute('aria-pressed','false');});
     b.setAttribute('aria-pressed','true'); scopes.forEach(function(s){s.setRate(running?HZ:0);}); });
+
+  // Palette selector — built from PALETTES/PALETTE_ORDER (Aurora default). Switching
+  // recolours new rows going forward and repaints the legend; the saved choice is
+  // restored on load. Old rows already on the canvas keep their colours until they
+  // scroll off (the page paints incrementally and keeps no per-row dB history).
+  var palSeg=document.getElementById('palette');
+  palSeg.innerHTML=PALETTE_ORDER.map(function(id){
+    return '<button data-pal="'+id+'" aria-pressed="'+(id===activePalette?'true':'false')+'" title="'+PALETTES[id].name+' colour map">'+PALETTES[id].name+'</button>';
+  }).join('');
+  palSeg.addEventListener('click',function(e){var b=e.target.closest('button');if(!b)return; setPalette(b.getAttribute('data-pal')); });
+  setPalette(activePalette);   // sync legend gradient + pressed state to the saved choice
 
   var acc=0,last=performance.now();
   function loop(now){ if(!running)return; var dt=(now-last)/1000;last=now;acc+=dt;var interval=1/HZ,did=0;

--- a/docs/rf-waterfall.md
+++ b/docs/rf-waterfall.md
@@ -84,6 +84,19 @@ the scroll-speed setting.
 Both engines emit the same frame shape, feed the same ring buffer, recorder and
 `/api/net/rtl/power/frames`, so nothing else on the page changes.
 
+## Colour palettes
+
+The top toolbar has a **Palette** selector for the waterfall colour map. Five are
+built in — **Aurora** (default: cool navy→teal→lavender), **Inferno** (hot
+black→red→orange), **Viridis** (perceptually-uniform, colour-blind friendly),
+**Classic** (the traditional SDR#/GQRX blue→green→red rainbow) and **Mono**
+(grayscale). The choice is remembered per-browser (`localStorage`
+`ragnar_rf_palette`) and the legend gradient tracks it. Switching recolours new
+rows going forward and applies to both panels; rows already painted keep their
+colours until they scroll off (the page paints incrementally and keeps no
+per-row dB history). Add one by dropping an entry into `PALETTES` +
+`PALETTE_ORDER` in the page — the selector builds itself from that list.
+
 ## The button and the toggle (WiFi Spectrum Analyzer)
 
 - **"RF Waterfall page" button** — appears in the analyzer's controls once a


### PR DESCRIPTION
Add a Palette selector to the RF Waterfall toolbar so the waterfall colour map can be switched between five built-ins: Aurora (the existing cool navy→lavender map, kept as the default), Inferno (hot), Viridis (perceptually-uniform / colour-blind friendly), Classic (the traditional SDR#/GQRX rainbow) and Mono (grayscale).

- The single hard-coded Aurora colormap is now a PALETTES table + PALETTE_ORDER; buildLUT()/gradCss() are palette-agnostic and the selector builds itself from the list, so adding a palette is one table entry.
- Choice persists per-browser (localStorage `ragnar_rf_palette`); the legend gradient tracks the active palette; switching applies to both panels and recolours new rows going forward.
- docs/rf-waterfall.md documents the selector.


Claude-Session: https://claude.ai/code/session_01W6xu9VgzpeEi3axooS3WrM