### PR TITLE
feat(rf-analyzer): I/Q sample plot (inspectrum's "Add sample plot")

### DIFF
--- a/demos/rf_analyzer.html
+++ b/demos/rf_analyzer.html
@@ -195,7 +195,7 @@
             <canvas class="rowcanvas" id="constell" style="height:190px"></canvas>
           </div>
           <div style="flex:1 1 220px;min-width:180px">
-            <div class="seg" id="instview" style="margin:2px 0 6px"><button data-iv="freq" aria-pressed="true">Freq</button><button data-iv="amp">Amp</button><button data-iv="phase">Phase</button></div>
+            <div class="seg" id="instview" style="margin:2px 0 6px"><button data-iv="iq">I/Q</button><button data-iv="freq" aria-pressed="true">Freq</button><button data-iv="amp">Amp</button><button data-iv="phase">Phase</button></div>
             <canvas class="rowcanvas" id="inst" style="height:150px"></canvas>
           </div>
         </div>
@@ -552,7 +552,20 @@
     if(!d||!d.ok){ plot('inst',[],[],'rgb(148,163,184)',false); return; }
     if(instView==='amp') plot('inst',d.t,d.amp_db,'rgb(63,181,107)',true);
     else if(instView==='phase') plot('inst',d.t,d.phase_deg,'rgb(129,140,248)',false);
+    else if(instView==='iq') plot2('inst',d.i,d.q,'rgb(245,185,66)','rgb(56,189,201)');  // sample plot: I & Q
     else plot('inst',d.t,d.freq_hz,'rgb(245,185,66)',false);
+  }
+  // two overlaid traces (raw I and Q), symmetric about 0 — the "sample plot".
+  function plot2(id,a,b,ca,cb){
+    var c=$(id),dpr=Math.min(window.devicePixelRatio||1,2),W=Math.max(200,c.clientWidth||300),H=c.clientHeight||120;
+    c.width=W*dpr;c.height=H*dpr;var g=c.getContext('2d');g.setTransform(dpr,0,0,dpr,0,0);g.clearRect(0,0,W,H);
+    if(!a||!a.length)return;
+    var m=1.05, py=function(v){return H/2-(v/m)*(H/2-3);}, px=function(i,n){return 6+i/(n-1)*(W-12);};
+    g.strokeStyle='rgba(255,255,255,0.08)';g.beginPath();g.moveTo(0,H/2);g.lineTo(W,H/2);g.stroke();
+    [[a,ca],[b,cb]].forEach(function(pair){var ys=pair[0];g.strokeStyle=pair[1];g.lineWidth=1;g.beginPath();
+      for(var i=0;i<ys.length;i++){var x=px(i,ys.length),y=py(ys[i]);i?g.lineTo(x,y):g.moveTo(x,y);}g.stroke();});
+    g.fillStyle=ca;g.font='9px monospace';g.textAlign='left';g.fillText('I',6,11);
+    g.fillStyle=cb;g.fillText('Q',16,11);
   }
   $('instview').addEventListener('click',function(e){var b=e.target.closest('button');if(!b)return; instView=b.getAttribute('data-iv');
     Array.prototype.forEach.call($('instview').querySelectorAll('button'),function(x){x.setAttribute('aria-pressed',x.getAttribute('data-iv')===instView?'true':'false');});

--- a/docs/rf-analyzer-roadmap.md
+++ b/docs/rf-analyzer-roadmap.md
@@ -47,6 +47,7 @@ Turn "here are bits" into "here is what it says."
 - *Left for later:* on-spectrogram persistence, prettier ruler tick steps.
 
 ## Segment 3 — Modulation analysis ✅ shipped
+- **Derived plots** (added 2026-09-11): the instantaneous toggle now includes an **I/Q sample plot** alongside Freq/Amp/Phase — inspectrum's full derived-plot set.
 - **IQ constellation** for a selection (scatter) + **instantaneous** amplitude /
   frequency / phase (toggle) — a Modulation card driven by the marker + BW.
 - **Automatic modulation classification** — a feature decision tree (envelope

--- a/sigmf_analyzer.py
+++ b/sigmf_analyzer.py
@@ -665,25 +665,32 @@ def constellation(name, f_offset_hz=0.0, bw_hz=None, t0=None, t1=None, n=2000):
 
 
 def instantaneous(name, f_offset_hz=0.0, bw_hz=None, t0=None, t1=None, n=1500):
-    """Instantaneous amplitude (dB), frequency (Hz) and phase (deg) over time."""
+    """Derived-plot data for a selection: the raw I/Q samples plus instantaneous
+    amplitude (dB), frequency (Hz) and phase (deg) over time — inspectrum's
+    sample / amplitude / frequency / phase plots."""
     import numpy as np
     x, nfs = _prep_selection(name, f_offset_hz, bw_hz, t0, t1)
     if len(x) < 16:
         return {"ok": False, "error": "selection too short"}
-    amp = np.abs(x); amp = amp / (amp.max() + 1e-9)
+    peak = float(np.max(np.abs(x))) + 1e-9
+    amp = np.abs(x) / peak
     ampdb = 20 * np.log10(amp + 1e-4)
     freq = np.concatenate([[0.0], np.angle(x[1:] * np.conj(x[:-1])) * nfs / (2 * np.pi)])
     phase = np.degrees(np.unwrap(np.angle(x)))
+    inphase = x.real / peak                       # normalised I and Q (the "sample plot")
+    quad = x.imag / peak
     n = int(max(200, min(4000, n)))
     def ds(v):
         return v[np.linspace(0, len(v) - 1, n).astype(int)] if len(v) > n else v
-    ampdb, freq, phase = ds(ampdb), ds(freq), ds(phase)
+    ampdb, freq, phase, inphase, quad = ds(ampdb), ds(freq), ds(phase), ds(inphase), ds(quad)
     t = np.linspace(0, len(x) / nfs, len(ampdb))
     return {"ok": True, "sample_rate_hz": round(nfs, 1),
             "t": [round(float(v), 6) for v in t.tolist()],
             "amp_db": [round(float(v), 2) for v in ampdb.tolist()],
             "freq_hz": [round(float(v), 1) for v in freq.tolist()],
-            "phase_deg": [round(float(v), 1) for v in phase.tolist()]}
+            "phase_deg": [round(float(v), 1) for v in phase.tolist()],
+            "i": [round(float(v), 3) for v in inphase.tolist()],
+            "q": [round(float(v), 3) for v in quad.tolist()]}
 
 
 def classify(name, f_offset_hz=0.0, bw_hz=None, t0=None, t1=None):


### PR DESCRIPTION
The Modulation card had amplitude/frequency/phase derived plots but not the raw sample plot. Add it so the analyzer matches inspectrum's Add-derived-plot set (sample / amplitude / frequency / phase).

- sigmf_analyzer.instantaneous(): also returns normalised raw I and Q arrays.
- rf_analyzer.html: an "I/Q" option in the derived-plot toggle draws I and Q as two overlaid traces about zero (plot2 helper).

Validated: instantaneous() returns aligned i/q (~[-1,1]) on a real capture; 46/46 selftests; page JS clean. Stacked on feature/analyzer-annotations (both touch these files, Seg 6 not yet in main).