### PR TITLE
feat(rf-analyzer): Segment 2 — measurement (cursors/Δ, box power, zoo…

### DIFF
--- a/demos/rf_analyzer.html
+++ b/demos/rf_analyzer.html
@@ -90,7 +90,11 @@
   <div class="grid">
     <div>
       <div class="card">
-        <h3>Spectrogram <span class="hint">drag a box to zoom · click to place a marker</span>
+        <h3>Spectrogram
+          <div class="seg" id="dragmode"><button data-dm="zoom" aria-pressed="true">Zoom</button><button data-dm="measure">Measure</button></div>
+          <button id="back" title="Back to the previous zoom">&#8592;&nbsp;Back</button>
+          <button id="clrcur" title="Clear the A/B cursors">Clear cursors</button>
+          <span class="hint">drag = zoom/measure · click = cursor A, then B (Δ)</span>
           <span class="legend"><span id="lfloor">—</span><span class="grad" id="grad"></span><span id="lceil">—</span></span>
         </h3>
         <div class="specwrap">
@@ -107,7 +111,9 @@
 
     <div>
       <div class="card">
-        <h3>Spectrum <span class="hint">avg power over the window</span></h3>
+        <h3>Spectrum <span class="hint">power over the window</span>
+          <div class="seg" id="psdmode" style="margin-left:auto"><button data-pm="avg" aria-pressed="true">Avg</button><button data-pm="max">Max-hold</button></div>
+        </h3>
         <canvas class="rowcanvas" id="psd"></canvas>
       </div>
       <div class="card" style="margin-top:16px">
@@ -116,7 +122,11 @@
         <div id="decout" class="msg">Hit Decode to run rtl_433 over the whole capture (TPMS · weather · remotes · doorbells…).</div>
       </div>
       <div class="card" style="margin-top:16px">
-        <h3>Bursts / packets <span class="hint" id="bcount"></span></h3>
+        <h3>Bursts / packets <span class="hint" id="bcount"></span>
+          <span class="lbl" style="margin-left:auto">merge gap</span>
+          <input id="gapms" type="number" value="25" min="1" step="1" style="width:58px" title="Bridge pulses closer than this (ms) into one burst — lower it to split repeated frames">
+          <span class="lbl">ms</span>
+        </h3>
         <div style="max-height:220px;overflow:auto">
           <table class="btable"><thead><tr><th>t (s)</th><th>dur</th><th>freq</th><th>BW</th><th>duty</th><th>dB</th></tr></thead>
             <tbody id="btbody"><tr><td class="empty" colspan="6">—</td></tr></tbody></table>
@@ -175,7 +185,8 @@
   var LUT=buildLUT(PALETTES[pal].stops);
 
   var $=function(id){return document.getElementById(id);};
-  var S={name:null, view:null, spec:null, marker:null, dur:0, fs:0, fc:0};
+  var S={name:null, view:null, spec:null, marker:null, markerB:null, hist:[],
+         dragMode:'zoom', psdMode:'avg', dur:0, fs:0, fc:0};
 
   function api(path,params){var q=Object.keys(params||{}).filter(function(k){return params[k]!=null;})
       .map(function(k){return k+'='+encodeURIComponent(params[k]);}).join('&');
@@ -203,7 +214,7 @@
   });}
 
   function loadCapture(name){
-    S.name=name; S.view=null; S.marker=null;
+    S.name=name; S.view=null; S.marker=null; S.markerB=null; S.hist=[];
     api('/api/net/rtl/analyze/summary',{name:name}).then(function(s){
       if(!s||!s.ok){ $('stats').innerHTML='<span class="msg">⚠ '+((s&&s.error)||'load failed')+'</span>'; return; }
       S.dur=s.duration_s; S.fs=s.sr_hz; S.fc=s.center_hz;
@@ -227,7 +238,7 @@
     var v=S.view, c=$('spec'), W=Math.max(320,Math.round(c.clientWidth||900));
     api('/api/net/rtl/analyze/spectrogram',{name:S.name,t0:v.t0,t1:v.t1,f0:v.f0,f1:v.f1,w:W,h:360}).then(function(d){
       if(!d||!d.ok)return; S.spec=d; drawSpec(d); });
-    api('/api/net/rtl/analyze/psd',{name:S.name,t0:v.t0,t1:v.t1}).then(drawPsd);
+    api('/api/net/rtl/analyze/psd',{name:S.name,t0:v.t0,t1:v.t1,mode:S.psdMode||'avg'}).then(drawPsd);
     api('/api/net/rtl/analyze/envelope',{name:S.name,t0:v.t0,t1:v.t1}).then(drawEnv);
   }
   var PAD={l:52,r:10,t:8,b:20};
@@ -255,18 +266,25 @@
     for(var xt=0;xt<=5;xt++){var tx=PAD.l+plotW*xt/5, tv=d.t0+(d.t1-d.t0)*xt/5;
       g.fillText(tv.toFixed(3)+'s',tx,PAD.t+plotH+4);}
     S._geom={plotW:plotW,plotH:plotH};
-    // marker
-    if(S.marker){var mx=PAD.l+(S.marker.t-d.t0)/(d.t1-d.t0)*plotW, my=PAD.t+(d.f1-S.marker.f)/(d.f1-d.f0)*plotH;
-      g.strokeStyle=getComputedStyle(document.documentElement).getPropertyValue('--accent')||'#f5b942';g.lineWidth=1;
-      g.beginPath();g.moveTo(mx,PAD.t);g.lineTo(mx,PAD.t+plotH);g.moveTo(PAD.l,my);g.lineTo(PAD.l+plotW,my);g.stroke();}
+    // A/B cursors (crosshairs); A=accent, B=cyan
+    function cross(m,color,label){ if(!m)return;
+      var mx=PAD.l+(m.t-d.t0)/(d.t1-d.t0)*plotW, my=PAD.t+(d.f1-m.f)/(d.f1-d.f0)*plotH;
+      if(mx<PAD.l-1||mx>PAD.l+plotW+1)mx=Math.max(PAD.l,Math.min(PAD.l+plotW,mx));
+      g.strokeStyle=color;g.lineWidth=1;g.beginPath();g.moveTo(mx,PAD.t);g.lineTo(mx,PAD.t+plotH);g.moveTo(PAD.l,my);g.lineTo(PAD.l+plotW,my);g.stroke();
+      g.fillStyle=color;g.font='bold 10px monospace';g.textAlign='left';g.textBaseline='top';g.fillText(label,mx+3,PAD.t+2);}
+    cross(S.marker,getComputedStyle(document.documentElement).getPropertyValue('--accent')||'#f5b942','A');
+    cross(S.markerB,getComputedStyle(document.documentElement).getPropertyValue('--cyan')||'#38bdc9','B');
     $('grad').style.background=gradCss(PALETTES[pal].stops);
     $('lfloor').textContent=Math.round(d.floor_db)+' dB'; $('lceil').textContent=Math.round(d.ceil_db)+' dB';
     setAx();
   }
-  function setAx(){var m=S.marker;
-    $('axinfo').innerHTML = m
-      ? 'Marker: <b>'+(m.f/1e6).toFixed(4)+' MHz</b> ('+fmtHz(m.f-S.fc)+' offset) · t=<b>'+m.t.toFixed(4)+' s</b>'
-      : 'Window: '+S.view.t0.toFixed(3)+'–'+S.view.t1.toFixed(3)+' s · '+(S.view.f0/1e6).toFixed(3)+'–'+(S.view.f1/1e6).toFixed(3)+' MHz';
+  function setAx(){var a=S.marker,b=S.markerB;
+    if(a&&b){ var dt=Math.abs(b.t-a.t), df=Math.abs(b.f-a.f);
+      $('axinfo').innerHTML='Δ  <b>Δt='+(dt*1000).toFixed(3)+' ms</b>  ·  <b>Δf='+fmtHz(df)+'</b>'
+        +(dt>0?'  ·  1/Δt=<b>'+(1/dt>=1000?(1/dt/1000).toFixed(2)+' kHz':(1/dt).toFixed(0)+' Hz')+'</b> (symbol rate)':'')
+        +'   ·   A '+(a.f/1e6).toFixed(4)+' MHz · B '+(b.f/1e6).toFixed(4)+' MHz'; return; }
+    if(a){ $('axinfo').innerHTML='Cursor A: <b>'+(a.f/1e6).toFixed(4)+' MHz</b> ('+fmtHz(a.f-S.fc)+' offset) · t=<b>'+a.t.toFixed(4)+' s</b>  ·  click again for B (Δ)'; return; }
+    $('axinfo').innerHTML='Window: '+S.view.t0.toFixed(3)+'–'+S.view.t1.toFixed(3)+' s · '+(S.view.f0/1e6).toFixed(3)+'–'+(S.view.f1/1e6).toFixed(3)+' MHz';
   }
   // ---- line plots (psd + envelope + demod wave) ----
   function plot(id,xs,ys,color,fill){
@@ -295,18 +313,41 @@
       box.style.left=x0+'px';box.style.top=y0+'px';box.style.width=Math.abs(e.clientX-drag.startX)+'px';box.style.height=Math.abs(e.clientY-drag.startY)+'px';});
     window.addEventListener('mouseup',function(e){ if(!drag)return; box.style.display='none';
       var moved=Math.abs(e.clientX-drag.startX)+Math.abs(e.clientY-drag.startY);
-      var b=toData(e);
-      if(moved<6){ S.marker={t:b.t,f:b.f}; $('bw').focus&&0; drawSpec(S.spec); setAx(); drag=null; return; }
+      var b=toData(e), sp=S.spec;
+      if(moved<6){ // click -> place/move A/B cursors
+        var p={t:b.t,f:b.f};
+        if(!S.marker){ S.marker=p; }
+        else if(!S.markerB){ S.markerB=p; }
+        else { var da=Math.hypot((S.marker.t-b.t)/(sp.t1-sp.t0),(S.marker.f-b.f)/(sp.f1-sp.f0));
+               var dbb=Math.hypot((S.markerB.t-b.t)/(sp.t1-sp.t0),(S.markerB.f-b.f)/(sp.f1-sp.f0));
+               if(da<=dbb) S.marker=p; else S.markerB=p; }
+        drawSpec(sp); setAx(); drag=null; return; }
       var t0=Math.min(drag.a.t,b.t),t1=Math.max(drag.a.t,b.t),f0=Math.min(drag.a.f,b.f),f1=Math.max(drag.a.f,b.f);
-      if(t1-t0>1e-4 && f1-f0>100){ S.view={t0:t0,t1:t1,f0:f0,f1:f1}; refreshWindow(); }
+      if(S.dragMode==='measure'){   // measure the boxed time×freq region, don't zoom
+        if(t1-t0>1e-5 && f1-f0>10){ $('axinfo').innerHTML='measuring…';
+          api('/api/net/rtl/analyze/measure',{name:S.name,t0:t0,t1:t1,f0:f0,f1:f1}).then(function(m){
+            if(!m||!m.ok){ $('axinfo').innerHTML='⚠ '+((m&&m.error)||'measure failed'); return; }
+            $('axinfo').innerHTML='Box '+(m.f0/1e6).toFixed(4)+'–'+(m.f1/1e6).toFixed(4)+' MHz · '+m.dt_ms+' ms  →  '
+              +'ch.power <b>'+m.channel_power_db+' dB</b> · peak <b>'+m.peak_db+' dB</b> @ '+(m.peak_hz/1e6).toFixed(4)+' MHz · mean '+m.mean_db+' dB'; }); }
+        drag=null; return; }
+      if(t1-t0>1e-4 && f1-f0>100){ S.hist.push(S.view); S.view={t0:t0,t1:t1,f0:f0,f1:f1}; refreshWindow(); }
       drag=null;});
   })();
-  $('reset').addEventListener('click',function(){ if(!S.name)return; S.view={t0:0,t1:S.dur,f0:S.fc-S.fs/2,f1:S.fc+S.fs/2}; S.marker=null; refreshWindow(); });
+  $('reset').addEventListener('click',function(){ if(!S.name)return; S.hist=[]; S.view={t0:0,t1:S.dur,f0:S.fc-S.fs/2,f1:S.fc+S.fs/2}; S.marker=null; S.markerB=null; refreshWindow(); });
+  $('back').addEventListener('click',function(){ if(S.hist.length){ S.view=S.hist.pop(); refreshWindow(); } });
+  $('clrcur').addEventListener('click',function(){ S.marker=null; S.markerB=null; if(S.spec){drawSpec(S.spec);} setAx(); });
+  $('dragmode').addEventListener('click',function(e){var b=e.target.closest('button');if(!b)return; S.dragMode=b.getAttribute('data-dm');
+    Array.prototype.forEach.call($('dragmode').querySelectorAll('button'),function(x){x.setAttribute('aria-pressed',x.getAttribute('data-dm')===S.dragMode?'true':'false');});});
+  $('psdmode').addEventListener('click',function(e){var b=e.target.closest('button');if(!b)return; S.psdMode=b.getAttribute('data-pm');
+    Array.prototype.forEach.call($('psdmode').querySelectorAll('button'),function(x){x.setAttribute('aria-pressed',x.getAttribute('data-pm')===S.psdMode?'true':'false');});
+    if(S.name){var v=S.view; api('/api/net/rtl/analyze/psd',{name:S.name,t0:v.t0,t1:v.t1,mode:S.psdMode}).then(drawPsd);}});
+  $('gapms').addEventListener('change',function(){ if(S.name) loadBursts(); });
 
   // ---- bursts ----
-  function loadBursts(){ api('/api/net/rtl/analyze/bursts',{name:S.name}).then(function(d){
+  function loadBursts(){ var gap=parseFloat($('gapms').value)||25;
+    api('/api/net/rtl/analyze/bursts',{name:S.name,gap_ms:gap}).then(function(d){
     var tb=$('btbody'), b=(d&&d.bursts)||[]; $('bcount').textContent=b.length?b.length+' detected':'';
-    if(!b.length){ tb.innerHTML='<tr><td class="empty" colspan="5">No bursts above the noise floor.</td></tr>'; return; }
+    if(!b.length){ tb.innerHTML='<tr><td class="empty" colspan="6">No bursts above the noise floor.</td></tr>'; return; }
     tb.innerHTML=b.map(function(x,i){return '<tr data-i="'+i+'"><td>'+x.t0.toFixed(4)+'</td><td>'+x.dur_ms+' ms</td><td>'+x.f_mhz.toFixed(4)+'</td><td>'+x.bw_khz+' kHz</td><td>'+(x.duty!=null?Math.round(x.duty*100)+'%':'—')+'</td><td>'+Math.round(x.peak_db)+'</td></tr>';}).join('');
     tb.querySelectorAll('tr').forEach(function(tr){tr.addEventListener('click',function(){var x=b[+tr.getAttribute('data-i')];
       var pad=(x.t1-x.t0)*0.5+0.002; S.view={t0:Math.max(0,x.t0-pad),t1:Math.min(S.dur,x.t1+pad),

--- a/docs/rf-analyzer-roadmap.md
+++ b/docs/rf-analyzer-roadmap.md
@@ -34,14 +34,17 @@ Turn "here are bits" into "here is what it says."
 - *Done when:* a real doorbell/TPMS capture names the device via rtl_433, and an
   unknown OOK signal yields clean per-packet hex.
 
-## Segment 2 — Measurement (inspectrum-grade)
-- Draggable **dual cursors** (time + frequency) with **Δt / Δf** readouts and the
-  implied **symbol rate** (1/Δt).
-- **Box power** measurement over a selection (channel power, peak, mean).
-- **Persistence / max-hold** on the spectrogram; **zoom history** (back).
-- Cleaner rulers (nice tick steps, absolute + relative axes).
-- *Done when:* you can measure a burst's timing and a channel's power to a number
-  without leaving the page.
+## Segment 2 — Measurement (inspectrum-grade) ✅ shipped
+- **Dual A/B cursors** (time + frequency) with **Δt / Δf** and the implied
+  **symbol rate** (1/Δt) — click for A, click again for B.
+- **Box power** measurement (Zoom↔Measure mode; drag a box → channel power, peak
+  freq+level, mean).
+- **Zoom history** (Back button) + Reset.
+- **Max-hold vs Avg** on the Spectrum panel (max-hold reveals intermittent
+  carriers a mean buries).
+- Follow-ups shipped alongside: burst **merge-gap** control (split repeated
+  frames vs one transmission) and **newest-first** capture ordering.
+- *Left for later:* on-spectrogram persistence, prettier ruler tick steps.
 
 ## Segment 3 — Modulation analysis
 - **IQ constellation** for a selection (PSK/QAM); **instantaneous** amplitude /

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -22154,7 +22154,14 @@ def register_network_diagnostics(app, logger=None):
     def net_rtl_analyze_psd():
         a = request.args
         return _analyze(sigmf_analyzer.psd, name=a.get('name', ''),
-                        t0=_fl(a.get('t0')), t1=_fl(a.get('t1')))
+                        t0=_fl(a.get('t0')), t1=_fl(a.get('t1')), mode=a.get('mode', 'avg'))
+
+    @app.route('/api/net/rtl/analyze/measure', methods=['GET'])
+    def net_rtl_analyze_measure():
+        a = request.args
+        return _analyze(sigmf_analyzer.measure, name=a.get('name', ''),
+                        t0=_fl(a.get('t0')), t1=_fl(a.get('t1')),
+                        f0=_fl(a.get('f0')), f1=_fl(a.get('f1')))
 
     @app.route('/api/net/rtl/analyze/envelope', methods=['GET'])
     def net_rtl_analyze_envelope():
@@ -22164,7 +22171,13 @@ def register_network_diagnostics(app, logger=None):
 
     @app.route('/api/net/rtl/analyze/bursts', methods=['GET'])
     def net_rtl_analyze_bursts():
-        return _analyze(sigmf_analyzer.bursts, name=request.args.get('name', ''))
+        a = request.args
+        kw = {"name": a.get('name', '')}
+        if _fl(a.get('gap_ms')) is not None:
+            kw["gap_ms"] = _fl(a.get('gap_ms'))
+        if _fl(a.get('thresh_db')) is not None:
+            kw["thresh_db"] = _fl(a.get('thresh_db'))
+        return _analyze(sigmf_analyzer.bursts, **kw)
 
     @app.route('/api/net/rtl/analyze/demod', methods=['GET'])
     def net_rtl_analyze_demod():

--- a/sigmf_analyzer.py
+++ b/sigmf_analyzer.py
@@ -88,10 +88,10 @@ def load(name):
 
 
 def list_captures():
-    """Every capture in the dir with both sidecars, newest first."""
+    """Every capture in the dir with both sidecars, **newest first** (by mtime)."""
     import glob
-    out = []
-    for meta_p in sorted(glob.glob(os.path.join(_cap_dir(), "*.sigmf-meta")), reverse=True):
+    rows = []
+    for meta_p in glob.glob(os.path.join(_cap_dir(), "*.sigmf-meta")):
         base = os.path.basename(meta_p)[:-len(".sigmf-meta")]
         data_p = meta_p[:-len(".sigmf-meta")] + ".sigmf-data"
         if not os.path.exists(data_p):
@@ -101,14 +101,16 @@ def list_captures():
             g, c = m.get("global", {}), (m.get("captures") or [{}])[0]
             fs = float(g.get("core:sample_rate") or 0)
             nbytes = os.path.getsize(data_p)
-            out.append({"name": base, "sr_hz": fs,
-                        "center_hz": c.get("core:frequency"),
-                        "datetime": c.get("core:datetime"),
-                        "bytes": nbytes,
-                        "duration_s": round(nbytes / 2 / fs, 3) if fs else None})
+            mtime = os.path.getmtime(data_p)
+            rows.append((mtime, {"name": base, "sr_hz": fs,
+                                 "center_hz": c.get("core:frequency"),
+                                 "datetime": c.get("core:datetime"),
+                                 "bytes": nbytes, "mtime": mtime,
+                                 "duration_s": round(nbytes / 2 / fs, 3) if fs else None}))
         except (OSError, ValueError):
             continue
-    return {"captures": out}
+    rows.sort(key=lambda r: r[0], reverse=True)      # newest capture first
+    return {"captures": [r[1] for r in rows]}
 
 
 # --------------------------------------------------------------------------
@@ -120,8 +122,10 @@ def _noise_floor_db(psd_db):
     return float(np.percentile(psd_db, 30))
 
 
-def welch_psd(iq, fs, nfft=4096):
-    """Averaged power spectrum (fftshifted), returns (freqs_hz, db). Pure-ish."""
+def welch_psd(iq, fs, nfft=4096, reduce="mean"):
+    """Power spectrum (fftshifted), returns (freqs_hz, db). ``reduce`` is
+    ``"mean"`` (averaged / Welch) or ``"max"`` (max-hold across time — reveals
+    intermittent carriers a mean would bury). Pure-ish."""
     import numpy as np
     n = len(iq)
     if n < nfft:
@@ -130,12 +134,19 @@ def welch_psd(iq, fs, nfft=4096):
     ncol = max(1, (n - nfft) // (nfft // 2) + 1)
     ncol = min(ncol, 400)
     starts = np.linspace(0, max(0, n - nfft), ncol).astype(int)
-    acc = np.zeros(nfft, dtype=np.float64)
+    acc = None
     for s in starts:
         seg = iq[s:s + nfft] * win
         S = np.fft.fftshift(np.fft.fft(seg))
-        acc += (S.real ** 2 + S.imag ** 2)
-    acc /= len(starts)
+        p = (S.real ** 2 + S.imag ** 2)
+        if acc is None:
+            acc = p.astype(np.float64)
+        elif reduce == "max":
+            np.maximum(acc, p, out=acc)
+        else:
+            acc += p
+    if reduce != "max":
+        acc /= len(starts)
     db = 10.0 * np.log10(acc / (nfft * float(np.sum(win ** 2))) + 1e-12)
     freqs = np.fft.fftshift(np.fft.fftfreq(nfft, 1.0 / fs))
     return freqs, db
@@ -261,21 +272,54 @@ def spectrogram(name, t0=None, t1=None, f0=None, f1=None, w=900, h=360, nfft=102
             "data": base64.b64encode(grid.tobytes()).decode("ascii")}
 
 
-def psd(name, t0=None, t1=None, n=900):
+def psd(name, t0=None, t1=None, n=900, mode="avg"):
+    """Power spectrum over [t0,t1]. ``mode`` = "avg" (Welch) or "max" (max-hold)."""
     import numpy as np
     iq, fs, fc, _ = load(name)
-    dur = len(iq) / fs
     i0 = 0 if t0 is None else max(0, int(float(t0) * fs))
     i1 = len(iq) if t1 is None else min(len(iq), int(float(t1) * fs))
-    freqs, db = welch_psd(iq[i0:i1] if i1 > i0 else iq, fs)
+    reduce = "max" if str(mode).lower().startswith("max") else "mean"
+    freqs, db = welch_psd(iq[i0:i1] if i1 > i0 else iq, fs, reduce=reduce)
     n = int(max(64, min(1600, n)))
     fr = (freqs + fc) / 1e6
     if len(db) > n:
         db = _pool_max(db, n)
         fr = fr[np.linspace(0, len(fr) - 1, n).astype(int)]
-    return {"ok": True, "freqs_mhz": [round(x, 4) for x in fr.tolist()],
+    return {"ok": True, "mode": reduce, "freqs_mhz": [round(x, 4) for x in fr.tolist()],
             "db": [round(x, 1) for x in db.tolist()],
             "noise_db": round(_noise_floor_db(db), 1)}
+
+
+def measure(name, t0, t1, f0, f1):
+    """Measure a time×frequency box: channel power, peak (freq+level), mean, span.
+
+    Integrates the Welch PSD of the [t0,t1] slice over [f0,f1] (absolute Hz).
+    Relative dB (consistent, not absolute dBm), matching the rest of the tool.
+    """
+    import numpy as np
+    iq, fs, fc, _ = load(name)
+    dur = len(iq) / fs
+    t0 = max(0.0, float(t0)); t1 = min(dur, float(t1))
+    i0, i1 = int(t0 * fs), int(t1 * fs)
+    if i1 - i0 < 16:
+        return {"ok": False, "error": "time selection too short"}
+    freqs, db = welch_psd(iq[i0:i1], fs)
+    absf = freqs + fc
+    f0, f1 = float(min(f0, f1)), float(max(f0, f1))
+    mask = (absf >= f0) & (absf <= f1)
+    if not mask.any():
+        return {"ok": False, "error": "frequency selection outside the capture"}
+    lin = 10.0 ** (db[mask] / 10.0)
+    sub = db[mask]; subf = absf[mask]
+    pk = int(np.argmax(sub))
+    return {"ok": True, "t0": round(t0, 5), "t1": round(t1, 5),
+            "f0": round(f0, 1), "f1": round(f1, 1),
+            "dt_ms": round((t1 - t0) * 1000, 3), "span_khz": round((f1 - f0) / 1e3, 2),
+            "channel_power_db": round(float(10.0 * np.log10(lin.sum() + 1e-12)), 1),
+            "peak_db": round(float(sub[pk]), 1),
+            "peak_hz": round(float(subf[pk]), 1),
+            "mean_db": round(float(10.0 * np.log10(lin.mean() + 1e-12)), 1),
+            "bins": int(mask.sum())}
 
 
 def envelope(name, t0=None, t1=None, n=1200):
@@ -593,6 +637,14 @@ def selftest():
         p = psd("synth", n=256)
         check("psd: freqs+db aligned, noise below peak",
               len(p["freqs_mhz"]) == len(p["db"]) and max(p["db"]) - p["noise_db"] > 15)
+        pm = psd("synth", n=256, mode="max")
+        check("psd: max-hold >= average at the peak and is labelled",
+              pm["mode"] == "max" and max(pm["db"]) >= max(p["db"]) - 0.5)
+        # measure a box around the +150 kHz tone
+        mb = measure("synth", 0.0, 0.2, 433_900_000 + 130_000, 433_900_000 + 170_000)
+        check("measure: box power + peak near +150 kHz tone",
+              mb["ok"] and abs(mb["peak_hz"] - (433_900_000 + 150_000)) < 8000
+              and mb["channel_power_db"] > mb["mean_db"], str(mb.get("peak_hz")))
         check("list: the synth capture is listed",
               any(c["name"] == "synth" for c in list_captures()["captures"]))
         # pure bit slicer on a clean square wave


### PR DESCRIPTION
…m history, max-hold) + follow-ups

Segment 2 ("Measurement", inspectrum-grade) on the analyzer page:
- Dual A/B cursors on the spectrogram (click A, click B) with Δt / Δf and the implied symbol rate (1/Δt); Clear-cursors button.
- Zoom↔Measure mode toggle: in Measure, drag a box -> sigmf_analyzer.measure() returns channel power / peak (freq+level) / mean over that time×freq region.
- Zoom history: Back button (stack of views) + Reset.
- Spectrum panel Avg vs Max-hold (welch_psd reduce="max"; psd mode param).

Requested follow-ups shipped with it:
- Burst merge-gap control (bursts gap_ms via /analyze/bursts?gap_ms=…) — lower it to split a continuous transmission into its repeated frames (e.g. 25ms→1 vs 5ms→9 on the real garage capture).
- list_captures() now sorts newest-first by mtime (+ returns mtime).

Backend: measure() + welch_psd max-hold + psd/bursts params; routes /analyze/measure and mode/gap_ms params. 18/18 selftests (measure, psd max-hold, merge). Validated on real captures (measure box, gap 25→1/5→9, newest-first list). Stacked on feature/analyzer-decode (Seg 1) — NOTE that PR isn't in main yet, so merge this branch to bring Seg 1 + burst fix + Seg 2 together.