### PR TITLE
feat(rf-analyzer): Segment 6 — SigMF annotations (label signals, roun…

### DIFF
--- a/demos/rf_analyzer.html
+++ b/demos/rf_analyzer.html
@@ -65,6 +65,11 @@
   .bits{font-family:var(--mono);font-size:12px;color:var(--live);word-break:break-all;line-height:1.7;padding:10px 14px;background:var(--panel-2);
     border-top:1px solid var(--line-soft);max-height:150px;overflow:auto;white-space:pre-wrap}
   .msg{font-family:var(--mono);font-size:12px;color:var(--muted);padding:12px 14px}
+  .annbar{display:flex;flex-wrap:wrap;gap:6px;align-items:center;padding:6px 14px;border-top:1px solid var(--line-soft);font-family:var(--mono);font-size:11px;color:var(--muted)}
+  .annbar .ann{display:inline-flex;align-items:center;gap:6px;background:rgba(63,181,107,.12);border:1px solid rgba(63,181,107,.4);border-radius:14px;padding:3px 6px 3px 10px;color:var(--live)}
+  .annbar .ann b{color:var(--ink);font-weight:600}
+  .annbar .ann button{background:none;border:0;color:var(--muted);cursor:pointer;font-size:13px;padding:0 2px}
+  .annbar .ann button:hover{color:var(--rose)}
   .fcands{display:inline-flex;flex-wrap:wrap;gap:6px;margin-top:4px}
   .fcand{font-family:var(--mono);font-size:11px;color:var(--ink-dim);background:var(--panel-2);border:1px solid var(--line);border-radius:6px;padding:4px 9px;cursor:pointer}
   .fcand:hover{border-color:var(--cyan);color:var(--cyan)}
@@ -115,7 +120,7 @@
     <div>
       <div class="card">
         <h3>Spectrogram
-          <div class="seg" id="dragmode"><button data-dm="zoom" aria-pressed="true">Zoom</button><button data-dm="measure">Measure</button></div>
+          <div class="seg" id="dragmode"><button data-dm="zoom" aria-pressed="true">Zoom</button><button data-dm="measure">Measure</button><button data-dm="annotate">Annotate</button></div>
           <button id="back" title="Back to the previous zoom">&#8592;&nbsp;Back</button>
           <button id="clrcur" title="Clear the A/B cursors">Clear cursors</button>
           <span class="hint">drag = zoom/measure · click = cursor A, then B (Δ)</span>
@@ -127,6 +132,7 @@
           <div class="specspin" id="specspin"><div class="ring"></div><span>computing spectrogram…</span></div>
         </div>
         <div class="axinfo" id="axinfo">—</div>
+        <div id="annbar" class="annbar" hidden></div>
       </div>
       <div class="card" style="margin-top:16px">
         <h3>Time envelope <span class="hint">amplitude over the shown window (AM/OOK view)</span></h3>
@@ -249,6 +255,8 @@
   function api(path,params){var q=Object.keys(params||{}).filter(function(k){return params[k]!=null;})
       .map(function(k){return k+'='+encodeURIComponent(params[k]);}).join('&');
     return fetch(path+(q?'?'+q:'')).then(function(r){return r.json();});}
+  function api2(path,body){return fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify(body||{})}).then(function(r){return r.json();});}
   function fmtHz(hz){var a=Math.abs(hz); if(a>=1e6)return (hz/1e6).toFixed(3)+' MHz'; if(a>=1e3)return (hz/1e3).toFixed(1)+' kHz'; return Math.round(hz)+' Hz';}
 
   // ---- palette selector ----
@@ -273,7 +281,7 @@
 
   function loadCapture(name){
     S.name=name; S.view=null; S.marker=null; S.markerB=null; S.hist=[];
-    S.summaryData=null; S.classifyData=null; S.framesData=null; S.demod=null; S.bursts=null;
+    S.summaryData=null; S.classifyData=null; S.framesData=null; S.demod=null; S.bursts=null; S.annotations=[];
     api('/api/net/rtl/analyze/summary',{name:name}).then(function(s){
       if(!s||!s.ok){ $('stats').innerHTML='<span class="msg">⚠ '+((s&&s.error)||'load failed')+'</span>'; return; }
       S.dur=s.duration_s; S.fs=s.sr_hz; S.fc=s.center_hz; S.summaryData=s;
@@ -288,7 +296,7 @@
         ['Bursts',s.bursts,'']
       ].map(function(x){return '<div class="stat"><span class="k">'+x[0]+'</span><span class="v '+x[2]+'">'+x[1]+'</span></div>';}).join('');
       S.view={t0:0,t1:S.dur,f0:S.fc-S.fs/2,f1:S.fc+S.fs/2};
-      refreshWindow(); loadBursts();
+      refreshWindow(); loadBursts(); loadAnnotations();
     });
   }
 
@@ -339,6 +347,17 @@
       g.fillStyle=color;g.font='bold 10px monospace';g.textAlign='left';g.textBaseline='top';g.fillText(label,mx+3,PAD.t+2);}
     cross(S.marker,getComputedStyle(document.documentElement).getPropertyValue('--accent')||'#f5b942','A');
     cross(S.markerB,getComputedStyle(document.documentElement).getPropertyValue('--cyan')||'#38bdc9','B');
+    // saved SigMF annotations: boxes + labels (freq-less ones span the band)
+    (S.annotations||[]).forEach(function(an){
+      var t0=Math.max(d.t0,an.t0), t1=Math.min(d.t1,an.t1); if(t1<=t0) return;
+      var f0=an.f0_mhz!=null?an.f0_mhz*1e6:d.f0, f1=an.f1_mhz!=null?an.f1_mhz*1e6:d.f1;
+      var x0=PAD.l+(t0-d.t0)/(d.t1-d.t0)*plotW, x1=PAD.l+(t1-d.t0)/(d.t1-d.t0)*plotW;
+      var ya=PAD.t+(d.f1-Math.min(f1,d.f1))/(d.f1-d.f0)*plotH, yb=PAD.t+(d.f1-Math.max(f0,d.f0))/(d.f1-d.f0)*plotH;
+      g.strokeStyle='rgba(63,181,107,0.9)';g.lineWidth=1;g.setLineDash([4,3]);
+      g.strokeRect(x0,Math.min(ya,yb),Math.max(2,x1-x0),Math.max(2,Math.abs(yb-ya)));g.setLineDash([]);
+      if(an.label){ g.fillStyle='rgba(63,181,107,0.95)';g.font='bold 10px monospace';g.textAlign='left';g.textBaseline='bottom';
+        g.fillText(an.label, x0+2, Math.min(ya,yb)-1); }
+    });
     $('grad').style.background=gradCss(PALETTES[pal].stops);
     $('lfloor').textContent=Math.round(d.floor_db)+' dB'; $('lceil').textContent=Math.round(d.ceil_db)+' dB';
     setAx();
@@ -395,6 +414,11 @@
             $('axinfo').innerHTML='Box '+(m.f0/1e6).toFixed(4)+'–'+(m.f1/1e6).toFixed(4)+' MHz · '+m.dt_ms+' ms  →  '
               +'ch.power <b>'+m.channel_power_db+' dB</b> · peak <b>'+m.peak_db+' dB</b> @ '+(m.peak_hz/1e6).toFixed(4)+' MHz · mean '+m.mean_db+' dB'; }); }
         drag=null; return; }
+      if(S.dragMode==='annotate'){   // draw a labelled box + save it into the .sigmf-meta
+        if(t1-t0>1e-5 && f1-f0>10){ var lab=(window.prompt('Label this signal (saved into the SigMF file):','')||'').trim();
+          if(lab!==null){ api2('/api/net/rtl/analyze/annotate',{name:S.name,t0:t0,t1:t1,f0:f0,f1:f1,label:lab}).then(function(r){
+            if(r&&r.ok){ S.annotations=r.annotations; renderAnnBar(); if(S.spec)drawSpec(S.spec); } }); } }
+        drag=null; return; }
       if(t1-t0>1e-4 && f1-f0>100){ S.hist.push(S.view); S.view={t0:t0,t1:t1,f0:f0,f1:f1}; refreshWindow(); }
       drag=null;});
   })();
@@ -402,7 +426,21 @@
   $('back').addEventListener('click',function(){ if(S.hist.length){ S.view=S.hist.pop(); refreshWindow(); } });
   $('clrcur').addEventListener('click',function(){ S.marker=null; S.markerB=null; if(S.spec){drawSpec(S.spec);} setAx(); });
   $('dragmode').addEventListener('click',function(e){var b=e.target.closest('button');if(!b)return; S.dragMode=b.getAttribute('data-dm');
-    Array.prototype.forEach.call($('dragmode').querySelectorAll('button'),function(x){x.setAttribute('aria-pressed',x.getAttribute('data-dm')===S.dragMode?'true':'false');});});
+    Array.prototype.forEach.call($('dragmode').querySelectorAll('button'),function(x){x.setAttribute('aria-pressed',x.getAttribute('data-dm')===S.dragMode?'true':'false');});
+    if(S.dragMode==='annotate'){ $('axinfo').innerHTML='<span style="color:var(--live)">Annotate mode: drag a box around a signal to label + save it into the SigMF file.</span>'; }});
+  function loadAnnotations(){ if(!S.name){return;} api('/api/net/rtl/analyze/annotations',{name:S.name}).then(function(r){
+    S.annotations=(r&&r.annotations)||[]; renderAnnBar(); if(S.spec)drawSpec(S.spec); }).catch(function(){}); }
+  function renderAnnBar(){ var el=$('annbar'), a=S.annotations||[];
+    if(!a.length){ el.hidden=true; el.innerHTML=''; return; }
+    el.hidden=false;
+    el.innerHTML='<span>annotations:</span>'+a.map(function(x){
+      var fr=(x.f0_mhz!=null?x.f0_mhz.toFixed(3)+'–'+x.f1_mhz.toFixed(3)+' MHz':'full band');
+      return '<span class="ann"><b>'+esc(x.label||'(unlabelled)')+'</b> '+x.t0.toFixed(3)+'–'+x.t1.toFixed(3)+'s · '+fr
+        +' <button data-i="'+x.index+'" title="Delete">✕</button></span>';}).join('');
+    el.querySelectorAll('button[data-i]').forEach(function(b){ b.addEventListener('click',function(){
+      api2('/api/net/rtl/analyze/annotation/delete',{name:S.name,index:+b.getAttribute('data-i')}).then(function(r){
+        if(r&&r.ok){ S.annotations=r.annotations; renderAnnBar(); if(S.spec)drawSpec(S.spec); } }); }); });
+  }
   $('psdmode').addEventListener('click',function(e){var b=e.target.closest('button');if(!b)return; S.psdMode=b.getAttribute('data-pm');
     Array.prototype.forEach.call($('psdmode').querySelectorAll('button'),function(x){x.setAttribute('aria-pressed',x.getAttribute('data-pm')===S.psdMode?'true':'false');});
     if(S.name){var v=S.view; api('/api/net/rtl/analyze/psd',{name:S.name,t0:v.t0,t1:v.t1,mode:S.psdMode}).then(drawPsd);}});

--- a/docs/rf-analyzer-roadmap.md
+++ b/docs/rf-analyzer-roadmap.md
@@ -94,11 +94,25 @@ Turn "here are bits" into "here is what it says."
 - **Decimate-on-load** option for very wide/long files.
 - *Done when:* a 30 s / 120 MB capture is analysable on a 512 MB board.
 
-## Segment 6 — SigMF annotations & interop
-- **Annotate on the spectrogram** — draw/label a signal box and **save it back to
-  the `.sigmf-meta` as SigMF annotations** (the IQEngine model); reload shows them.
-- **Export a selection** as a new SigMF sub-capture; export decoded bits / CSV.
-- *Done when:* annotations round-trip through the SigMF file and open elsewhere.
+## Segment 6 — SigMF annotations & interop ✅ shipped
+- **Annotate on the spectrogram** — an **Annotate** drag mode: drag a box around a
+  signal, label it, and it's **saved into the `.sigmf-meta` as a standard SigMF
+  annotation** (`core:sample_start`/`core:sample_count` + `core:freq_lower_edge`/
+  `core:freq_upper_edge` + `core:label`). Saved annotations draw as dashed
+  green boxes with labels and list as chips with ✕-delete under the spectrogram;
+  they load automatically when a capture opens (so a capture's band-label
+  annotation from capture time shows too).
+- **Round-trips / interop:** annotations persist in the SigMF file, so a capture
+  labelled here opens with its labels in IQEngine / inspectrum / any SigMF tool,
+  and vice-versa. Backend `add_annotation` / `list_annotations` /
+  `delete_annotation` (+ pure `_box_to_annotation`/`_annotation_to_box`); routes
+  `/analyze/{annotations,annotate,annotation/delete}`. Writes are user-only (not
+  in the AI action allowlist — those stay read-only).
+- *Validated:* 6 new selftests (46/46) — box↔annotation round-trip, add persists
+  in the file (interop-visible), delete, zero-span rejected; plus a real-capture
+  add→verify-in-file→delete.
+- *Left for later:* export a selection as a new SigMF sub-capture; export decoded
+  bits / CSV.
 
 ## Segment 7 — Advanced DSP
 - **Filter design + apply** (band-pass/notch) with before/after; export/listen.

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -22213,6 +22213,25 @@ def register_network_diagnostics(app, logger=None):
         return _analyze(sigmf_analyzer.frames, bits=bits, line=a.get('line', 'raw'),
                         period=_fl(a.get('period')))
 
+    # SigMF annotations (save/label a signal box into the .sigmf-meta; interop).
+    @app.route('/api/net/rtl/analyze/annotations', methods=['GET'])
+    def net_rtl_analyze_annotations():
+        return _analyze(sigmf_analyzer.list_annotations, name=request.args.get('name', ''))
+
+    @app.route('/api/net/rtl/analyze/annotate', methods=['POST'])
+    def net_rtl_analyze_annotate():
+        d = request.get_json(silent=True) or {}
+        return _analyze(sigmf_analyzer.add_annotation, name=d.get('name', ''),
+                        t0=_fl(d.get('t0')), t1=_fl(d.get('t1')),
+                        f0_hz=_fl(d.get('f0')), f1_hz=_fl(d.get('f1')),
+                        label=(d.get('label') or ''))
+
+    @app.route('/api/net/rtl/analyze/annotation/delete', methods=['POST'])
+    def net_rtl_analyze_annotation_delete():
+        d = request.get_json(silent=True) or {}
+        return _analyze(sigmf_analyzer.delete_annotation, name=d.get('name', ''),
+                        index=d.get('index'))
+
     # ADS-B (1090 MHz aircraft) via dump1090 — powers the radar screen. Uses the
     # whole RTL-SDR, so starting it stops the sub-GHz sweep/decoder, and vice
     # versa (the rtl power/ism starts above stop ADS-B first). Receive-only.

--- a/sigmf_analyzer.py
+++ b/sigmf_analyzer.py
@@ -1018,6 +1018,119 @@ def frames(name=None, bits=None, line=None, period=None):
 
 
 # --------------------------------------------------------------------------
+# SigMF annotations — draw/label a signal box on the spectrogram and save it
+# into the capture's .sigmf-meta as standard SigMF annotations (sample range +
+# freq edges + label). They round-trip through the file, so a capture annotated
+# here opens with its labels in IQEngine / inspectrum / any SigMF-aware tool,
+# and vice-versa. Pure box<->annotation helpers are selftested; add/list/delete
+# do the file read-modify-write.
+# --------------------------------------------------------------------------
+
+def _box_to_annotation(t0, t1, f0_hz, f1_hz, label, fs, fc=None):
+    """(time,freq) box -> a SigMF v1.0.0 annotation dict (pure)."""
+    a, b = sorted((float(t0), float(t1)))
+    s0 = max(0, int(round(a * fs)))
+    cnt = max(1, int(round((b - a) * fs)))
+    ann = {"core:sample_start": s0, "core:sample_count": cnt}
+    if f0_hz is not None and f1_hz is not None:
+        lo, hi = sorted((float(f0_hz), float(f1_hz)))
+        ann["core:freq_lower_edge"] = lo
+        ann["core:freq_upper_edge"] = hi
+    if label:
+        ann["core:label"] = str(label)[:200]
+    ann["core:generator"] = "Ragnar Signal Analyzer"
+    return ann
+
+
+def _annotation_to_box(ann, fs, fc=None):
+    """A SigMF annotation dict -> a UI-friendly box (pure)."""
+    s0 = int(ann.get("core:sample_start", 0) or 0)
+    cnt = int(ann.get("core:sample_count", 0) or 0)
+    t0 = s0 / fs if fs else 0.0
+    t1 = (s0 + cnt) / fs if (fs and cnt) else t0
+    fl = ann.get("core:freq_lower_edge")
+    fu = ann.get("core:freq_upper_edge")
+    return {"t0": round(t0, 6), "t1": round(t1, 6),
+            "f0_mhz": (round(float(fl) / 1e6, 6) if fl is not None else None),
+            "f1_mhz": (round(float(fu) / 1e6, 6) if fu is not None else None),
+            "label": ann.get("core:label") or ann.get("core:description") or "",
+            "sample_start": s0, "sample_count": cnt}
+
+
+def _read_meta(name):
+    _, meta_p = _paths(name)
+    if not os.path.exists(meta_p):
+        raise ValueError("capture not found")
+    with open(meta_p) as fh:
+        return json.load(fh), meta_p
+
+
+def _capture_fs_fc(meta):
+    g = meta.get("global", {}); c = (meta.get("captures") or [{}])[0]
+    return float(g.get("core:sample_rate") or 0) or 1.0, float(c.get("core:frequency") or 0)
+
+
+def list_annotations(name):
+    """Annotations stored in the capture's .sigmf-meta, as UI boxes."""
+    meta, _ = _read_meta(name)
+    fs, fc = _capture_fs_fc(meta)
+    anns = meta.get("annotations") or []
+    return {"ok": True, "annotations": [dict(_annotation_to_box(a, fs, fc), index=i)
+                                        for i, a in enumerate(anns)]}
+
+
+def add_annotation(name, t0, t1, f0_hz=None, f1_hz=None, label=None):
+    """Append a SigMF annotation to the capture's .sigmf-meta (read-modify-write).
+
+    Clamps the box to the capture's extent; keeps annotations sorted by
+    sample_start (the SigMF convention)."""
+    meta, meta_p = _read_meta(name)
+    fs, fc = _capture_fs_fc(meta)
+    _, meta_p2 = _paths(name)
+    data_p = meta_p[:-len(".sigmf-meta")] + ".sigmf-data"
+    nsamp = (os.path.getsize(data_p) // 2) if os.path.exists(data_p) else None
+    try:
+        t0 = float(t0); t1 = float(t1)
+    except (TypeError, ValueError):
+        return {"ok": False, "error": "t0/t1 must be numeric"}
+    dur = (nsamp / fs) if nsamp else max(t0, t1)
+    t0 = max(0.0, min(dur, t0)); t1 = max(0.0, min(dur, t1))
+    if abs(t1 - t0) < 1e-9:
+        return {"ok": False, "error": "annotation has zero time span"}
+    ann = _box_to_annotation(t0, t1, f0_hz, f1_hz, label, fs, fc)
+    anns = meta.get("annotations") or []
+    anns.append(ann)
+    anns.sort(key=lambda a: a.get("core:sample_start", 0))
+    meta["annotations"] = anns
+    try:
+        with open(meta_p, "w") as fh:
+            json.dump(meta, fh, indent=2)
+    except OSError as exc:
+        return {"ok": False, "error": "cannot write meta: %s" % exc}
+    return dict(list_annotations(name), added=_annotation_to_box(ann, fs, fc))
+
+
+def delete_annotation(name, index):
+    """Remove the annotation at ``index`` from the .sigmf-meta."""
+    meta, meta_p = _read_meta(name)
+    anns = meta.get("annotations") or []
+    try:
+        index = int(index)
+    except (TypeError, ValueError):
+        return {"ok": False, "error": "index must be an integer"}
+    if not (0 <= index < len(anns)):
+        return {"ok": False, "error": "annotation index out of range"}
+    anns.pop(index)
+    meta["annotations"] = anns
+    try:
+        with open(meta_p, "w") as fh:
+            json.dump(meta, fh, indent=2)
+    except OSError as exc:
+        return {"ok": False, "error": "cannot write meta: %s" % exc}
+    return list_annotations(name)
+
+
+# --------------------------------------------------------------------------
 # AI agent actions — the assistant may propose analyzer actions (tune, demod,
 # classify, …) as a JSON block; this parses/validates them into a safe,
 # allowlisted list the page executes against its existing controls. All actions
@@ -1281,6 +1394,29 @@ def selftest():
               and mb["channel_power_db"] > mb["mean_db"], str(mb.get("peak_hz")))
         check("list: the synth capture is listed",
               any(c["name"] == "synth" for c in list_captures()["captures"]))
+        # --- SigMF annotations round-trip ---
+        _b = _box_to_annotation(0.08, 0.12, 434_040_000, 434_060_000, "OOK burst", 1_000_000.0)
+        check("annot: box -> SigMF annotation (samples + freq edges + label)",
+              _b["core:sample_start"] == 80000 and _b["core:sample_count"] == 40000
+              and _b["core:freq_lower_edge"] == 434_040_000.0
+              and _b["core:label"] == "OOK burst", str(_b))
+        _rb = _annotation_to_box(_b, 1_000_000.0)
+        check("annot: annotation -> box round-trips t/f/label",
+              abs(_rb["t0"] - 0.08) < 1e-6 and abs(_rb["t1"] - 0.12) < 1e-6
+              and abs(_rb["f0_mhz"] - 434.04) < 1e-6 and _rb["label"] == "OOK burst")
+        r1 = add_annotation("synth", 0.08, 0.12, 434_040_000, 434_060_000, "burst A")
+        check("annot: add writes it to the .sigmf-meta + lists back",
+              r1["ok"] and any(a["label"] == "burst A" for a in r1["annotations"]))
+        # persisted on disk (reload the meta fresh)?
+        _m2, _ = _read_meta("synth")
+        check("annot: persisted in the SigMF file (interop-visible)",
+              any(a.get("core:label") == "burst A" for a in _m2.get("annotations", [])))
+        _idx = next(a["index"] for a in list_annotations("synth")["annotations"] if a["label"] == "burst A")
+        r2 = delete_annotation("synth", _idx)
+        check("annot: delete removes it",
+              r2["ok"] and not any(a["label"] == "burst A" for a in r2["annotations"]))
+        check("annot: clamped + zero-span rejected",
+              add_annotation("synth", 0.1, 0.1).get("ok") is False)
         # pure bit slicer on a clean square wave
         import numpy as np
         sq = (np.arange(1000) // 10) % 2


### PR DESCRIPTION
Draw/label a signal box on the spectrogram and save it into the capture's .sigmf-meta as a standard SigMF annotation, so analysis round-trips and opens in IQEngine / inspectrum / any SigMF tool.

- sigmf_analyzer: pure _box_to_annotation/_annotation_to_box (sample range + freq edges + label), and add_annotation/list_annotations/delete_annotation (file read-modify-write; clamps to capture extent; keeps annotations sorted by sample_start).
- network_diagnostics: routes /analyze/{annotations,annotate,annotation/delete}.
- rf_analyzer.html: an "Annotate" drag mode (drag a box -> prompt label -> save), saved annotations drawn as dashed green labelled boxes on the spectrogram + a chip bar with ✕-delete, auto-loaded when a capture opens. api2() POST helper.

Writes are user-only (kept OUT of the AI action allowlist — those stay read-only). Validated: 6 new selftests (46/46) — box↔annotation round-trip, add persists in the file (interop-visible), delete, zero-span rejected; plus a real capture add→verify-in-.sigmf-meta→delete. Page + Python syntax clean.