### PR TITLE
Feature/sigmf analyzer

### DIFF
--- a/demos/rf_analyzer.html
+++ b/demos/rf_analyzer.html
@@ -1,0 +1,330 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Signal Analyzer — Ragnar</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@600;700&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap">
+<style>
+  :root{--ground:#0a0e14;--panel:#111722;--panel-2:#0d1420;--ink:#cdd6e4;--ink-dim:#8b98ab;
+    --muted:#6b7a8f;--line:#1e2836;--line-soft:#161f2c;--accent:#f5b942;--cyan:#38bdc9;--live:#3fb56b;--rose:#fb7185;
+    --mono:"IBM Plex Mono",ui-monospace,monospace;--disp:"IBM Plex Sans",system-ui,sans-serif;--head:"Chakra Petch",var(--disp);}
+  *{box-sizing:border-box}html,body{margin:0}
+  body{background:var(--ground);color:var(--ink);font-family:var(--disp);line-height:1.5;padding:clamp(12px,2.5vw,28px);
+    -webkit-font-smoothing:antialiased;min-height:100vh}
+  .wrap{max-width:1500px;margin:0 auto;overflow-x:hidden}
+  header{display:flex;flex-wrap:wrap;align-items:flex-end;gap:12px 20px;border-bottom:1px solid var(--line);padding-bottom:14px;margin-bottom:16px}
+  .eyebrow{font-family:var(--mono);font-size:11px;letter-spacing:.28em;text-transform:uppercase;color:var(--cyan);margin:0 0 6px}
+  h1{font-family:var(--head);font-weight:700;font-size:clamp(24px,4vw,36px);margin:0}
+  .spacer{flex:1 1 auto}
+  a.back{font-family:var(--head);font-weight:600;font-size:13px;color:var(--cyan);text-decoration:none;border:1px solid rgba(56,189,201,.4);
+    padding:8px 13px;border-radius:7px}
+  a.back:hover{background:rgba(56,189,201,.1);color:#fff}
+  .bar{display:flex;flex-wrap:wrap;align-items:center;gap:8px 14px;margin-bottom:16px;padding:10px 14px;background:var(--panel-2);border:1px solid var(--line);border-radius:10px}
+  .lbl{font-family:var(--mono);font-size:10.5px;letter-spacing:.14em;text-transform:uppercase;color:var(--muted)}
+  select,button,input{font-family:var(--mono);font-size:12px;color:var(--ink);background:var(--panel);border:1px solid var(--line);border-radius:7px;padding:8px 11px}
+  button{cursor:pointer;transition:border-color .15s,color .15s,background .15s}
+  button:hover{border-color:var(--cyan);color:#fff}
+  button[aria-pressed="true"]{border-color:var(--cyan);color:var(--cyan);background:rgba(56,189,201,.12)}
+  button.go{background:var(--cyan);color:var(--ground);border-color:var(--cyan);font-weight:600}
+  .seg{display:inline-flex;flex-wrap:wrap;border:1px solid var(--line);border-radius:7px;overflow:hidden}
+  .seg button{border:0;border-radius:0;background:transparent}
+  .seg button[aria-pressed="true"]{background:rgba(56,189,201,.14);color:var(--cyan)}
+  .stats{display:flex;flex-wrap:wrap;gap:14px 20px;margin-bottom:16px}
+  .stat{display:flex;flex-direction:column;gap:1px;min-width:70px}
+  .stat .k{font-family:var(--mono);font-size:9.5px;letter-spacing:.13em;text-transform:uppercase;color:var(--muted)}
+  .stat .v{font-family:var(--mono);font-size:15px;font-weight:600;color:var(--ink);font-variant-numeric:tabular-nums}
+  .stat .v.cy{color:var(--cyan)} .stat .v.pk{color:var(--accent)}
+  .grid{display:grid;grid-template-columns:2fr 1fr;gap:16px;align-items:start}
+  @media (max-width:900px){.grid{grid-template-columns:1fr}}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:10px;overflow:hidden}
+  .card h3{font-family:var(--head);font-weight:600;font-size:13px;margin:0;padding:10px 14px;border-bottom:1px solid var(--line-soft);
+    background:var(--panel-2);display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+  .card h3 .hint{font-family:var(--mono);font-size:10.5px;color:var(--muted);font-weight:400}
+  .specwrap{position:relative;background:#05080d}
+  canvas.spec{display:block;width:100%;height:auto;cursor:crosshair}
+  .selbox{position:absolute;border:1px solid var(--accent);background:rgba(245,185,66,.12);pointer-events:none;display:none}
+  .rowcanvas{display:block;width:100%;height:120px;background:var(--panel-2)}
+  .legend{display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:10px;color:var(--muted);margin-left:auto}
+  .legend .grad{width:110px;height:9px;border-radius:3px}
+  .btable{width:100%;border-collapse:collapse;font-family:var(--mono);font-size:12px}
+  .btable th{text-align:left;color:var(--muted);font-weight:500;font-size:9.5px;letter-spacing:.1em;text-transform:uppercase;padding:8px 10px;border-bottom:1px solid var(--line-soft)}
+  .btable td{padding:7px 10px;border-bottom:1px solid var(--line-soft);color:var(--ink)}
+  .btable tr{cursor:pointer} .btable tr:hover td{background:rgba(56,189,201,.07)}
+  .btable .empty{color:var(--muted);padding:14px 10px}
+  .demodbar{display:flex;flex-wrap:wrap;align-items:center;gap:8px 12px;padding:10px 14px;border-bottom:1px solid var(--line-soft)}
+  .demodbar input{width:86px}
+  .bits{font-family:var(--mono);font-size:12px;color:var(--live);word-break:break-all;line-height:1.7;padding:10px 14px;background:var(--panel-2);
+    border-top:1px solid var(--line-soft);max-height:150px;overflow:auto;white-space:pre-wrap}
+  .msg{font-family:var(--mono);font-size:12px;color:var(--muted);padding:12px 14px}
+  .axinfo{font-family:var(--mono);font-size:10.5px;color:var(--ink-dim);padding:6px 14px;border-top:1px solid var(--line-soft)}
+  .axinfo b{color:var(--accent)}
+  footer{margin-top:20px;padding-top:14px;border-top:1px solid var(--line);font-family:var(--mono);font-size:11px;color:var(--muted);line-height:1.7}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div>
+      <p class="eyebrow">Ragnar · Signal Intelligence</p>
+      <h1>Signal Analyzer</h1>
+    </div>
+    <div class="spacer"></div>
+    <a class="back" href="/rf-waterfall">&#8592;&nbsp;RF Waterfall</a>
+  </header>
+
+  <div class="bar">
+    <span class="lbl">Capture</span>
+    <select id="cap"><option value="">— loading… —</option></select>
+    <button id="reload" title="Refresh the capture list">&#8635;</button>
+    <span class="lbl">Palette</span>
+    <div class="seg" id="palette"></div>
+    <span class="spacer"></span>
+    <button id="reset" title="Reset zoom to the whole capture">Reset zoom</button>
+  </div>
+
+  <div class="stats" id="stats"></div>
+
+  <div class="grid">
+    <div>
+      <div class="card">
+        <h3>Spectrogram <span class="hint">drag a box to zoom · click to place a marker</span>
+          <span class="legend"><span id="lfloor">—</span><span class="grad" id="grad"></span><span id="lceil">—</span></span>
+        </h3>
+        <div class="specwrap">
+          <canvas class="spec" id="spec"></canvas>
+          <div class="selbox" id="selbox"></div>
+        </div>
+        <div class="axinfo" id="axinfo">—</div>
+      </div>
+      <div class="card" style="margin-top:16px">
+        <h3>Time envelope <span class="hint">amplitude over the shown window (AM/OOK view)</span></h3>
+        <canvas class="rowcanvas" id="env"></canvas>
+      </div>
+    </div>
+
+    <div>
+      <div class="card">
+        <h3>Spectrum <span class="hint">avg power over the window</span></h3>
+        <canvas class="rowcanvas" id="psd"></canvas>
+      </div>
+      <div class="card" style="margin-top:16px">
+        <h3>Bursts / packets <span class="hint" id="bcount"></span></h3>
+        <div style="max-height:220px;overflow:auto">
+          <table class="btable"><thead><tr><th>t (s)</th><th>dur</th><th>freq</th><th>BW</th><th>dB</th></tr></thead>
+            <tbody id="btbody"><tr><td class="empty" colspan="5">—</td></tr></tbody></table>
+        </div>
+      </div>
+      <div class="card" style="margin-top:16px">
+        <h3>Demodulate <span class="hint">recover bits from the marked signal</span></h3>
+        <div class="demodbar">
+          <div class="seg" id="mode">
+            <button data-m="ook" aria-pressed="true">OOK/AM</button>
+            <button data-m="fsk">FSK/FM</button>
+          </div>
+          <span class="lbl">BW kHz</span><input id="bw" type="number" value="60" step="any">
+          <button class="go" id="run">Demodulate</button>
+        </div>
+        <canvas class="rowcanvas" id="wave" style="height:90px"></canvas>
+        <div class="bits" id="bits">Place a marker on a signal (or click a burst), then Demodulate.</div>
+      </div>
+    </div>
+  </div>
+
+  <footer>
+    On-box analysis of the RF Waterfall's SigMF captures (<code>data/iq_captures/</code>). DSP runs in numpy/scipy on the
+    device; this page is a viewer, so it works from a phone. For deep work, download the <code>.sigmf-data</code> and open it in
+    GNU Radio / inspectrum / URH.
+  </footer>
+</div>
+
+<script>
+(function(){
+  "use strict";
+  // ---- palettes (shared look with the waterfall) ----
+  var PALETTES={
+    aurora:{name:'Aurora',stops:[[0,[7,26,44]],[.28,[22,90,130]],[.52,[46,160,150]],[.78,[123,140,210]],[1,[206,196,230]]]},
+    inferno:{name:'Inferno',stops:[[0,[4,3,18]],[.25,[87,16,110]],[.5,[188,55,84]],[.75,[249,142,9]],[1,[252,255,164]]]},
+    viridis:{name:'Viridis',stops:[[0,[68,1,84]],[.25,[59,82,139]],[.5,[33,145,140]],[.75,[94,201,98]],[1,[253,231,37]]]},
+    classic:{name:'Classic',stops:[[0,[0,0,12]],[.2,[0,40,150]],[.4,[0,180,200]],[.6,[40,200,70]],[.8,[240,220,40]],[1,[230,40,30]]]},
+    mono:{name:'Mono',stops:[[0,[6,8,12]],[.5,[120,124,132]],[1,[240,242,246]]]}
+  };
+  var ORDER=['aurora','inferno','viridis','classic','mono'];
+  function buildLUT(stops){var lut=new Uint8Array(256*3);
+    for(var i=0;i<256;i++){var t=i/255,a=stops[0],b=stops[stops.length-1];
+      for(var s=0;s<stops.length-1;s++){if(t>=stops[s][0]&&t<=stops[s+1][0]){a=stops[s];b=stops[s+1];break;}}
+      var f=(t-a[0])/((b[0]-a[0])||1);
+      lut[i*3]=a[1][0]+(b[1][0]-a[1][0])*f;lut[i*3+1]=a[1][1]+(b[1][1]-a[1][1])*f;lut[i*3+2]=a[1][2]+(b[1][2]-a[1][2])*f;}
+    return lut;}
+  function gradCss(stops){return "linear-gradient(90deg,"+stops.map(function(s){return "rgb("+s[1].join(",")+") "+Math.round(s[0]*100)+"%";}).join(",")+")";}
+  var pal='aurora'; try{var sp=localStorage.getItem('ragnar_rf_palette'); if(sp&&PALETTES[sp])pal=sp;}catch(e){}
+  var LUT=buildLUT(PALETTES[pal].stops);
+
+  var $=function(id){return document.getElementById(id);};
+  var S={name:null, view:null, spec:null, marker:null, dur:0, fs:0, fc:0};
+
+  function api(path,params){var q=Object.keys(params||{}).filter(function(k){return params[k]!=null;})
+      .map(function(k){return k+'='+encodeURIComponent(params[k]);}).join('&');
+    return fetch(path+(q?'?'+q:'')).then(function(r){return r.json();});}
+  function fmtHz(hz){var a=Math.abs(hz); if(a>=1e6)return (hz/1e6).toFixed(3)+' MHz'; if(a>=1e3)return (hz/1e3).toFixed(1)+' kHz'; return Math.round(hz)+' Hz';}
+
+  // ---- palette selector ----
+  (function(){var seg=$('palette');
+    seg.innerHTML=ORDER.map(function(id){return '<button data-p="'+id+'" aria-pressed="'+(id===pal?'true':'false')+'">'+PALETTES[id].name+'</button>';}).join('');
+    seg.addEventListener('click',function(e){var b=e.target.closest('button');if(!b)return;
+      pal=b.getAttribute('data-p'); LUT=buildLUT(PALETTES[pal].stops);
+      try{localStorage.setItem('ragnar_rf_palette',pal);}catch(x){}
+      Array.prototype.forEach.call(seg.querySelectorAll('button'),function(x){x.setAttribute('aria-pressed',x.getAttribute('data-p')===pal?'true':'false');});
+      $('grad').style.background=gradCss(PALETTES[pal].stops); if(S.spec)drawSpec(S.spec);});
+    $('grad').style.background=gradCss(PALETTES[pal].stops);
+  })();
+
+  // ---- capture list ----
+  function loadList(sel){return api('/api/net/rtl/analyze/list',{}).then(function(d){
+    var caps=(d&&d.captures)||[], el=$('cap');
+    if(!caps.length){ el.innerHTML='<option value="">— no captures yet — grab one with ⤓ SigMF —</option>'; return; }
+    el.innerHTML=caps.map(function(c){var mb=(c.bytes/1e6).toFixed(1), du=c.duration_s?c.duration_s+'s':'';
+      return '<option value="'+encodeURIComponent(c.name)+'">'+c.name+'  ('+mb+' MB '+du+')</option>';}).join('');
+    var want=sel||caps[0].name; el.value=encodeURIComponent(want); loadCapture(want);
+  });}
+
+  function loadCapture(name){
+    S.name=name; S.view=null; S.marker=null;
+    api('/api/net/rtl/analyze/summary',{name:name}).then(function(s){
+      if(!s||!s.ok){ $('stats').innerHTML='<span class="msg">⚠ '+((s&&s.error)||'load failed')+'</span>'; return; }
+      S.dur=s.duration_s; S.fs=s.sr_hz; S.fc=s.center_hz;
+      $('stats').innerHTML=[
+        ['Center',(s.center_hz/1e6).toFixed(3)+' MHz','cy'],
+        ['Sample rate',(s.sr_hz/1e6).toFixed(3)+' MS/s',''],
+        ['Duration',s.duration_s+' s',''],
+        ['Peak',(s.peak_hz/1e6).toFixed(4)+' MHz','pk'],
+        ['SNR',Math.round(s.snr_db)+' dB','cy'],
+        ['Noise',Math.round(s.noise_db)+' dB',''],
+        ['Occupied BW',fmtHz(s.occupied_bw_hz),''],
+        ['Bursts',s.bursts,'']
+      ].map(function(x){return '<div class="stat"><span class="k">'+x[0]+'</span><span class="v '+x[2]+'">'+x[1]+'</span></div>';}).join('');
+      S.view={t0:0,t1:S.dur,f0:S.fc-S.fs/2,f1:S.fc+S.fs/2};
+      refreshWindow(); loadBursts();
+    });
+  }
+
+  // ---- spectrogram ----
+  function refreshWindow(){
+    var v=S.view, c=$('spec'), W=Math.max(320,Math.round(c.clientWidth||900));
+    api('/api/net/rtl/analyze/spectrogram',{name:S.name,t0:v.t0,t1:v.t1,f0:v.f0,f1:v.f1,w:W,h:360}).then(function(d){
+      if(!d||!d.ok)return; S.spec=d; drawSpec(d); });
+    api('/api/net/rtl/analyze/psd',{name:S.name,t0:v.t0,t1:v.t1}).then(drawPsd);
+    api('/api/net/rtl/analyze/envelope',{name:S.name,t0:v.t0,t1:v.t1}).then(drawEnv);
+  }
+  var PAD={l:52,r:10,t:8,b:20};
+  function drawSpec(d){
+    var c=$('spec'),dpr=Math.min(window.devicePixelRatio||1,2);
+    var Wc=Math.max(320,Math.round(c.clientWidth||900)), Hc=420;
+    c.width=Wc*dpr; c.height=Hc*dpr; c.style.height=Hc+'px';
+    var g=c.getContext('2d'); g.setTransform(dpr,0,0,dpr,0,0); g.clearRect(0,0,Wc,Hc);
+    var plotW=Wc-PAD.l-PAD.r, plotH=Hc-PAD.t-PAD.b;
+    // decode base64 grid -> offscreen image, then scale into the plot
+    var bin=atob(d.data), n=bin.length, buf=new Uint8Array(n); for(var i=0;i<n;i++)buf[i]=bin.charCodeAt(i);
+    var off=document.createElement('canvas'); off.width=d.w; off.height=d.h;
+    var octx=off.getContext('2d'), img=octx.createImageData(d.w,d.h), px=img.data;
+    for(var k=0;k<d.w*d.h;k++){var val=buf[k];px[k*4]=LUT[val*3];px[k*4+1]=LUT[val*3+1];px[k*4+2]=LUT[val*3+2];px[k*4+3]=255;}
+    octx.putImageData(img,0,0);
+    g.imageSmoothingEnabled=false;
+    g.drawImage(off,0,0,d.w,d.h,PAD.l,PAD.t,plotW,plotH);
+    // axes
+    g.fillStyle='#64748b';g.font='9px monospace';
+    g.textAlign='right';g.textBaseline='middle';
+    for(var yf=0;yf<=4;yf++){var fy=PAD.t+plotH*yf/4, fv=d.f1-(d.f1-d.f0)*yf/4;
+      g.fillText((fv/1e6).toFixed(3),PAD.l-4,fy);
+      g.strokeStyle='rgba(255,255,255,0.05)';g.beginPath();g.moveTo(PAD.l,fy);g.lineTo(PAD.l+plotW,fy);g.stroke();}
+    g.textAlign='center';g.textBaseline='top';
+    for(var xt=0;xt<=5;xt++){var tx=PAD.l+plotW*xt/5, tv=d.t0+(d.t1-d.t0)*xt/5;
+      g.fillText(tv.toFixed(3)+'s',tx,PAD.t+plotH+4);}
+    S._geom={plotW:plotW,plotH:plotH};
+    // marker
+    if(S.marker){var mx=PAD.l+(S.marker.t-d.t0)/(d.t1-d.t0)*plotW, my=PAD.t+(d.f1-S.marker.f)/(d.f1-d.f0)*plotH;
+      g.strokeStyle=getComputedStyle(document.documentElement).getPropertyValue('--accent')||'#f5b942';g.lineWidth=1;
+      g.beginPath();g.moveTo(mx,PAD.t);g.lineTo(mx,PAD.t+plotH);g.moveTo(PAD.l,my);g.lineTo(PAD.l+plotW,my);g.stroke();}
+    $('grad').style.background=gradCss(PALETTES[pal].stops);
+    $('lfloor').textContent=Math.round(d.floor_db)+' dB'; $('lceil').textContent=Math.round(d.ceil_db)+' dB';
+    setAx();
+  }
+  function setAx(){var m=S.marker;
+    $('axinfo').innerHTML = m
+      ? 'Marker: <b>'+(m.f/1e6).toFixed(4)+' MHz</b> ('+fmtHz(m.f-S.fc)+' offset) · t=<b>'+m.t.toFixed(4)+' s</b>'
+      : 'Window: '+S.view.t0.toFixed(3)+'–'+S.view.t1.toFixed(3)+' s · '+(S.view.f0/1e6).toFixed(3)+'–'+(S.view.f1/1e6).toFixed(3)+' MHz';
+  }
+  // ---- line plots (psd + envelope + demod wave) ----
+  function plot(id,xs,ys,color,fill){
+    var c=$(id),dpr=Math.min(window.devicePixelRatio||1,2),W=Math.max(200,c.clientWidth||300),H=c.clientHeight||120;
+    c.width=W*dpr;c.height=H*dpr;var g=c.getContext('2d');g.setTransform(dpr,0,0,dpr,0,0);g.clearRect(0,0,W,H);
+    if(!ys||!ys.length)return; var lo=Math.min.apply(null,ys),hi=Math.max.apply(null,ys); if(hi-lo<1){hi+=1;lo-=1;}
+    var px=function(i){return 6+i/(ys.length-1)*(W-12);}, py=function(v){return H-4-(v-lo)/(hi-lo)*(H-10);};
+    g.strokeStyle=color;g.lineWidth=1.2;g.beginPath();
+    for(var i=0;i<ys.length;i++){var x=px(i),y=py(ys[i]);i?g.lineTo(x,y):g.moveTo(x,y);}
+    g.stroke();
+    if(fill){g.lineTo(px(ys.length-1),H);g.lineTo(px(0),H);g.closePath();g.fillStyle=color.replace('rgb','rgba').replace(')',',0.12)');g.fill();}
+  }
+  function drawPsd(d){ if(d&&d.ok) plot('psd',d.freqs_mhz,d.db,'rgb(56,189,201)',true); }
+  function drawEnv(d){ if(d&&d.ok) plot('env',d.t,d.db,'rgb(63,181,107)',true); }
+
+  // ---- drag-to-zoom + click marker ----
+  (function(){var c=$('spec'),box=$('selbox'),drag=null;
+    function toData(ev){var r=c.getBoundingClientRect(),gx=(S._geom||{}),
+        x=(ev.clientX-r.left-PAD.l)/(gx.plotW||1), y=(ev.clientY-r.top-PAD.t)/(gx.plotH||1);
+      x=Math.max(0,Math.min(1,x));y=Math.max(0,Math.min(1,y));
+      var d=S.spec; return {t:d.t0+(d.t1-d.t0)*x, f:d.f1-(d.f1-d.f0)*y, px:ev.clientX-r.left, py:ev.clientY-r.top};}
+    c.addEventListener('mousedown',function(e){ if(!S.spec)return; drag={a:toData(e),startX:e.clientX,startY:e.clientY}; });
+    window.addEventListener('mousemove',function(e){ if(!drag)return;
+      var r=c.getBoundingClientRect(); box.style.display='block';
+      var x0=Math.min(drag.startX,e.clientX)-r.left, y0=Math.min(drag.startY,e.clientY)-r.top;
+      box.style.left=x0+'px';box.style.top=y0+'px';box.style.width=Math.abs(e.clientX-drag.startX)+'px';box.style.height=Math.abs(e.clientY-drag.startY)+'px';});
+    window.addEventListener('mouseup',function(e){ if(!drag)return; box.style.display='none';
+      var moved=Math.abs(e.clientX-drag.startX)+Math.abs(e.clientY-drag.startY);
+      var b=toData(e);
+      if(moved<6){ S.marker={t:b.t,f:b.f}; $('bw').focus&&0; drawSpec(S.spec); setAx(); drag=null; return; }
+      var t0=Math.min(drag.a.t,b.t),t1=Math.max(drag.a.t,b.t),f0=Math.min(drag.a.f,b.f),f1=Math.max(drag.a.f,b.f);
+      if(t1-t0>1e-4 && f1-f0>100){ S.view={t0:t0,t1:t1,f0:f0,f1:f1}; refreshWindow(); }
+      drag=null;});
+  })();
+  $('reset').addEventListener('click',function(){ if(!S.name)return; S.view={t0:0,t1:S.dur,f0:S.fc-S.fs/2,f1:S.fc+S.fs/2}; S.marker=null; refreshWindow(); });
+
+  // ---- bursts ----
+  function loadBursts(){ api('/api/net/rtl/analyze/bursts',{name:S.name}).then(function(d){
+    var tb=$('btbody'), b=(d&&d.bursts)||[]; $('bcount').textContent=b.length?b.length+' detected':'';
+    if(!b.length){ tb.innerHTML='<tr><td class="empty" colspan="5">No bursts above the noise floor.</td></tr>'; return; }
+    tb.innerHTML=b.map(function(x,i){return '<tr data-i="'+i+'"><td>'+x.t0.toFixed(4)+'</td><td>'+x.dur_ms+' ms</td><td>'+x.f_mhz.toFixed(4)+'</td><td>'+x.bw_khz+' kHz</td><td>'+Math.round(x.peak_db)+'</td></tr>';}).join('');
+    tb.querySelectorAll('tr').forEach(function(tr){tr.addEventListener('click',function(){var x=b[+tr.getAttribute('data-i')];
+      var pad=(x.t1-x.t0)*0.5+0.002; S.view={t0:Math.max(0,x.t0-pad),t1:Math.min(S.dur,x.t1+pad),
+        f0:x.f_mhz*1e6-Math.max(x.bw_khz*1e3*3,30e3), f1:x.f_mhz*1e6+Math.max(x.bw_khz*1e3*3,30e3)};
+      S.marker={t:(x.t0+x.t1)/2, f:x.f_mhz*1e6}; if(x.bw_khz)$('bw').value=Math.max(10,Math.round(x.bw_khz*1.5)); refreshWindow(); setAx();});});
+  });}
+
+  // ---- demod ----
+  var mode='ook';
+  $('mode').addEventListener('click',function(e){var b=e.target.closest('button');if(!b)return; mode=b.getAttribute('data-m');
+    Array.prototype.forEach.call($('mode').querySelectorAll('button'),function(x){x.setAttribute('aria-pressed',x.getAttribute('data-m')===mode?'true':'false');});});
+  $('run').addEventListener('click',function(){
+    if(!S.name){return;}
+    var v=S.view, foff=(S.marker?S.marker.f:S.fc)-S.fc, bw=(parseFloat($('bw').value)||60)*1e3;
+    $('bits').textContent='demodulating…';
+    api('/api/net/rtl/analyze/demod',{name:S.name,mode:mode,f_offset:foff,bw:bw,t0:v.t0,t1:v.t1}).then(function(d){
+      if(!d||!d.ok){ $('bits').textContent='⚠ '+((d&&d.error)||'demod failed'); return; }
+      plot('wave',d.wave,d.wave,'rgb(245,185,66)',false);
+      $('bits').textContent='baud ≈ '+d.baud+'   ('+d.n_bits+' bits @ '+(d.f_offset_hz/1e3).toFixed(1)+' kHz offset, BW '+(d.bw_hz/1e3).toFixed(0)+' kHz)\n'+(d.bits||'(no bits recovered)');
+    }).catch(function(){ $('bits').textContent='demod request failed'; });
+  });
+
+  $('cap').addEventListener('change',function(){ var n=decodeURIComponent($('cap').value||''); if(n)loadCapture(n); });
+  $('reload').addEventListener('click',function(){ loadList(S.name); });
+  window.addEventListener('resize',function(){ if(S.spec)drawSpec(S.spec); });
+
+  // preselect a capture from ?name=
+  var want=new URLSearchParams(location.search).get('name');
+  loadList(want);
+})();
+</script>
+</body>
+</html>

--- a/demos/rf_waterfall.html
+++ b/demos/rf_waterfall.html
@@ -602,11 +602,19 @@
       +'<input type="number" class="iqsec" value="2" min="0.1" max="30" step="0.5" title="Capture length (seconds)" style="width:46px;font-family:var(--mono);font-size:11px;color:var(--ink);background:var(--panel);border:1px solid var(--line);border-radius:5px;padding:3px 5px">'
       +'<button class="iqbtn" title="Capture raw IQ to a SigMF recording — opens in GNU Radio / inspectrum / URH">&#8681;&nbsp;SigMF</button>'
       +'<span class="iqstat rsp"></span>'
+      +'<span class="rsp">Sessions</span><select class="iqlist" title="All recorded SigMF sessions"><option value="">—</option></select>'
+      +'<button class="iqopen" title="Open the selected SigMF session in the Signal Analyzer">&#128200;&nbsp;Analyzer</button>'
+      +'<button class="iqreload" title="Refresh the session list">&#8635;</button>'
       +'<span class="rsp">·</span>'
       +'<button class="basebtn" aria-pressed="false" title="Learn a baseline spectrum, then alert on new / vanished carriers + broadband jamming (into the Watchtower feed)">&#9737;&nbsp;Baseline</button>'
       +'<span class="basestat rsp"></span>';
     this.iqBtn=g.querySelector('.iqbtn'); this.iqSec=g.querySelector('.iqsec'); this.iqStat=g.querySelector('.iqstat');
     this.iqBtn.addEventListener('click',function(){ self.iqCapture(); });
+    this.iqList=g.querySelector('.iqlist'); this.iqOpen=g.querySelector('.iqopen');
+    this.iqOpen.addEventListener('click',function(){ self.openInAnalyzer(); });
+    g.querySelector('.iqreload').addEventListener('click',function(){ self.refreshSessions(); });
+    this.iqList.addEventListener('dblclick',function(){ self.openInAnalyzer(); });
+    this.refreshSessions();
     this.baseBtn=g.querySelector('.basebtn'); this.baseStat=g.querySelector('.basestat');
     this.baseBtn.addEventListener('click',function(){ self.baselineToggle(); });
     this.baselinePoll();   // reflect any baseline already running server-side
@@ -623,6 +631,21 @@
     g.querySelector('.rexit').addEventListener('click',function(){ self.exitReplay(); });
     this.refreshRecordings();
   };
+  // All recorded SigMF sessions (data/iq_captures) -> the Sessions dropdown, so
+  // any past capture can be opened in the Analyzer, not just the latest one.
+  Scope.prototype.refreshSessions=function(sel){ var self=this;
+    if(!this.iqList) return;
+    fetch('/api/net/rtl/analyze/list').then(function(r){return r.json();}).then(function(d){
+      var caps=(d&&d.captures)||[], cur=sel||self.iqList.value;
+      if(!caps.length){ self.iqList.innerHTML='<option value="">— no sessions yet —</option>'; return; }
+      self.iqList.innerHTML=caps.map(function(c){var mb=(c.bytes/1e6).toFixed(1),du=c.duration_s?(' '+c.duration_s+'s'):'';
+        return '<option value="'+esc(c.name)+'">'+esc(c.name)+' ('+mb+'MB'+du+')</option>';}).join('');
+      if(cur) self.iqList.value=cur;
+    }).catch(function(){});
+  };
+  Scope.prototype.openInAnalyzer=function(){ var n=this.iqList&&this.iqList.value;
+    if(!n){ if(this.iqStat) this.iqStat.textContent='pick a session first'; return; }
+    window.open('/rf-analyzer?name='+encodeURIComponent(n),'_blank'); };
   // Raw-IQ capture to a SigMF recording. Centres on the marker (else the span
   // centre) at a single-tune sample rate; steals the dongle, so the live sweep
   // pauses and resumes when the capture finishes.
@@ -650,7 +673,8 @@
         self.iqStat.innerHTML='<span style="color:var(--live)">&#10003; '+mb+' MB</span> '
           +'<a href="/api/net/rtl/iq/file?name='+n+'" download style="color:var(--cyan);margin:0 6px">.sigmf-data</a>'
           +'<a href="/api/net/rtl/iq/file?name='+n+'&kind=meta" download style="color:var(--cyan)">.sigmf-meta</a>'
-          +'<a href="/rf-analyzer?name='+n+'" target="_blank" style="color:var(--accent);margin-left:10px;font-weight:600">&#128200; Open in Analyzer</a>'; }
+          +'<a href="/rf-analyzer?name='+n+'" target="_blank" style="color:var(--accent);margin-left:10px;font-weight:600">&#128200; Open in Analyzer</a>';
+        self.refreshSessions(st.name); }   // add the fresh capture to the Sessions dropdown
       // resume the sweep the capture interrupted
       if(self._iqWasLive && self.available){ self._iqWasLive=false; self._rangeKnown=false; self.resetCanvas(); self.startLive(); }
     }).catch(function(){ if(self._iqPoll){clearInterval(self._iqPoll);self._iqPoll=null;} });

--- a/demos/rf_waterfall.html
+++ b/demos/rf_waterfall.html
@@ -649,7 +649,8 @@
       else if(st.done && st.name){ var n=encodeURIComponent(st.name), mb=(st.bytes/1e6).toFixed(1);
         self.iqStat.innerHTML='<span style="color:var(--live)">&#10003; '+mb+' MB</span> '
           +'<a href="/api/net/rtl/iq/file?name='+n+'" download style="color:var(--cyan);margin:0 6px">.sigmf-data</a>'
-          +'<a href="/api/net/rtl/iq/file?name='+n+'&kind=meta" download style="color:var(--cyan)">.sigmf-meta</a>'; }
+          +'<a href="/api/net/rtl/iq/file?name='+n+'&kind=meta" download style="color:var(--cyan)">.sigmf-meta</a>'
+          +'<a href="/rf-analyzer?name='+n+'" target="_blank" style="color:var(--accent);margin-left:10px;font-weight:600">&#128200; Open in Analyzer</a>'; }
       // resume the sweep the capture interrupted
       if(self._iqWasLive && self.available){ self._iqWasLive=false; self._rangeKnown=false; self.resetCanvas(); self.startLive(); }
     }).catch(function(){ if(self._iqPoll){clearInterval(self._iqPoll);self._iqPoll=null;} });

--- a/demos/rf_waterfall.html
+++ b/demos/rf_waterfall.html
@@ -611,6 +611,8 @@
       +'<span class="iqstat rsp"></span>'
       +'<span class="rsp">Sessions</span><select class="iqlist" title="All recorded SigMF sessions"><option value="">—</option></select>'
       +'<button class="iqopen" title="Open the selected SigMF session in the Signal Analyzer">&#128200;&nbsp;Analyzer</button>'
+      +'<button class="iqrename" title="Rename the selected session">&#9998;&nbsp;Rename</button>'
+      +'<button class="iqdel" title="Delete the selected session">&#128465;&nbsp;Delete</button>'
       +'<button class="iqreload" title="Refresh the session list">&#8635;</button>'
       +'<span class="infowrap"><button class="infobtn" title="Capture size &amp; memory">&#9432;</button>'
         +'<div class="infopop">'
@@ -629,6 +631,8 @@
     this.iqBtn.addEventListener('click',function(){ self.iqCapture(); });
     this.iqList=g.querySelector('.iqlist'); this.iqOpen=g.querySelector('.iqopen');
     this.iqOpen.addEventListener('click',function(){ self.openInAnalyzer(); });
+    g.querySelector('.iqrename').addEventListener('click',function(){ self.renameSession(); });
+    g.querySelector('.iqdel').addEventListener('click',function(){ self.deleteSession(); });
     g.querySelector('.iqreload').addEventListener('click',function(){ self.refreshSessions(); });
     var ib=g.querySelector('.infobtn'), ip=g.querySelector('.infopop');
     if(ib&&ip){ ib.addEventListener('click',function(e){ e.stopPropagation(); ip.classList.toggle('show'); });
@@ -666,6 +670,22 @@
   Scope.prototype.openInAnalyzer=function(){ var n=this.iqList&&this.iqList.value;
     if(!n){ if(this.iqStat) this.iqStat.textContent='pick a session first'; return; }
     window.open('/rf-analyzer?name='+encodeURIComponent(n),'_blank'); };
+  Scope.prototype.renameSession=function(){ var self=this, n=this.iqList&&this.iqList.value;
+    if(!n){ this.iqStat.textContent='pick a session first'; return; }
+    var nn=(window.prompt('Rename session:', n)||'').trim(); if(!nn||nn===n) return;
+    fetch('/api/net/rtl/iq/rename',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name:n,new:nn})})
+      .then(function(r){return r.json();}).then(function(res){
+        if(!res||!res.ok){ self.iqStat.innerHTML='<span style="color:#fb7185">'+esc((res&&res.error)||'rename failed')+'</span>'; return; }
+        self.iqStat.innerHTML='<span style="color:var(--live)">renamed &rarr; '+esc(res.name)+'</span>'; self.refreshSessions(res.name);
+      }).catch(function(){ self.iqStat.textContent='rename failed'; }); };
+  Scope.prototype.deleteSession=function(){ var self=this, n=this.iqList&&this.iqList.value;
+    if(!n){ this.iqStat.textContent='pick a session first'; return; }
+    if(!window.confirm('Delete SigMF session "'+n+'"? This removes the .sigmf-data + .sigmf-meta files.')) return;
+    fetch('/api/net/rtl/iq/delete',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name:n})})
+      .then(function(r){return r.json();}).then(function(res){
+        if(!res||!res.ok){ self.iqStat.innerHTML='<span style="color:#fb7185">delete failed</span>'; return; }
+        self.iqStat.innerHTML='<span style="color:var(--ink-dim)">deleted '+esc(n)+'</span>'; self.refreshSessions();
+      }).catch(function(){ self.iqStat.textContent='delete failed'; }); };
   // Raw-IQ capture to a SigMF recording. Centres on the marker (else the span
   // centre) at a single-tune sample rate; steals the dongle, so the live sweep
   // pauses and resumes when the capture finishes.

--- a/demos/rf_waterfall.html
+++ b/demos/rf_waterfall.html
@@ -146,6 +146,13 @@
   .recbar .recdot{color:#fb7185}
   .recbar select{font-family:var(--mono);font-size:11px;color:var(--ink-dim);background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:4px 6px}
   .recbar input[type="range"]{flex:1 1 120px;min-width:100px;accent-color:var(--cyan)}
+  .infowrap{position:relative;display:inline-flex}
+  .infowrap .infobtn{padding:4px 9px;font-size:12px;line-height:1;color:var(--cyan);border-color:rgba(56,189,201,.4)}
+  .infopop{position:absolute;bottom:calc(100% + 8px);left:0;width:min(280px,80vw);z-index:40;display:none;
+    background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:11px 13px;box-shadow:0 14px 34px -14px #000;
+    font-family:var(--mono);font-size:11px;line-height:1.6;color:var(--ink-dim);white-space:normal;text-align:left}
+  .infopop.show{display:block}
+  .infopop b{color:var(--ink)} .infopop .warn{color:var(--accent)} .infopop .k{color:var(--cyan)}
   .recbar .rsp{color:var(--muted)}
   .scope-head .fsbtn{font-family:var(--mono);font-size:11px;color:var(--ink);background:var(--panel);border:1px solid var(--line);padding:5px 11px;border-radius:6px;cursor:pointer;transition:border-color .15s,background .15s,color .15s;white-space:nowrap}
   .scope-head .fsbtn:hover{border-color:rgba(56,189,201,.5);color:var(--cyan);background:rgba(56,189,201,.08)}
@@ -605,6 +612,16 @@
       +'<span class="rsp">Sessions</span><select class="iqlist" title="All recorded SigMF sessions"><option value="">—</option></select>'
       +'<button class="iqopen" title="Open the selected SigMF session in the Signal Analyzer">&#128200;&nbsp;Analyzer</button>'
       +'<button class="iqreload" title="Refresh the session list">&#8635;</button>'
+      +'<span class="infowrap"><button class="infobtn" title="Capture size &amp; memory">&#9432;</button>'
+        +'<div class="infopop">'
+          +'<b>IQ capture &amp; memory</b><br>'
+          +'A SigMF capture is raw IQ &mdash; about <span class="k">4 MB per second</span> at 2 MS/s. '
+          +'The Analyzer loads the <b>whole file into RAM</b> as complex samples (&asymp;<b>4&times; the file size</b>).<br><br>'
+          +'On a low-memory board like a <b>Pi Zero (512 MB)</b>, keep captures small: '
+          +'<span class="warn">&le; ~50 MB (~12 s)</span> &rarr; ~200 MB RAM. '
+          +'Pi 4/5 handle hundreds of MB fine.<br><br>'
+          +'For long captures, <b>download the .sigmf-data</b> and analyse it on a desktop (GNU Radio / inspectrum / URH).'
+        +'</div></span>'
       +'<span class="rsp">·</span>'
       +'<button class="basebtn" aria-pressed="false" title="Learn a baseline spectrum, then alert on new / vanished carriers + broadband jamming (into the Watchtower feed)">&#9737;&nbsp;Baseline</button>'
       +'<span class="basestat rsp"></span>';
@@ -613,6 +630,9 @@
     this.iqList=g.querySelector('.iqlist'); this.iqOpen=g.querySelector('.iqopen');
     this.iqOpen.addEventListener('click',function(){ self.openInAnalyzer(); });
     g.querySelector('.iqreload').addEventListener('click',function(){ self.refreshSessions(); });
+    var ib=g.querySelector('.infobtn'), ip=g.querySelector('.infopop');
+    if(ib&&ip){ ib.addEventListener('click',function(e){ e.stopPropagation(); ip.classList.toggle('show'); });
+      document.addEventListener('click',function(e){ if(!ip.contains(e.target)&&e.target!==ib) ip.classList.remove('show'); }); }
     this.iqList.addEventListener('dblclick',function(){ self.openInAnalyzer(); });
     this.refreshSessions();
     this.baseBtn=g.querySelector('.basebtn'); this.baseStat=g.querySelector('.basestat');

--- a/docs/rf-waterfall-guide.md
+++ b/docs/rf-waterfall-guide.md
@@ -84,6 +84,14 @@ capture opens directly in **GNU Radio, inspectrum or Universal Radio Hacker** �
 turning Ragnar into a real capture instrument you can hand to serious DSP tools,
 not a closed viewer. Files land under `data/iq_captures/` with download links.
 
+**📈 Open in Analyzer** — every finished capture also gets a button to the
+on-box **Signal Analyzer** (`/rf-analyzer`): a zoomable spectrogram of the
+recording, spectrum + time-envelope panels, automatic **burst/packet detection**,
+and a **demodulator** that recovers a **bitstream** (OOK/AM or FSK/FM) with an
+estimated symbol rate. It runs entirely on the device (numpy/scipy), so you can
+analyse a capture from your phone without a desktop — then drop to GNU Radio /
+URH when you want to go deeper.
+
 ## 7. Trustworthy frequencies (PPM calibration)
 
 A cheap RTL-SDR crystal is typically tens of ppm off — tens of kHz at 900 MHz,

--- a/docs/rf-waterfall.md
+++ b/docs/rf-waterfall.md
@@ -184,6 +184,32 @@ turning Ragnar into a real capture instrument rather than a closed viewer.
   `.sigmf-data` + `.sigmf-meta` download links. Backend: `rtl_sdr.iq_capture_*`
   + `sigmf_meta()`; routes `/api/net/rtl/iq/{start,status,stop,list,delete,file}`.
 
+## Signal Analyzer (on-box SigMF analysis)
+
+A finished SigMF capture shows an **📈 Open in Analyzer** link that opens
+**`/rf-analyzer`** (`demos/rf_analyzer.html`) — a dedicated page that analyses the
+recording *on the device* so it works from a phone, no desktop DSP tools needed.
+All the maths runs in numpy/scipy in `sigmf_analyzer.py`; the page is a viewer
+that requests windows:
+
+- **Summary** — center/rate/duration, measured noise floor, peak frequency, SNR,
+  occupied bandwidth, burst count.
+- **Zoomable spectrogram** — a time × frequency image for any window; drag a box
+  to zoom, click to drop a marker. Rendered client-side with the waterfall
+  palettes (the backend returns a compact base64 dB grid).
+- **Spectrum + time-envelope** panels for the shown window.
+- **Burst / packet list** — automatic on/off detection (start/end/BW/level);
+  click a row to zoom to it and pre-fill the demodulator.
+- **Demodulate** — shift to the marked signal, low-pass to a chosen bandwidth,
+  and demodulate **OOK/AM** (envelope) or **FSK/FM** (instantaneous frequency),
+  estimate the symbol rate and **recover a bitstream**.
+
+Routes (read-only over `data/iq_captures/`, so no dongle needed):
+`/api/net/rtl/analyze/{list,summary,spectrogram,psd,envelope,bursts,demod}` and
+the page at `/rf-analyzer` (optionally `?name=<capture>`). For heavier work the
+raw `.sigmf-data` still opens in GNU Radio / inspectrum / URH. `scipy` is used
+for decimation/filtering in the demodulator.
+
 ## Colour palettes
 
 The top toolbar has a **Palette** selector for the waterfall colour map. Five are

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -22077,6 +22077,12 @@ def register_network_diagnostics(app, logger=None):
         _log("net/rtl/iq/delete")
         return jsonify(rtl_sdr.iq_capture_delete(data.get('name', '')))
 
+    @app.route('/api/net/rtl/iq/rename', methods=['POST'])
+    def net_rtl_iq_rename():
+        data = request.get_json(silent=True) or {}
+        _log("net/rtl/iq/rename")
+        return jsonify(rtl_sdr.iq_capture_rename(data.get('name', ''), data.get('new', '')))
+
     @app.route('/api/net/rtl/iq/file', methods=['GET'])
     def net_rtl_iq_file():
         from flask import send_file

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -54,6 +54,7 @@ import report_common
 import bt_scanner
 import sdr_spectrum
 import rtl_sdr
+import sigmf_analyzer
 import adsb
 import meshtastic_node
 import pagerdecode as pager   # decoder module (the `pager/` package is a separate device UI)
@@ -22111,6 +22112,60 @@ def register_network_diagnostics(app, logger=None):
         _log("net/rtl/calibrate true=%s near=%s" % (data.get('true_mhz'), data.get('near_mhz')))
         return jsonify(rtl_sdr.calibrate_from_reference(
             data.get('true_mhz'), near_mhz=data.get('near_mhz')))
+
+    # On-box SigMF IQ analyzer (powers the /rf-analyzer page). Read-only over the
+    # capture files, so it never touches the dongle and runs anytime.
+    def _fl(v):
+        try: return float(v)
+        except (TypeError, ValueError): return None
+
+    def _analyze(fn, **kw):
+        try:
+            return jsonify(fn(**kw))
+        except ValueError as exc:
+            return jsonify({"ok": False, "error": str(exc)}), 404
+        except Exception as exc:   # pragma: no cover - defensive
+            return jsonify({"ok": False, "error": str(exc)}), 500
+
+    @app.route('/api/net/rtl/analyze/list', methods=['GET'])
+    def net_rtl_analyze_list():
+        return jsonify(sigmf_analyzer.list_captures())
+
+    @app.route('/api/net/rtl/analyze/summary', methods=['GET'])
+    def net_rtl_analyze_summary():
+        return _analyze(sigmf_analyzer.summary, name=request.args.get('name', ''))
+
+    @app.route('/api/net/rtl/analyze/spectrogram', methods=['GET'])
+    def net_rtl_analyze_spectrogram():
+        a = request.args
+        return _analyze(sigmf_analyzer.spectrogram, name=a.get('name', ''),
+                        t0=_fl(a.get('t0')), t1=_fl(a.get('t1')),
+                        f0=_fl(a.get('f0')), f1=_fl(a.get('f1')),
+                        w=int(_fl(a.get('w')) or 900), h=int(_fl(a.get('h')) or 360),
+                        nfft=int(_fl(a.get('nfft')) or 1024))
+
+    @app.route('/api/net/rtl/analyze/psd', methods=['GET'])
+    def net_rtl_analyze_psd():
+        a = request.args
+        return _analyze(sigmf_analyzer.psd, name=a.get('name', ''),
+                        t0=_fl(a.get('t0')), t1=_fl(a.get('t1')))
+
+    @app.route('/api/net/rtl/analyze/envelope', methods=['GET'])
+    def net_rtl_analyze_envelope():
+        a = request.args
+        return _analyze(sigmf_analyzer.envelope, name=a.get('name', ''),
+                        t0=_fl(a.get('t0')), t1=_fl(a.get('t1')))
+
+    @app.route('/api/net/rtl/analyze/bursts', methods=['GET'])
+    def net_rtl_analyze_bursts():
+        return _analyze(sigmf_analyzer.bursts, name=request.args.get('name', ''))
+
+    @app.route('/api/net/rtl/analyze/demod', methods=['GET'])
+    def net_rtl_analyze_demod():
+        a = request.args
+        return _analyze(sigmf_analyzer.demod, name=a.get('name', ''),
+                        mode=a.get('mode', 'ook'), f_offset_hz=_fl(a.get('f_offset')) or 0.0,
+                        bw_hz=_fl(a.get('bw')), t0=_fl(a.get('t0')), t1=_fl(a.get('t1')))
 
     # ADS-B (1090 MHz aircraft) via dump1090 — powers the radar screen. Uses the
     # whole RTL-SDR, so starting it stops the sub-GHz sweep/decoder, and vice

--- a/rtl_sdr.py
+++ b/rtl_sdr.py
@@ -1785,6 +1785,31 @@ def iq_capture_delete(name):
     return {"ok": ok}
 
 
+def iq_capture_rename(name, new):
+    """Rename a SigMF capture (both sidecars). Sanitises the new name; refuses to
+    clobber an existing capture."""
+    old = _rec_safe(name)
+    dst = _rec_safe(new)
+    if not dst:
+        return {"ok": False, "error": "invalid new name"}
+    if dst == old:
+        return {"ok": True, "name": dst}
+    d = _iq_cap_dir()
+    src_data = os.path.join(d, old + ".sigmf-data")
+    if not os.path.exists(src_data):
+        return {"ok": False, "error": "capture not found"}
+    if os.path.exists(os.path.join(d, dst + ".sigmf-data")):
+        return {"ok": False, "error": "a capture named '%s' already exists" % dst}
+    try:
+        for suffix in (".sigmf-data", ".sigmf-meta"):
+            s = os.path.join(d, old + suffix)
+            if os.path.exists(s):
+                os.rename(s, os.path.join(d, dst + suffix))
+    except OSError as exc:
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True, "name": dst}
+
+
 _iqcap = IqCapture()
 
 

--- a/sigmf_analyzer.py
+++ b/sigmf_analyzer.py
@@ -1,0 +1,523 @@
+#!/usr/bin/env python3
+"""sigmf_analyzer.py — on-box analysis of the RF Waterfall's SigMF IQ captures.
+
+The RF Waterfall's ``⤓ SigMF`` button ([[rtl_sdr]] IqCapture) writes raw IQ
+recordings (``data/iq_captures/<name>.sigmf-data`` + ``.sigmf-meta``). Desktop
+tools (inspectrum / URH / GNU Radio) analyse those on a laptop; this module does
+it **on the Pi** so the "Open in Analyzer" page works straight from a phone.
+
+Everything heavy runs here in numpy/scipy and the page is just a viewer that
+requests windows:
+
+  * :func:`summary`     — center/rate/duration, measured noise floor, peak
+    offset, occupied bandwidth, burst count.
+  * :func:`spectrogram` — a zoomable time x frequency power grid for any
+    [t0,t1] x [f0,f1] window, returned as a compact base64 uint8 image the page
+    colours with the waterfall palette.
+  * :func:`psd`         — averaged power spectrum over a time range.
+  * :func:`envelope`    — amplitude-over-time (for AM/OOK + burst spotting).
+  * :func:`bursts`      — automatic on/off packet detection (start/end/BW/level).
+  * :func:`demod`       — shift/filter/demodulate a chosen signal (AM-OOK or
+    FM-FSK), estimate the symbol rate and recover a bitstream.
+
+SigMF datatype ``cu8`` (interleaved unsigned-8 I/Q — the RTL-SDR's native form)
+is the primary format; ``cs8`` is also accepted. Pure DSP helpers are
+selftested against a synthesised capture (a tone + an OOK burst), no hardware.
+"""
+
+import base64
+import json
+import os
+import struct
+import time
+
+
+def _cap_dir():
+    # Mirror rtl_sdr._iq_cap_dir() without a hard import dependency.
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "iq_captures")
+
+
+def _safe(name):
+    import re
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", str(name or ""))[:80]
+
+
+# --------------------------------------------------------------------------
+# Loading (cached by name + mtime so repeated window requests are cheap)
+# --------------------------------------------------------------------------
+
+_CACHE = {}          # name -> (mtime, iq(complex64), fs, fc, meta)
+_CACHE_MAX = 3       # keep only a few captures resident (they can be tens of MB)
+
+
+def _paths(name):
+    base = os.path.join(_cap_dir(), _safe(name))
+    return base + ".sigmf-data", base + ".sigmf-meta"
+
+
+def load(name):
+    """Return (iq complex64, fs Hz, fc Hz, meta) for a capture, or raise ValueError."""
+    import numpy as np
+    data_p, meta_p = _paths(name)
+    if not os.path.exists(data_p) or not os.path.exists(meta_p):
+        raise ValueError("capture not found")
+    mtime = os.path.getmtime(data_p)
+    hit = _CACHE.get(name)
+    if hit and hit[0] == mtime:
+        return hit[1], hit[2], hit[3], hit[4]
+    with open(meta_p) as fh:
+        meta = json.load(fh)
+    g = meta.get("global", {})
+    cap0 = (meta.get("captures") or [{}])[0]
+    fs = float(g.get("core:sample_rate") or 0) or 1.0
+    fc = float(cap0.get("core:frequency") or 0)
+    dtype = (g.get("core:datatype") or "cu8").lower()
+    raw = np.fromfile(data_p, dtype=np.uint8)
+    raw = raw[: (raw.size // 2) * 2]                 # whole I/Q pairs only
+    if dtype.startswith("cs8"):                       # signed 8-bit
+        s = raw.astype(np.int8).astype(np.float32)
+        iq = (s[0::2] + 1j * s[1::2]) / 128.0
+    else:                                             # cu8 (default): unsigned 8-bit
+        f = raw.astype(np.float32) - 127.5
+        iq = (f[0::2] + 1j * f[1::2]) / 127.5
+    iq = iq.astype(np.complex64)
+    if len(_CACHE) >= _CACHE_MAX:
+        _CACHE.pop(next(iter(_CACHE)))
+    _CACHE[name] = (mtime, iq, fs, fc, meta)
+    return iq, fs, fc, meta
+
+
+def list_captures():
+    """Every capture in the dir with both sidecars, newest first."""
+    import glob
+    out = []
+    for meta_p in sorted(glob.glob(os.path.join(_cap_dir(), "*.sigmf-meta")), reverse=True):
+        base = os.path.basename(meta_p)[:-len(".sigmf-meta")]
+        data_p = meta_p[:-len(".sigmf-meta")] + ".sigmf-data"
+        if not os.path.exists(data_p):
+            continue
+        try:
+            m = json.load(open(meta_p))
+            g, c = m.get("global", {}), (m.get("captures") or [{}])[0]
+            fs = float(g.get("core:sample_rate") or 0)
+            nbytes = os.path.getsize(data_p)
+            out.append({"name": base, "sr_hz": fs,
+                        "center_hz": c.get("core:frequency"),
+                        "datetime": c.get("core:datetime"),
+                        "bytes": nbytes,
+                        "duration_s": round(nbytes / 2 / fs, 3) if fs else None})
+        except (OSError, ValueError):
+            continue
+    return {"captures": out}
+
+
+# --------------------------------------------------------------------------
+# Pure DSP helpers (numpy) — selftested on synthetic signals
+# --------------------------------------------------------------------------
+
+def _noise_floor_db(psd_db):
+    import numpy as np
+    return float(np.percentile(psd_db, 30))
+
+
+def welch_psd(iq, fs, nfft=4096):
+    """Averaged power spectrum (fftshifted), returns (freqs_hz, db). Pure-ish."""
+    import numpy as np
+    n = len(iq)
+    if n < nfft:
+        nfft = 1 << max(6, int(np.log2(max(2, n))))
+    win = np.hanning(nfft).astype(np.float32)
+    ncol = max(1, (n - nfft) // (nfft // 2) + 1)
+    ncol = min(ncol, 400)
+    starts = np.linspace(0, max(0, n - nfft), ncol).astype(int)
+    acc = np.zeros(nfft, dtype=np.float64)
+    for s in starts:
+        seg = iq[s:s + nfft] * win
+        S = np.fft.fftshift(np.fft.fft(seg))
+        acc += (S.real ** 2 + S.imag ** 2)
+    acc /= len(starts)
+    db = 10.0 * np.log10(acc / (nfft * float(np.sum(win ** 2))) + 1e-12)
+    freqs = np.fft.fftshift(np.fft.fftfreq(nfft, 1.0 / fs))
+    return freqs, db
+
+
+def occupied_bw(freqs, db, frac=0.99):
+    """99%-power occupied bandwidth around the strongest bin (Hz). Pure."""
+    import numpy as np
+    lin = 10.0 ** (db / 10.0)
+    pk = int(np.argmax(lin))
+    tot = float(lin.sum())
+    if tot <= 0:
+        return 0.0
+    acc, lo = 0.0, pk
+    for i in range(pk, -1, -1):
+        acc += lin[i]
+        lo = i
+        if acc >= tot * (1 - frac) / 2:
+            break
+    acc, hi = 0.0, pk
+    for i in range(pk, len(lin)):
+        acc += lin[i]
+        hi = i
+        if acc >= tot * (1 - frac) / 2:
+            break
+    return abs(float(freqs[hi] - freqs[lo]))
+
+
+def _pool_max(a, out):
+    """Downsample a 1-D array to length ``out`` by block-max (keeps thin peaks)."""
+    import numpy as np
+    n = len(a)
+    if out >= n:
+        idx = np.clip((np.arange(out) * n / out).astype(int), 0, n - 1)
+        return a[idx]
+    edges = (np.arange(out + 1) * n / out).astype(int)
+    return np.array([a[edges[i]:max(edges[i] + 1, edges[i + 1])].max() for i in range(out)])
+
+
+def stft_grid(iq, fs, fc, t0, t1, f0, f1, w=900, h=360, nfft=1024):
+    """A time x frequency power grid over [t0,t1] s x [f0,f1] Hz.
+
+    Returns (grid uint8 [h,w], floor_db, ceil_db, actual t0,t1,f0,f1). Rows are
+    frequency (top = high), cols are time. Values are dB clipped to
+    [floor,ceil] and mapped 0..255 for the page's palette LUT. Pure numpy.
+    """
+    import numpy as np
+    n = len(iq)
+    i0 = max(0, int(t0 * fs)); i1 = min(n, int(t1 * fs))
+    if i1 - i0 < nfft:
+        i1 = min(n, i0 + nfft)
+        i0 = max(0, i1 - nfft)
+    seg = iq[i0:i1]
+    win = np.hanning(nfft).astype(np.float32)
+    ncol = max(1, (len(seg) - nfft) // nfft + 1)          # non-overlapping frames
+    ncol = min(ncol, 4000)
+    starts = np.linspace(0, max(0, len(seg) - nfft), ncol).astype(int)
+    frames = np.stack([seg[s:s + nfft] for s in starts]) * win           # (T, nfft)
+    S = np.fft.fftshift(np.fft.fft(frames, axis=1), axes=1)
+    P = (S.real ** 2 + S.imag ** 2) / (nfft * float(np.sum(win ** 2)))
+    db = (10.0 * np.log10(P + 1e-12)).T                                  # (freq, time)
+    fbins = np.fft.fftshift(np.fft.fftfreq(nfft, 1.0 / fs)) + fc         # absolute Hz
+    # crop to [f0,f1]
+    lo = np.searchsorted(fbins, f0); hi = np.searchsorted(fbins, f1)
+    lo = max(0, min(lo, nfft - 1)); hi = max(lo + 1, min(hi, nfft))
+    db = db[lo:hi, :]
+    fmin, fmax = float(fbins[lo]), float(fbins[hi - 1])
+    # resize: freq rows -> h (max-pool), time cols -> w
+    if db.shape[0] != h:
+        db = np.stack([_pool_max(db[:, c], h) for c in range(db.shape[1])], axis=1) \
+            if db.shape[1] <= h * 4 else \
+            np.apply_along_axis(lambda col: _pool_max(col, h), 0, db)
+    if db.shape[1] != w:
+        db = np.apply_along_axis(lambda row: _pool_max(row, w), 1, db)
+    db = db[::-1, :]                                        # top row = high freq
+    floor = float(np.percentile(db, 25)) - 4.0
+    ceil = float(np.percentile(db, 99.9)) + 2.0
+    if ceil - floor < 12:
+        ceil = floor + 12
+    g = np.clip((db - floor) / (ceil - floor), 0, 1)
+    grid = (g * 255).astype(np.uint8)
+    tt0 = i0 / fs + starts[0] / fs
+    tt1 = i0 / fs + (starts[-1] + nfft) / fs
+    return grid, floor, ceil, tt0, tt1, fmin, fmax
+
+
+# --------------------------------------------------------------------------
+# Public API (dicts for the web layer)
+# --------------------------------------------------------------------------
+
+def summary(name):
+    import numpy as np
+    iq, fs, fc, meta = load(name)
+    n = len(iq)
+    freqs, db = welch_psd(iq, fs)
+    nf = _noise_floor_db(db)
+    pk = int(np.argmax(db))
+    obw = occupied_bw(freqs, db)
+    b = bursts(name).get("bursts", [])
+    return {"ok": True, "name": name, "samples": n, "duration_s": round(n / fs, 4),
+            "sr_hz": fs, "center_hz": fc, "span_hz": fs,
+            "noise_db": round(nf, 1), "peak_db": round(float(db[pk]), 1),
+            "peak_offset_hz": round(float(freqs[pk]), 1),
+            "peak_hz": round(fc + float(freqs[pk]), 1),
+            "snr_db": round(float(db[pk]) - nf, 1),
+            "occupied_bw_hz": round(obw, 1), "bursts": len(b),
+            "datetime": (meta.get("captures") or [{}])[0].get("core:datetime")}
+
+
+def spectrogram(name, t0=None, t1=None, f0=None, f1=None, w=900, h=360, nfft=1024):
+    iq, fs, fc, _ = load(name)
+    dur = len(iq) / fs
+    t0 = 0.0 if t0 is None else max(0.0, float(t0))
+    t1 = dur if t1 is None else min(dur, float(t1))
+    f0 = fc - fs / 2 if f0 is None else float(f0)
+    f1 = fc + fs / 2 if f1 is None else float(f1)
+    w = int(max(64, min(1600, w))); h = int(max(64, min(720, h)))
+    nfft = int(max(128, min(8192, nfft)))
+    grid, floor, ceil, tt0, tt1, fmin, fmax = stft_grid(iq, fs, fc, t0, t1, f0, f1, w, h, nfft)
+    return {"ok": True, "w": grid.shape[1], "h": grid.shape[0],
+            "t0": tt0, "t1": tt1, "f0": fmin, "f1": fmax,
+            "floor_db": round(floor, 1), "ceil_db": round(ceil, 1),
+            "data": base64.b64encode(grid.tobytes()).decode("ascii")}
+
+
+def psd(name, t0=None, t1=None, n=900):
+    import numpy as np
+    iq, fs, fc, _ = load(name)
+    dur = len(iq) / fs
+    i0 = 0 if t0 is None else max(0, int(float(t0) * fs))
+    i1 = len(iq) if t1 is None else min(len(iq), int(float(t1) * fs))
+    freqs, db = welch_psd(iq[i0:i1] if i1 > i0 else iq, fs)
+    n = int(max(64, min(1600, n)))
+    fr = (freqs + fc) / 1e6
+    if len(db) > n:
+        db = _pool_max(db, n)
+        fr = fr[np.linspace(0, len(fr) - 1, n).astype(int)]
+    return {"ok": True, "freqs_mhz": [round(x, 4) for x in fr.tolist()],
+            "db": [round(x, 1) for x in db.tolist()],
+            "noise_db": round(_noise_floor_db(db), 1)}
+
+
+def envelope(name, t0=None, t1=None, n=1200):
+    """Amplitude (dB) over time — the AM/OOK view + what bursts() thresholds."""
+    import numpy as np
+    iq, fs, fc, _ = load(name)
+    dur = len(iq) / fs
+    i0 = 0 if t0 is None else max(0, int(float(t0) * fs))
+    i1 = len(iq) if t1 is None else min(len(iq), int(float(t1) * fs))
+    seg = iq[i0:i1] if i1 > i0 else iq
+    mag = np.abs(seg)
+    n = int(max(64, min(4000, n)))
+    if len(mag) > n:                                   # block-mean then to dB
+        edges = (np.arange(n + 1) * len(mag) / n).astype(int)
+        mag = np.array([mag[edges[i]:max(edges[i] + 1, edges[i + 1])].mean() for i in range(n)])
+    db = 20.0 * np.log10(mag + 1e-6)
+    t = (i0 / fs) + np.linspace(0, (len(seg)) / fs, len(db))
+    return {"ok": True, "t": [round(x, 5) for x in t.tolist()],
+            "db": [round(x, 1) for x in db.tolist()]}
+
+
+def bursts(name, thresh_db=8.0, min_ms=0.2):
+    """Detect on/off bursts from the amplitude envelope (energy above noise)."""
+    import numpy as np
+    iq, fs, fc, _ = load(name)
+    mag = np.abs(iq)
+    # coarse envelope to keep it cheap on long captures
+    step = max(1, len(mag) // 200000)
+    env = mag[::step]
+    env_fs = fs / step
+    edb = 20.0 * np.log10(env + 1e-6)
+    nf = float(np.percentile(edb, 30))
+    on = edb > (nf + thresh_db)
+    out = []
+    i, N = 0, len(on)
+    min_samp = int(min_ms / 1000.0 * env_fs)
+    while i < N:
+        if on[i]:
+            j = i
+            while j < N and on[j]:
+                j += 1
+            if j - i >= max(1, min_samp):
+                seg = iq[i * step: j * step]
+                fr, db = welch_psd(seg, fs, nfft=min(2048, 1 << int(np.log2(max(2, len(seg))))))
+                pk = int(np.argmax(db))
+                out.append({"t0": round(i / env_fs, 5), "t1": round(j / env_fs, 5),
+                            "dur_ms": round((j - i) / env_fs * 1000, 3),
+                            "f_mhz": round((fc + float(fr[pk])) / 1e6, 4),
+                            "bw_khz": round(occupied_bw(fr, db) / 1e3, 1),
+                            "peak_db": round(float(db[pk]), 1)})
+            i = j
+        else:
+            i += 1
+    return {"ok": True, "bursts": out[:200], "count": len(out)}
+
+
+def _slice_bits(level, fs, max_bits=512):
+    """Turn a boolean decision stream into (baud, bit-string) via run lengths. Pure."""
+    import numpy as np
+    lvl = level.astype(np.int8)
+    if lvl.size < 4:
+        return 0.0, ""
+    chg = np.where(np.diff(lvl) != 0)[0] + 1
+    bounds = np.concatenate([[0], chg, [len(lvl)]])
+    runs = np.diff(bounds)
+    real = runs[runs >= 2]
+    if real.size == 0:
+        return 0.0, ""
+    ui = float(np.percentile(real, 10))               # shortest symbol ~ unit interval
+    if ui < 1:
+        return 0.0, ""
+    baud = fs / ui
+    nb = min(max_bits, int(len(lvl) / ui))
+    centers = (np.arange(nb) + 0.5) * ui
+    idx = np.clip(centers.astype(int), 0, len(lvl) - 1)
+    bits = lvl[idx]
+    return baud, "".join("1" if b else "0" for b in bits)
+
+
+def demod(name, mode="ook", f_offset_hz=0.0, bw_hz=None, t0=None, t1=None):
+    """Shift to f_offset, low-pass to bw, demodulate (ook/am or fsk/fm), recover bits.
+
+    Returns the estimated symbol rate, a recovered bitstream, and a downsampled
+    waveform (dB envelope for OOK/AM, instantaneous frequency for FSK/FM) to plot.
+    """
+    import numpy as np
+    from scipy import signal as sig
+    iq, fs, fc, _ = load(name)
+    dur = len(iq) / fs
+    i0 = 0 if t0 is None else max(0, int(float(t0) * fs))
+    i1 = len(iq) if t1 is None else min(len(iq), int(float(t1) * fs))
+    x = iq[i0:i1] if i1 > i0 else iq
+    if len(x) < 16:
+        return {"ok": False, "error": "selection too short"}
+    foff = float(f_offset_hz or 0.0)
+    bw = float(bw_hz) if bw_hz else min(fs / 4, 200e3)
+    bw = max(1e3, min(bw, fs / 2))
+    n = np.arange(len(x))
+    x = x * np.exp(-2j * np.pi * (foff / fs) * n)     # mix the signal down to DC
+    dec = int(max(1, fs // (bw * 2)))                  # decimate to ~2*bw
+    if dec > 1:
+        x = sig.decimate(x, dec, ftype="fir")
+    nfs = fs / dec
+    mode = (mode or "ook").lower()
+    if mode in ("fsk", "fm"):
+        inst = np.angle(x[1:] * np.conj(x[:-1])) * nfs / (2 * np.pi)   # Hz
+        wave = inst
+        level = inst > np.median(inst)
+        ylabel = "inst. freq (Hz)"
+    else:                                              # ook / am
+        env = np.abs(x)
+        env = env / (env.max() + 1e-9)
+        wave = 20.0 * np.log10(env + 1e-4)
+        thr = 0.5 * (float(np.percentile(env, 90)) + float(np.percentile(env, 10)))
+        level = env > thr
+        ylabel = "envelope (dB)"
+    baud, bits = _slice_bits(level, nfs)
+    # downsample the waveform for transport/plot
+    m = 1600
+    if len(wave) > m:
+        edges = (np.arange(m + 1) * len(wave) / m).astype(int)
+        wave = np.array([wave[edges[i]:max(edges[i] + 1, edges[i + 1])].mean() for i in range(m)])
+    return {"ok": True, "mode": mode, "sample_rate_hz": round(nfs, 1),
+            "baud": round(baud, 1), "n_bits": len(bits), "bits": bits,
+            "ylabel": ylabel,
+            "wave": [round(float(v), 3) for v in wave.tolist()],
+            "t0": i0 / fs, "t1": i1 / fs, "bw_hz": bw, "f_offset_hz": foff}
+
+
+# --------------------------------------------------------------------------
+# Self-test — synthesise a cu8 capture (tone + OOK burst) and check the DSP
+# --------------------------------------------------------------------------
+
+def _write_synth(path_base, fs=1_000_000.0, fc=433_900_000.0):
+    """Write a synthetic cu8 SigMF capture: a CW tone at +150 kHz for the whole
+    record, plus an OOK burst at +150 kHz (on/off keyed) in the middle."""
+    import numpy as np
+    dur = 0.2
+    n = int(fs * dur)
+    t = np.arange(n) / fs
+    tone = 0.25 * np.exp(2j * np.pi * 150_000 * t)          # CW carrier at +150 kHz
+    # OOK: 2000 baud square keying gating a +150 kHz carrier, only mid-record
+    baud = 2000.0
+    key = ((t * baud).astype(int) % 2).astype(np.float32)   # 1010...
+    gate = ((t > 0.08) & (t < 0.12)).astype(np.float32)
+    ook = 0.5 * key * gate * np.exp(2j * np.pi * 150_000 * t)
+    noise = (np.random.randn(n) + 1j * np.random.randn(n)) * 0.02
+    x = tone + ook + noise
+    i = np.clip(np.round(x.real * 127.5 + 127.5), 0, 255).astype(np.uint8)
+    q = np.clip(np.round(x.imag * 127.5 + 127.5), 0, 255).astype(np.uint8)
+    inter = np.empty(2 * n, dtype=np.uint8); inter[0::2] = i; inter[1::2] = q
+    inter.tofile(path_base + ".sigmf-data")
+    meta = {"global": {"core:datatype": "cu8", "core:sample_rate": fs,
+                       "core:version": "1.0.0"},
+            "captures": [{"core:sample_start": 0, "core:frequency": fc,
+                          "core:datetime": "2026-01-01T00:00:00Z"}],
+            "annotations": []}
+    json.dump(meta, open(path_base + ".sigmf-meta", "w"))
+
+
+def selftest():
+    import tempfile
+    results = []
+
+    def check(name, ok, detail=""):
+        results.append({"name": name, "pass": bool(ok), "detail": detail})
+
+    try:
+        import numpy  # noqa
+        import scipy  # noqa
+    except Exception as exc:
+        return {"pass": False, "passed": 0, "total": 1,
+                "results": [{"name": "deps: numpy+scipy import", "pass": False, "detail": str(exc)}]}
+
+    tmp = tempfile.mkdtemp(prefix="sigmf-st-")
+    saved = globals()["_cap_dir"]
+    globals()["_cap_dir"] = lambda: tmp
+    try:
+        _write_synth(os.path.join(tmp, "synth"))
+        s = summary("synth")
+        check("summary: peak near +150 kHz of a 433.9 MHz capture",
+              abs(s["peak_offset_hz"] - 150_000) < 8000, str(s.get("peak_offset_hz")))
+        check("summary: duration ~0.2 s @ 1 MS/s", abs(s["duration_s"] - 0.2) < 0.01, str(s["duration_s"]))
+        check("summary: SNR positive (tone over noise)", s["snr_db"] > 15, str(s["snr_db"]))
+        sp = spectrogram("synth", w=200, h=120)
+        raw = base64.b64decode(sp["data"])
+        check("spectrogram: grid is h*w uint8 bytes",
+              len(raw) == sp["w"] * sp["h"] and sp["w"] == 200 and sp["h"] == 120, str((sp["w"], sp["h"], len(raw))))
+        check("spectrogram: dynamic range present (floor<ceil)", sp["ceil_db"] > sp["floor_db"])
+        b = bursts("synth")
+        check("bursts: the mid-record OOK burst is detected",
+              b["count"] >= 1 and any(0.07 < x["t0"] < 0.12 for x in b["bursts"]), str(b["count"]))
+        d = demod("synth", mode="ook", f_offset_hz=150_000, bw_hz=60_000, t0=0.08, t1=0.12)
+        check("demod: OOK recovers ~2000 baud",
+              d["ok"] and abs(d["baud"] - 2000) < 400, str(d.get("baud")))
+        check("demod: recovers a bitstream", d["ok"] and d["n_bits"] > 8 and set(d["bits"]) <= {"0", "1"},
+              str(d.get("n_bits")))
+        e = envelope("synth", n=300)
+        check("envelope: returns matched t/db arrays", len(e["t"]) == len(e["db"]) > 0)
+        p = psd("synth", n=256)
+        check("psd: freqs+db aligned, noise below peak",
+              len(p["freqs_mhz"]) == len(p["db"]) and max(p["db"]) - p["noise_db"] > 15)
+        check("list: the synth capture is listed",
+              any(c["name"] == "synth" for c in list_captures()["captures"]))
+        # pure bit slicer on a clean square wave
+        import numpy as np
+        sq = (np.arange(1000) // 10) % 2
+        baud, bits = _slice_bits(sq.astype(bool), 10000.0)
+        check("bits: clean 10-sample square -> ~1000 baud", abs(baud - 1000) < 120, str(baud))
+    finally:
+        globals()["_cap_dir"] = saved
+        import shutil
+        shutil.rmtree(tmp, ignore_errors=True)
+        _CACHE.clear()
+
+    passed = sum(1 for r in results if r["pass"])
+    return {"pass": passed == len(results), "passed": passed,
+            "total": len(results), "results": results}
+
+
+def _main(argv):
+    import argparse
+    ap = argparse.ArgumentParser(description="On-box SigMF IQ analyzer")
+    sub = ap.add_subparsers(dest="cmd")
+    sub.add_parser("selftest")
+    sub.add_parser("list")
+    ps = sub.add_parser("summary"); ps.add_argument("name")
+    args = ap.parse_args(argv)
+    if args.cmd == "selftest":
+        r = selftest()
+        for it in r["results"]:
+            print("  [%s] %s%s" % ("PASS" if it["pass"] else "FAIL", it["name"],
+                                   "" if it["pass"] else "  (%s)" % it["detail"]))
+        print("\n%d/%d checks pass — %s" % (r["passed"], r["total"], "OK" if r["pass"] else "FAIL"))
+        return 0 if r["pass"] else 1
+    if args.cmd == "list":
+        print(json.dumps(list_captures(), indent=2)); return 0
+    if args.cmd == "summary":
+        print(json.dumps(summary(args.name), indent=2)); return 0
+    ap.print_help(); return 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(_main(sys.argv[1:]))

--- a/webapp_modern.py
+++ b/webapp_modern.py
@@ -8735,6 +8735,17 @@ def rf_waterfall_page():
     return _no_store(make_response(send_from_directory('demos', 'rf_waterfall.html')))
 
 
+@app.route('/rf-analyzer')
+def rf_analyzer_page():
+    """Serve the on-box SigMF IQ Analyzer page.
+
+    Read-only over the RF Waterfall's SigMF captures (data/iq_captures/*), so it
+    needs no radio and is always served (it shows a "no captures yet" state when
+    empty). Login is required (not in the auth whitelist).
+    """
+    return _no_store(make_response(send_from_directory('demos', 'rf_analyzer.html')))
+
+
 @app.route('/adsb-radar')
 def adsb_radar_page():
     """Serve the ADS-B radar screen (live aircraft at 1090 MHz via dump1090).


### PR DESCRIPTION
This pull request introduces a new signal analysis page and enhances the existing RF Waterfall demo with improved SigMF session management and user guidance. The main changes are the addition of a comprehensive `Signal Analyzer` UI for on-device RF capture analysis, and expanded session controls and info popovers in the waterfall demo.

**Key changes:**

### New Signal Analyzer Demo

* Added a new standalone `rf_analyzer.html` page that provides an interactive UI for exploring SigMF IQ captures, including spectrogram, spectrum, envelope, burst/packet detection, and demodulation features. The UI is mobile-friendly and communicates with the backend via REST APIs for data and analysis.

### RF Waterfall Demo Enhancements

**Session Management:**

* Added a sessions dropdown and associated controls (`iqlist`, `iqopen`, `iqrename`, `iqdel`, `iqreload`) to the RF Waterfall UI, enabling users to select, open in the analyzer, rename, delete, and refresh SigMF capture sessions directly from the interface. Double-clicking a session also opens it in the analyzer.

**User Guidance:**

* Introduced an info popover (`infowrap`/`infopop`) explaining IQ capture sizes and memory usage, with guidance for low-memory devices and recommendations for large captures. This helps users avoid running out of RAM on constrained hardware. [[1]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404R149-R155) [[2]](diffhunk://#diff-5d66103b78d5f3f4ff3c4edf7a1611f22ed3ed2385e7d3a44de3191486851404R612-R641)

**Styling:**

* Added CSS for the new session controls and info popover to ensure a consistent and accessible user experience.

These updates significantly improve the usability and self-service capabilities of the RF analysis demos, especially for users working with multiple captures or on resource-limited devices.