### PR TITLE
feat(rf-analyzer): candidate frame lengths + per-candidate CRC scan

### DIFF
--- a/demos/rf_analyzer.html
+++ b/demos/rf_analyzer.html
@@ -65,6 +65,11 @@
   .bits{font-family:var(--mono);font-size:12px;color:var(--live);word-break:break-all;line-height:1.7;padding:10px 14px;background:var(--panel-2);
     border-top:1px solid var(--line-soft);max-height:150px;overflow:auto;white-space:pre-wrap}
   .msg{font-family:var(--mono);font-size:12px;color:var(--muted);padding:12px 14px}
+  .fcands{display:inline-flex;flex-wrap:wrap;gap:6px;margin-top:4px}
+  .fcand{font-family:var(--mono);font-size:11px;color:var(--ink-dim);background:var(--panel-2);border:1px solid var(--line);border-radius:6px;padding:4px 9px;cursor:pointer}
+  .fcand:hover{border-color:var(--cyan);color:var(--cyan)}
+  .fcand.hit{border-color:var(--live);color:var(--live)}
+  .fcand.cur{background:rgba(56,189,201,.14);color:var(--cyan);border-color:var(--cyan)}
   .aichips{display:flex;flex-wrap:wrap;gap:8px;padding:10px 14px 4px}
   .aichips button{font-family:var(--mono);font-size:11.5px;color:var(--ink-dim);background:var(--panel-2);border:1px solid var(--line);border-radius:16px;padding:6px 12px;cursor:pointer}
   .aichips button:hover{border-color:var(--cyan);color:var(--cyan)}
@@ -440,26 +445,39 @@
     Array.prototype.forEach.call($('bitview').querySelectorAll('button'),function(x){x.setAttribute('aria-pressed',x.getAttribute('data-v')===bitview?'true':'false');}); renderBits();});
   $('manch').addEventListener('click',function(){ manch=!manch; $('manch').setAttribute('aria-pressed',manch?'true':'false'); renderBits();});
   $('copybits').addEventListener('click',function(){ var t=S._bitsShown||''; if(navigator.clipboard)navigator.clipboard.writeText(t).catch(function(){}); });
-  $('frames').addEventListener('click',function(){
+  function runFrames(period){
     var d=S.demod; if(!d||!d.bits){ return; }
     var fo=$('framesout'); fo.hidden=false; fo.textContent='analysing frames…';
-    api('/api/net/rtl/analyze/frames',{bits:d.bits, line:(manch?'manchester':'raw')}).then(function(r){
+    var q={bits:d.bits, line:(manch?'manchester':'raw')}; if(period) q.period=period;
+    api('/api/net/rtl/analyze/frames',q).then(function(r){
       if(!r||!r.ok){ fo.innerHTML='<span style="color:var(--rose)">⚠ '+esc((r&&r.error)||'no structure')+'</span>'; return; }
       S.framesData=r;
+      var crcHtml=function(cm){return (cm&&cm.length)
+        ? '<span style="color:var(--live)">✓ CRC: '+cm.map(function(m){return esc(m.algo)+' ('+m.width+'b/'+m.over_bytes+'B)';}).join(', ')+'</span>'
+        : '<span style="color:var(--muted)">no CRC match</span>';};
       var lines=[];
       lines.push('preamble '+r.preamble_bits+' bits · '
-        +(r.period_bits?('frame period <b>'+r.period_bits+' bits</b> · '+r.repeats+' repeats · '
-          +Math.round(r.stable_fraction*100)+'% bits stable'+(r.identical?' (identical)':'')):'<span style="color:var(--muted)">no repeated frame found (jitter or single frame)</span>'));
+        +(r.period_bits?('frame length <b>'+r.period_bits+' bits</b> · '+r.repeats+' repeats · '
+          +Math.round(r.stable_fraction*100)+'% stable'+(r.identical?' (identical)':'')):'<span style="color:var(--muted)">no confident single period — try a candidate below</span>'));
       lines.push('consensus: <span style="color:var(--live)">'+esc(r.consensus_hex)+'</span>');
       if(r.period_bits && r.varying_positions && r.varying_positions.length)
         lines.push('<span style="color:var(--accent)">rolling/varying bit positions:</span> '+r.varying_positions.join(', '));
-      var cm=(r.crc&&r.crc.matches)||[];
-      lines.push(cm.length
-        ? '<span style="color:var(--live)">✓ CRC match:</span> '+cm.map(function(m){return esc(m.algo)+' ('+m.width+'-bit over '+m.over_bytes+' bytes)';}).join(' · ')
-        : '<span style="color:var(--muted)">no common CRC/checksum matched the trailer</span>');
-      fo.innerHTML=lines.join('<br>');
+      lines.push((r.crc&&r.crc.matches)?crcHtml(r.crc.matches):'');
+      // candidate frame lengths — clickable, each with its own CRC verdict
+      var cand=(r.candidates||[]);
+      if(cand.length){
+        var chips=cand.map(function(c){var hit=c.crc_matches&&c.crc_matches.length;
+          var cur=(c.period_bits===r.period_bits);
+          return '<button class="fcand'+(hit?' hit':'')+(cur?' cur':'')+'" data-p="'+c.period_bits+'" '
+            +'title="'+c.repeats+' repeats · '+Math.round(c.stable_fraction*100)+'% stable'+(hit?' · CRC '+esc(c.crc_matches[0].algo):'')+'">'
+            +c.period_bits+'b'+(hit?' ✓CRC':'')+'</button>';}).join('');
+        lines.push('<span style="color:var(--muted)">candidate frame lengths (click to align):</span><div class="fcands">'+chips+'</div>');
+      }
+      fo.innerHTML=lines.filter(Boolean).join('<br>');
+      fo.querySelectorAll('.fcand').forEach(function(b){ b.addEventListener('click',function(){ runFrames(+b.getAttribute('data-p')); }); });
     }).catch(function(){ fo.textContent='frame request failed'; });
-  });
+  }
+  $('frames').addEventListener('click',function(){ runFrames(); });
   function toHex(b){var h=[];for(var i=0;i+8<=b.length;i+=8)h.push(('0'+parseInt(b.substr(i,8),2).toString(16)).slice(-2));
     var r=b.length%8; var s=h.join(' '); if(r)s+=' +'+b.substr(b.length-r); return s;}
   function manchester(b){var o='';for(var i=0;i+2<=b.length;i+=2){var p=b.substr(i,2);o+=(p==='01'?'1':(p==='10'?'0':'?'));}return o;}
@@ -583,7 +601,7 @@
     if(a.action==='demod'){ if(a.mode) setDemodMode(a.mode); if(a.bw_khz!=null)$('bw').value=a.bw_khz; $('run').click(); return; }
     if(a.action==='classify'){ $('runmod').click(); return; }
     if(a.action==='frames'){ if(a.line==='manchester'&&!manch) $('manch').click();
-      else if((!a.line||a.line==='raw')&&manch) $('manch').click(); $('frames').click(); return; }
+      else if((!a.line||a.line==='raw')&&manch) $('manch').click(); runFrames(a.period_bits||undefined); return; }
     if(a.action==='decode433'){ $('rundec').click(); return; }
   }
   function renderAiActions(actions){

--- a/docs/rf-analyzer-roadmap.md
+++ b/docs/rf-analyzer-roadmap.md
@@ -69,12 +69,21 @@ Turn "here are bits" into "here is what it says."
 - **CRC/checksum scanner** (`crc_scan`): tries CRC-8 (× variants), CRC-16
   (CCITT/XMODEM/ARC/MODBUS), sum-8 and XOR-8 over the trailing byte(s) and reports
   matches — a ⌗ Frames button on the demod card.
-- *Validated:* 8 new selftests (30/30) — line decode, period=fundamental, fixed-
-  vs-rolling map, and an appended CRC-8 / sum-8 recovered. **Honest limit:** on
-  real run-length-recovered bits, timing jitter can defeat autocorrelation period
-  detection (real garage capture peaked at 0.43, below the 0.5 confidence gate) —
-  it then degrades to one frame + hex + CRC scan. Clean/clock-recovered bitstreams
-  align well. (Clock recovery is a later-segment improvement.)
+- **Candidate frame lengths + per-candidate CRC** (`_period_candidates` /
+  `_eval_period`): beyond the single autocorr fundamental, the tool ranks several
+  plausible frame lengths (autocorr peaks above a low floor + common byte-aligned
+  lengths), aligns each (from 0 AND after the preamble), and **CRC-scans each
+  independently**; a length whose trailer validates a CRC wins the headline.
+  Clickable candidate chips (force a length); the AI `frames` action can pass
+  `period_bits`. This directly fixes the jitter limitation below — on the real
+  garage bits (which the single-period pass returned "no period" for) it now
+  surfaces candidates incl. a **24-bit frame with a CRC match** (a lead to verify;
+  a short-frame CRC hit can be coincidental).
+- *Validated:* 40/40 selftests — line decode, period=fundamental, fixed-vs-rolling
+  map, appended CRC-8 / sum-8, candidate list incl. the true period, explicit
+  period honoured, CRC-validated length wins the headline. **Note:** run-length
+  demod jitter still weakens the *single* autocorr pick; candidates + CRC are the
+  mitigation. Clock recovery remains a later improvement.
 - *Left for later:* deeper rtl_433 hooks (per-protocol enable, raw pulse view),
   user-defined field layouts.
 

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -22210,7 +22210,8 @@ def register_network_diagnostics(app, logger=None):
     def net_rtl_analyze_frames():
         a = request.args
         bits = (a.get('bits', '') or '')[:8192]     # cap: a frame bitstream, not a file
-        return _analyze(sigmf_analyzer.frames, bits=bits, line=a.get('line', 'raw'))
+        return _analyze(sigmf_analyzer.frames, bits=bits, line=a.get('line', 'raw'),
+                        period=_fl(a.get('period')))
 
     # ADS-B (1090 MHz aircraft) via dump1090 — powers the radar screen. Uses the
     # whole RTL-SDR, so starting it stops the sub-GHz sweep/decoder, and vice

--- a/sigmf_analyzer.py
+++ b/sigmf_analyzer.py
@@ -773,6 +773,65 @@ def _repeat_period(bits, min_p=8):
     return 0
 
 
+def _period_candidates(bits, min_p=8, topk=6, floor=0.2):
+    """Ranked candidate frame periods from autocorrelation (pure, numpy).
+
+    Unlike :func:`_repeat_period` (which gates hard and returns one fundamental),
+    this returns *several* plausible periods even when the top peak is weak — so
+    a jittery real bitstream still offers frame lengths to try. Harmonics of an
+    already-listed candidate are collapsed to the fundamental.
+    """
+    import numpy as np
+    n = len(bits)
+    if n < min_p * 2:
+        return []
+    s = np.frombuffer(bits.encode(), dtype=np.uint8).astype(np.float32)
+    s = np.where(s == ord("1"), 1.0, -1.0)
+    s -= s.mean()
+    if s.std() < 1e-6:
+        return []
+    energy = float(np.dot(s, s)) / n + 1e-9
+    hi = n // 2
+    scored = []
+    for lag in range(min_p, hi + 1):
+        a, b = s[:-lag], s[lag:]
+        scored.append((float(np.dot(a, b) / len(a)) / energy, lag))
+    scored = [x for x in scored if x[0] >= floor]
+    scored.sort(reverse=True)                       # strongest correlation first
+    out = []
+    for c, lag in scored:
+        # collapse harmonics: skip a lag that's ~an integer multiple of one kept
+        if any(abs(lag - k * p) <= 1 for p in out for k in range(1, lag // p + 1)):
+            continue
+        out.append(lag)
+        if len(out) >= topk:
+            break
+    return out
+
+
+def _eval_period(bits, period, skip=0):
+    """Align a bitstream into frames of ``period`` (optionally after a ``skip``
+    preamble), build a consensus + stability map, and CRC-scan it (pure)."""
+    import numpy as np
+    body = bits[skip:]
+    nrep = len(body) // period
+    if period < 8 or nrep < 2:
+        return None
+    frames = [body[i * period:(i + 1) * period] for i in range(nrep)]
+    arr = np.array([[1 if ch == "1" else 0 for ch in f] for f in frames])
+    agree = arr.mean(axis=0)
+    consensus = "".join("1" if a >= 0.5 else "0" for a in agree)
+    stable = np.array([1.0 - 2 * min(a, 1 - a) for a in agree])
+    varying = [i for i, st in enumerate(stable) if st < 0.85]
+    crc = crc_scan(consensus)
+    return {"period_bits": period, "skip_bits": skip, "repeats": nrep,
+            "consensus_bits": consensus, "consensus_hex": _to_hex(consensus),
+            "varying_positions": varying[:200],
+            "stable_fraction": round(float((stable >= 0.85).mean()), 3),
+            "identical": len(varying) == 0,
+            "crc_matches": crc["matches"]}
+
+
 def _to_hex(bits):
     """Group a bit string into hex bytes (MSB first); trailing <8 bits appended."""
     out = []
@@ -785,40 +844,76 @@ def _to_hex(bits):
     return s
 
 
-def frame_analysis(bits):
-    """Structure a recovered bitstream: preamble, repeated-frame period, and a
-    per-bit stability map across repeats (constant code vs rolling bits) (pure).
+def frame_analysis(bits, period=None):
+    """Structure a recovered bitstream: preamble, repeated-frame period(s), a
+    per-bit stability map (fixed code vs rolling bits), and CRC per candidate.
 
     Aligning the repeated frames a remote transmits is *the* reverse-engineering
-    move: bits that never change across repeats are the fixed code / address;
-    bits that flip are a rolling code, counter or checksum.
+    move. Beyond the single best autocorrelation period, this returns a ranked
+    list of **candidate frame lengths** — each aligned (optionally after the
+    preamble), consensus-built and **CRC-scanned** — so a jittery real bitstream
+    still offers frame boundaries to try, and a length whose trailer validates a
+    CRC rises to the top. Pass ``period`` to force a specific frame length.
     """
-    import numpy as np
     bits = "".join(c for c in (bits or "") if c in "01")
     if len(bits) < 8:
         return {"ok": False, "error": "need at least 8 bits"}
     pre = _preamble(bits)
-    period = _repeat_period(bits)
+
+    # Build ranked candidate periods: the explicit one, the autocorr peaks, and
+    # a few common byte-aligned lengths — each evaluated aligned from 0 AND after
+    # the preamble, keeping whichever alignment reads better.
+    cand_periods = []
+    if period:
+        try:
+            cand_periods.append(int(period))
+        except (TypeError, ValueError):
+            pass
+    cand_periods += _period_candidates(bits)
+    for p in (24, 32, 40, 48, 64):                     # common ISM frame lengths
+        if 8 <= p <= len(bits) // 2:
+            cand_periods.append(p)
+    seen, evals = set(), []
+    for p in cand_periods:
+        if p in seen or p < 8:
+            continue
+        seen.add(p)
+        best_e = None
+        for skip in (0, pre if pre >= 4 else 0):
+            e = _eval_period(bits, p, skip)
+            if e and (best_e is None
+                      or (len(e["crc_matches"]), e["stable_fraction"])
+                      > (len(best_e["crc_matches"]), best_e["stable_fraction"])):
+                best_e = e
+        if best_e:
+            evals.append(best_e)
+    # rank: CRC match first, then most-stable, then most repeats
+    evals.sort(key=lambda e: (len(e["crc_matches"]) > 0, e["stable_fraction"], e["repeats"]),
+               reverse=True)
+    candidates = evals[:6]
+
     result = {"ok": True, "n_bits": len(bits), "preamble_bits": pre,
-              "period_bits": period}
-    if period >= 8:
-        nrep = len(bits) // period
-        frames = [bits[i * period:(i + 1) * period] for i in range(nrep)]
-        arr = np.array([[1 if ch == "1" else 0 for ch in f] for f in frames])
-        agree = arr.mean(axis=0)                       # fraction that are '1'
-        consensus = "".join("1" if a >= 0.5 else "0" for a in agree)
-        stable = np.array([1.0 - 2 * min(a, 1 - a) for a in agree])  # 1=constant,0=50/50
-        varying = [i for i, s in enumerate(stable) if s < 0.85]
-        result.update({"repeats": nrep, "consensus_bits": consensus,
-                       "consensus_hex": _to_hex(consensus),
-                       "varying_positions": varying[:200],
-                       "stable_fraction": round(float((stable >= 0.85).mean()), 3),
-                       "identical": len(varying) == 0})
+              "candidates": candidates}
+    # Headline pick: an explicit period, else a CRC-validated candidate, else the
+    # gated autocorr fundamental, else the whole blob (unchanged default).
+    forced = _eval_period(bits, int(period), 0) if period else None
+    crc_winner = next((e for e in candidates if e["crc_matches"]), None)
+    auto = _repeat_period(bits)
+    head = forced or crc_winner
+    if head is None and auto >= 8:
+        head = _eval_period(bits, auto, 0)
+    if head:
+        result["period_bits"] = head["period_bits"]
+        for k in ("repeats", "consensus_bits", "consensus_hex",
+                  "varying_positions", "stable_fraction", "identical"):
+            result[k] = head[k]
+        result["crc"] = {"checked": True, "matches": head["crc_matches"]}
     else:
+        result["period_bits"] = 0
         result.update({"repeats": 1, "consensus_bits": bits,
                        "consensus_hex": _to_hex(bits), "varying_positions": [],
                        "stable_fraction": 1.0, "identical": True})
-    result["crc"] = crc_scan(result["consensus_bits"])
+        result["crc"] = crc_scan(bits)
     return result
 
 
@@ -902,16 +997,21 @@ def _xor8(data):
     return x
 
 
-def frames(name=None, bits=None, line=None):
+def frames(name=None, bits=None, line=None, period=None):
     """Web entry: analyse a bitstream (raw or line-decoded) into frame structure.
 
     Pass ``bits`` directly (the demod output the page holds); ``line`` optionally
-    line-decodes first (manchester / nrzi / diff_manchester).
+    line-decodes first (manchester / nrzi / diff_manchester); ``period`` forces a
+    specific frame length (from clicking a candidate).
     """
     if not bits:
         return {"ok": False, "error": "no bits — demodulate a signal first"}
     b = line_decode(bits, line) if line and line != "raw" else bits
-    r = frame_analysis(b)
+    try:
+        period = int(period) if period else None
+    except (TypeError, ValueError):
+        period = None
+    r = frame_analysis(b, period=period)
     r["line"] = (line or "raw")
     r["decoded_bits"] = b
     return r
@@ -933,7 +1033,7 @@ _AI_ACTION_SCHEMA = {
                   "f0_mhz": (float, None), "f1_mhz": (float, None)},
     "demod":     {"mode": (str, {"ook", "fsk"}), "bw_khz": (float, None)},
     "classify":  {},
-    "frames":    {"line": (str, {"raw", "manchester", "nrzi"})},
+    "frames":    {"line": (str, {"raw", "manchester", "nrzi"}), "period_bits": (int, None)},
     "decode433": {},
     "reset":     {},
 }
@@ -1120,6 +1220,22 @@ def selftest():
         check("frame: fixed bits stable, rolling byte flagged varying",
               fa["repeats"] == 5 and any(p >= len(fixed) for p in fa["varying_positions"])
               and fa["stable_fraction"] < 1.0, str(fa.get("varying_positions"))[:60])
+        # candidate periods offered (incl. the true 32) + explicit period forcing
+        check("frame: candidate list offered incl. the true period",
+              any(c["period_bits"] == len(fixed) + 8 for c in fa["candidates"]),
+              str([c["period_bits"] for c in fa["candidates"]]))
+        check("frame: explicit period is honoured",
+              frame_analysis(fr_frames, period=len(fixed) + 8)["period_bits"] == len(fixed) + 8)
+        # a repeated 4-byte frame with a per-frame CRC-8 -> that length ranks first
+        # (its trailer validates a CRC) and is CRC-flagged in the candidate list.
+        one = [0x12, 0x34, 0x56]
+        one = one + [_crc8(one, 0x07)]
+        fbits = "".join(format(b, "08b") for b in one) * 6      # 32-bit frame ×6
+        fc2 = frame_analysis(fbits)
+        check("frame: CRC-validated frame length wins the headline",
+              fc2["period_bits"] == 32 and fc2["crc"]["matches"], str(fc2.get("period_bits")))
+        check("frame: a candidate carries its own CRC match",
+              any(c["period_bits"] == 32 and c["crc_matches"] for c in fc2["candidates"]))
         # CRC-8 appended over a known payload is recovered
         payload = [0xDE, 0xAD, 0xBE, 0xEF]
         crcv = _crc8(payload, 0x07)


### PR DESCRIPTION
The Frames tool found only ONE period (the autocorrelation fundamental) and, when that was weak — exactly the jittery run-length bits of a real remote — it gave up and CRC-scanned the whole blob as one frame. It never offered candidate frame lengths or ran CRC per candidate boundary (the reverse-engineering move).

- sigmf_analyzer._period_candidates(): ranked plausible periods from autocorr peaks above a low floor (harmonics collapsed to the fundamental).
- _eval_period(): align a bitstream into frames of a given length (from 0 or after the preamble), build consensus + stability, and CRC-scan it.
- frame_analysis(bits, period=None): returns a ranked `candidates` list, each aligned + CRC-scanned; a CRC-validated length wins the headline; `period` forces a specific length. Existing keys preserved (back-compat).
- frames()/route accept `period`; AI `frames` action gains optional `period_bits`.
- rf_analyzer.html: clickable candidate chips (green when a CRC matches) that re-align at that length.

Validated: 40/40 selftests (candidate list incl. the true period, explicit period honoured, CRC-validated length wins). On the REAL garage bits (previously "no period") it now surfaces candidates incl. a 24-bit frame with a CRC match — a lead to verify (a short-frame CRC hit can be coincidental).