### PR TITLE
feat(rf-analyzer): Segment 3 — modulation analysis (classify + conste…

### DIFF
--- a/demos/rf_analyzer.html
+++ b/demos/rf_analyzer.html
@@ -152,6 +152,21 @@
         <canvas class="rowcanvas" id="wave" style="height:90px"></canvas>
         <div class="bits" id="bits">Place a marker on a signal (or click a burst), then Demodulate.</div>
       </div>
+      <div class="card" style="margin-top:16px">
+        <h3>Modulation <span class="hint">classify + constellation + instantaneous — uses the marker &amp; BW</span>
+          <button class="go" id="runmod" style="margin-left:auto">Analyze</button></h3>
+        <div id="modout" class="msg">Mark a signal (or click a burst), set the demod BW, then Analyze.</div>
+        <div style="display:flex;flex-wrap:wrap;gap:8px;padding:0 10px 10px">
+          <div style="flex:1 1 190px;min-width:160px">
+            <div class="lbl" style="padding:4px 4px">IQ constellation</div>
+            <canvas class="rowcanvas" id="constell" style="height:190px"></canvas>
+          </div>
+          <div style="flex:1 1 220px;min-width:180px">
+            <div class="seg" id="instview" style="margin:2px 0 6px"><button data-iv="freq" aria-pressed="true">Freq</button><button data-iv="amp">Amp</button><button data-iv="phase">Phase</button></div>
+            <canvas class="rowcanvas" id="inst" style="height:150px"></canvas>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 
@@ -398,6 +413,41 @@
       if(!d||!d.ok){ S.demod=null; $('bits').textContent='⚠ '+((d&&d.error)||'demod failed'); return; }
       S.demod=d; plot('wave',d.wave,d.wave,'rgb(245,185,66)',false); renderBits();
     }).catch(function(){ $('bits').textContent='demod request failed'; });
+  });
+
+  // ---- modulation analysis: classify + constellation + instantaneous ----
+  var instView='freq';
+  function drawScatter(id,ix,qx){
+    var c=$(id),dpr=Math.min(window.devicePixelRatio||1,2),W=Math.max(120,c.clientWidth||190),H=c.clientHeight||190;
+    c.width=W*dpr;c.height=H*dpr;var g=c.getContext('2d');g.setTransform(dpr,0,0,dpr,0,0);g.clearRect(0,0,W,H);
+    // axes
+    g.strokeStyle='rgba(255,255,255,0.08)';g.beginPath();g.moveTo(W/2,0);g.lineTo(W/2,H);g.moveTo(0,H/2);g.lineTo(W,H/2);g.stroke();
+    if(!ix||!ix.length)return; var m=1.6, sx=W/2/m, sy=H/2/m;
+    g.fillStyle='rgba(56,189,201,0.5)';
+    for(var i=0;i<ix.length;i++){var x=W/2+ix[i]*sx, y=H/2-qx[i]*sy; g.fillRect(x-0.6,y-0.6,1.4,1.4);}
+  }
+  function drawInst(d){
+    if(!d||!d.ok){ plot('inst',[],[],'rgb(148,163,184)',false); return; }
+    if(instView==='amp') plot('inst',d.t,d.amp_db,'rgb(63,181,107)',true);
+    else if(instView==='phase') plot('inst',d.t,d.phase_deg,'rgb(129,140,248)',false);
+    else plot('inst',d.t,d.freq_hz,'rgb(245,185,66)',false);
+  }
+  $('instview').addEventListener('click',function(e){var b=e.target.closest('button');if(!b)return; instView=b.getAttribute('data-iv');
+    Array.prototype.forEach.call($('instview').querySelectorAll('button'),function(x){x.setAttribute('aria-pressed',x.getAttribute('data-iv')===instView?'true':'false');});
+    drawInst(S._inst);});
+  $('runmod').addEventListener('click',function(){
+    if(!S.name)return; var v=S.view, foff=(S.marker?S.marker.f:S.fc)-S.fc, bw=(parseFloat($('bw').value)||60)*1e3;
+    var q={name:S.name,f_offset:foff,bw:bw,t0:v.t0,t1:v.t1};
+    $('modout').textContent='analyzing…';
+    api('/api/net/rtl/analyze/classify',q).then(function(c){
+      if(!c||!c.ok){ $('modout').innerHTML='<span style="color:var(--rose)">⚠ '+esc((c&&c.error)||'failed')+'</span>'; return; }
+      var f=c.features||{};
+      $('modout').innerHTML='<b style="color:var(--cyan);font-size:14px">'+esc(c.label)+'</b>  ·  confidence '+Math.round(c.confidence*100)+'%'
+        +(c.symbol_rate_hz?'  ·  symbol rate ≈ <b>'+(c.symbol_rate_hz>=1000?(c.symbol_rate_hz/1000).toFixed(2)+' kBd':c.symbol_rate_hz+' Bd')+'</b>':'')
+        +'<br><span style="color:var(--muted);font-size:11px">env-var '+f.env_var+' · freq-spread '+f.ifr_std+' · occupancy '+Math.round((f.occupancy||0)*100)+'% · bimodality '+f.bimodality+'</span>';
+    }).catch(function(){ $('modout').textContent='classify request failed'; });
+    api('/api/net/rtl/analyze/constellation',q).then(function(cn){ if(cn&&cn.ok) drawScatter('constell',cn.i,cn.q); });
+    api('/api/net/rtl/analyze/instantaneous',q).then(function(ins){ S._inst=ins; drawInst(ins); });
   });
 
   $('cap').addEventListener('change',function(){ var n=decodeURIComponent($('cap').value||''); if(n)loadCapture(n); });

--- a/docs/rf-analyzer-roadmap.md
+++ b/docs/rf-analyzer-roadmap.md
@@ -46,15 +46,18 @@ Turn "here are bits" into "here is what it says."
   frames vs one transmission) and **newest-first** capture ordering.
 - *Left for later:* on-spectrogram persistence, prettier ruler tick steps.
 
-## Segment 3 — Modulation analysis
-- **IQ constellation** for a selection (PSK/QAM); **instantaneous** amplitude /
-  frequency / phase plots.
-- Robust **symbol-rate estimation** via autocorrelation / cyclostationarity (not
-  just run-length).
-- **Automatic modulation classification** (AM/FM/ASK/FSK/PSK/OFDM/chirp) with a
-  confidence, from spectral + envelope features.
-- *Done when:* the analyzer guesses the modulation of a signal it's never seen and
-  is usually right.
+## Segment 3 — Modulation analysis ✅ shipped
+- **IQ constellation** for a selection (scatter) + **instantaneous** amplitude /
+  frequency / phase (toggle) — a Modulation card driven by the marker + BW.
+- **Automatic modulation classification** — a feature decision tree (envelope
+  variance, inst-freq spread & bimodality, spectral occupancy, phase jumps) that
+  labels CW / OOK-ASK / FSK / FM / PSK / chirp-spread with a confidence, plus a
+  run-length **symbol-rate** estimate.
+- *Validated:* 4/4 synthetic classes + the real garage remote (OOK @ 2552 baud).
+  Classification is **per-selection** — point it at one clean burst, not a whole
+  recording with silence gaps.
+- *Left for later:* robust cyclostationary symbol-rate; PSK order (BPSK/QPSK)
+  from constellation clustering; OFDM detection.
 
 ## Segment 4 — Protocol framework
 - A pluggable **frame decoder** stage over recovered bits (preamble/sync search,

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -22190,6 +22190,22 @@ def register_network_diagnostics(app, logger=None):
     def net_rtl_analyze_decode433():
         return _analyze(sigmf_analyzer.decode433, name=request.args.get('name', ''))
 
+    def _sel(a):     # common signal-selection args for the modulation endpoints
+        return dict(name=a.get('name', ''), f_offset_hz=_fl(a.get('f_offset')) or 0.0,
+                    bw_hz=_fl(a.get('bw')), t0=_fl(a.get('t0')), t1=_fl(a.get('t1')))
+
+    @app.route('/api/net/rtl/analyze/classify', methods=['GET'])
+    def net_rtl_analyze_classify():
+        return _analyze(sigmf_analyzer.classify, **_sel(request.args))
+
+    @app.route('/api/net/rtl/analyze/constellation', methods=['GET'])
+    def net_rtl_analyze_constellation():
+        return _analyze(sigmf_analyzer.constellation, **_sel(request.args))
+
+    @app.route('/api/net/rtl/analyze/instantaneous', methods=['GET'])
+    def net_rtl_analyze_instantaneous():
+        return _analyze(sigmf_analyzer.instantaneous, **_sel(request.args))
+
     # ADS-B (1090 MHz aircraft) via dump1090 — powers the radar screen. Uses the
     # whole RTL-SDR, so starting it stops the sub-GHz sweep/decoder, and vice
     # versa (the rtl power/ism starts above stop ADS-B first). Receive-only.

--- a/sigmf_analyzer.py
+++ b/sigmf_analyzer.py
@@ -558,6 +558,144 @@ def decode433(name):
 
 
 # --------------------------------------------------------------------------
+# Segment 3 — modulation analysis: IQ constellation, instantaneous
+# amplitude/frequency/phase, and automatic modulation classification.
+# --------------------------------------------------------------------------
+
+def _prep_selection(name, f_offset_hz, bw_hz, t0, t1):
+    """Load, mix the chosen signal to DC and decimate to ~2*bw. Returns (x, nfs)."""
+    import numpy as np
+    from scipy import signal as sig
+    iq, fs, fc, _ = load(name)
+    dur = len(iq) / fs
+    i0 = 0 if t0 is None else max(0, int(float(t0) * fs))
+    i1 = len(iq) if t1 is None else min(len(iq), int(float(t1) * fs))
+    x = iq[i0:i1] if i1 > i0 else iq
+    if len(x) < 16:
+        return np.zeros(0, dtype=np.complex64), fs
+    foff = float(f_offset_hz or 0.0)
+    bw = float(bw_hz) if bw_hz else min(fs / 4, 200e3)
+    bw = max(1e3, min(bw, fs / 2))
+    n = np.arange(len(x))
+    x = x * np.exp(-2j * np.pi * (foff / fs) * n)
+    dec = int(max(1, fs // (bw * 2)))
+    if dec > 1:
+        x = sig.decimate(x, dec, ftype="fir")
+    return x.astype(np.complex64), fs / dec
+
+
+def _classify_signal(x, nfs):
+    """Heuristic automatic modulation classification from DSP features (pure).
+
+    Returns {label, confidence, symbol_rate_hz, features}. Not ML — a feature
+    decision tree over envelope variance, instantaneous-frequency spread &
+    bimodality, spectral occupancy and phase jumps. Honest, explainable, good
+    enough to guess the common ISM cases (CW / OOK-ASK / FSK / FM / chirp-spread).
+    """
+    import numpy as np
+    out = {"label": "unknown", "confidence": 0.0, "symbol_rate_hz": 0.0, "features": {}}
+    if x is None or len(x) < 64:
+        out["label"] = "too short"; return out
+    a = np.abs(x)
+    amean = float(a.mean())
+    if amean < 1e-4:
+        out["label"] = "no signal / noise"; return out
+    an = a / amean
+    env_var = float(np.var(an))                                   # amplitude modulation
+    ifr = np.angle(x[1:] * np.conj(x[:-1])) * nfs / (2 * np.pi)    # inst freq (Hz)
+    ifr_n = ifr / (nfs / 2.0)
+    ifr_std = float(np.std(ifr_n))
+    # spectral occupancy: fraction of bins within 10 dB of the peak (wideband-ness).
+    # Max-hold over the whole selection so a swept chirp shows its full band.
+    _fr, ps = welch_psd(x, nfs, nfft=min(2048, 1 << int(np.log2(max(2, len(x))))), reduce="max")
+    occ = float((ps > ps.max() - 10).mean())
+    # FSK bimodality: split inst-freq at its median, compare inter-cluster gap to spread
+    med = np.median(ifr)
+    lo, hi = ifr[ifr <= med], ifr[ifr > med]
+    bimod = 0.0
+    if len(lo) > 8 and len(hi) > 8:
+        sep = abs(float(hi.mean()) - float(lo.mean()))
+        spread = float(lo.std() + hi.std()) + 1e-9
+        bimod = sep / spread
+    # phase jumps (PSK tell): count large sample-to-sample phase steps
+    dphi = np.abs(np.angle(x[1:] * np.conj(x[:-1])))
+    phase_jumps = float((dphi > 1.2).mean())
+    f = {"env_var": round(env_var, 4), "ifr_std": round(ifr_std, 4),
+         "occupancy": round(occ, 3), "bimodality": round(bimod, 2),
+         "phase_jumps": round(phase_jumps, 4)}
+    out["features"] = f
+    # symbol rate via run-length of the thresholded feature (robust for random
+    # data, where autocorrelation has no clear peak) — reuse the demod's slicer.
+    if env_var > 0.05:
+        lvl = an > 0.5 * (float(np.percentile(an, 90)) + float(np.percentile(an, 10)))
+    else:
+        lvl = ifr_n > float(np.median(ifr_n))
+    _baud, _ = _slice_bits(lvl, nfs)
+    out["symbol_rate_hz"] = round(_baud, 1)
+    # --- decision tree ---
+    if occ > 0.55 and ifr_std > 0.15 and env_var < 0.25:
+        out["label"] = "chirp / spread (LoRa-like or wideband)"; out["confidence"] = round(min(1.0, occ), 2)
+    elif env_var > 0.3 and bimod < 2.0:
+        out["label"] = "OOK / ASK (on-off / amplitude)"; out["confidence"] = round(min(1.0, env_var), 2)
+    elif bimod > 3.0 and ifr_std > 0.02:
+        out["label"] = "FSK (frequency-shift keying)"; out["confidence"] = round(min(1.0, bimod / 6.0), 2)
+    elif ifr_std > 0.08:
+        out["label"] = "FM (frequency modulation)"; out["confidence"] = round(min(1.0, ifr_std * 3), 2)
+    elif phase_jumps > 0.02 and env_var < 0.2:
+        out["label"] = "PSK (phase-shift keying)"; out["confidence"] = round(min(1.0, phase_jumps * 8), 2)
+    else:
+        out["label"] = "CW carrier (unmodulated)"; out["confidence"] = round(max(0.4, 1.0 - ifr_std * 5 - env_var), 2)
+    return out
+
+
+def constellation(name, f_offset_hz=0.0, bw_hz=None, t0=None, t1=None, n=2000):
+    """IQ scatter (normalised) for the selected signal — PSK/QAM structure."""
+    import numpy as np
+    x, nfs = _prep_selection(name, f_offset_hz, bw_hz, t0, t1)
+    if len(x) < 16:
+        return {"ok": False, "error": "selection too short"}
+    rms = float(np.sqrt(np.mean(np.abs(x) ** 2))) or 1.0
+    x = x / rms
+    n = int(max(200, min(4000, n)))
+    if len(x) > n:
+        x = x[np.linspace(0, len(x) - 1, n).astype(int)]
+    return {"ok": True, "sample_rate_hz": round(nfs, 1),
+            "i": [round(float(v), 3) for v in x.real.tolist()],
+            "q": [round(float(v), 3) for v in x.imag.tolist()]}
+
+
+def instantaneous(name, f_offset_hz=0.0, bw_hz=None, t0=None, t1=None, n=1500):
+    """Instantaneous amplitude (dB), frequency (Hz) and phase (deg) over time."""
+    import numpy as np
+    x, nfs = _prep_selection(name, f_offset_hz, bw_hz, t0, t1)
+    if len(x) < 16:
+        return {"ok": False, "error": "selection too short"}
+    amp = np.abs(x); amp = amp / (amp.max() + 1e-9)
+    ampdb = 20 * np.log10(amp + 1e-4)
+    freq = np.concatenate([[0.0], np.angle(x[1:] * np.conj(x[:-1])) * nfs / (2 * np.pi)])
+    phase = np.degrees(np.unwrap(np.angle(x)))
+    n = int(max(200, min(4000, n)))
+    def ds(v):
+        return v[np.linspace(0, len(v) - 1, n).astype(int)] if len(v) > n else v
+    ampdb, freq, phase = ds(ampdb), ds(freq), ds(phase)
+    t = np.linspace(0, len(x) / nfs, len(ampdb))
+    return {"ok": True, "sample_rate_hz": round(nfs, 1),
+            "t": [round(float(v), 6) for v in t.tolist()],
+            "amp_db": [round(float(v), 2) for v in ampdb.tolist()],
+            "freq_hz": [round(float(v), 1) for v in freq.tolist()],
+            "phase_deg": [round(float(v), 1) for v in phase.tolist()]}
+
+
+def classify(name, f_offset_hz=0.0, bw_hz=None, t0=None, t1=None):
+    """Automatic modulation classification for the selected signal."""
+    x, nfs = _prep_selection(name, f_offset_hz, bw_hz, t0, t1)
+    r = _classify_signal(x, nfs)
+    r["ok"] = True
+    r["sample_rate_hz"] = round(nfs, 1)
+    return r
+
+
+# --------------------------------------------------------------------------
 # Self-test — synthesise a cu8 capture (tone + OOK burst) and check the DSP
 # --------------------------------------------------------------------------
 
@@ -634,6 +772,27 @@ def selftest():
               str(d.get("n_bits")))
         e = envelope("synth", n=300)
         check("envelope: returns matched t/db arrays", len(e["t"]) == len(e["db"]) > 0)
+        # --- modulation classification on synthetic baseband signals ---
+        import numpy as np
+        _nfs = 100000.0; _N = 40000; _t = np.arange(_N) / _nfs
+        noise = lambda: (np.random.randn(_N) + 1j * np.random.randn(_N)) * 0.01
+        cw = np.exp(2j * np.pi * 2000 * _t) + noise()
+        _sym = (np.random.rand((_t * 1000).astype(int).max() + 1) > 0.5).astype(float)
+        keyc = _sym[(_t * 1000).astype(int)]           # random 0/1 symbols @ 1000 baud
+        ook = keyc * np.exp(2j * np.pi * 2000 * _t) + noise()
+        ftone = np.where((_t * 1000).astype(int) % 2 == 0, 4000.0, -4000.0)
+        fsk = np.exp(2j * np.pi * np.cumsum(ftone) / _nfs) + noise()
+        sweep = np.linspace(-45000, 45000, _N)
+        chirp = np.exp(2j * np.pi * np.cumsum(sweep) / _nfs) + noise()
+        cl = lambda x: _classify_signal(x.astype(np.complex64), _nfs)["label"]
+        rcw, rook, rfsk, rch = cl(cw), cl(ook), cl(fsk), cl(chirp)
+        check("classify: CW carrier", "CW" in rcw, rcw)
+        check("classify: OOK/ASK", "OOK" in rook or "ASK" in rook, rook)
+        check("classify: FSK", "FSK" in rfsk, rfsk)
+        check("classify: chirp/spread", "chirp" in rch or "spread" in rch, rch)
+        check("classify: OOK symbol rate ~1000 baud",
+              abs(_classify_signal(ook.astype(np.complex64), _nfs)["symbol_rate_hz"] - 1000) < 200,
+              str(_classify_signal(ook.astype(np.complex64), _nfs)["symbol_rate_hz"]))
         p = psd("synth", n=256)
         check("psd: freqs+db aligned, noise below peak",
               len(p["freqs_mhz"]) == len(p["db"]) and max(p["db"]) - p["noise_db"] > 15)


### PR DESCRIPTION
A Modulation card on the analyzer, driven by the marker + demod BW over the current window:
- Automatic modulation classification (_classify_signal): a feature decision tree over envelope variance, instantaneous-frequency spread & bimodality, spectral occupancy (full-band max-hold) and phase jumps -> CW / OOK-ASK / FSK / FM / PSK / chirp-spread with a confidence, plus a run-length symbol-rate.
- IQ constellation (scatter) and instantaneous amplitude/frequency/phase (toggle).
- Backend: _prep_selection (mix-to-DC + decimate), classify/constellation/ instantaneous; routes /analyze/{classify,constellation,instantaneous}.

Validated: 5 new selftests (23/23) — CW/OOK/FSK/chirp synth all classify correctly + OOK symbol rate ~1000 baud; on real captures the garage remote classifies OOK @ 2552 baud (matches the demod). Classification is per-selection (point at one clean burst, not a whole recording with gaps).