### PR TITLE
feat(rf-analyzer): Segment 7 (start) — band-pass / notch filter with …

### DIFF
--- a/demos/rf_analyzer.html
+++ b/demos/rf_analyzer.html
@@ -218,6 +218,13 @@
           </div>
         </div>
       </div>
+      <div class="card" style="margin-top:16px">
+        <h3>Filter <span class="hint">band-pass isolates a signal · notch rejects an interferer — band from the A/B cursors or marker±BW</span>
+          <div class="seg" id="fkind" style="margin-left:auto"><button data-fk="bandpass" aria-pressed="true">Band-pass</button><button data-fk="notch">Notch</button></div>
+          <button class="go" id="runfilt">Apply</button></h3>
+        <div id="filtout" class="msg">Set a band (drop A &amp; B cursors, or a marker + BW), then Apply to see the spectrum before vs after.</div>
+        <canvas class="rowcanvas" id="filtcanvas" style="height:150px"></canvas>
+      </div>
     </div>
   </div>
 
@@ -652,6 +659,40 @@
     }).catch(function(){ $('modout').textContent='classify request failed'; });
     api('/api/net/rtl/analyze/constellation',q).then(function(cn){ if(cn&&cn.ok) drawScatter('constell',cn.i,cn.q); });
     api('/api/net/rtl/analyze/instantaneous',q).then(function(ins){ S._inst=ins; drawInst(ins); });
+  });
+
+  // ---- filter: band-pass / notch, spectrum before vs after ----
+  var fkind='bandpass';
+  $('fkind').addEventListener('click',function(e){var b=e.target.closest('button');if(!b)return; fkind=b.getAttribute('data-fk');
+    Array.prototype.forEach.call($('fkind').querySelectorAll('button'),function(x){x.setAttribute('aria-pressed',x.getAttribute('data-fk')===fkind?'true':'false');});});
+  function filterBand(){   // A/B cursors if both set, else marker ± demod BW
+    if(S.marker&&S.markerB) return [Math.min(S.marker.f,S.markerB.f), Math.max(S.marker.f,S.markerB.f)];
+    if(S.marker){ var bw=(parseFloat($('bw').value)||60)*1e3; return [S.marker.f-bw/2, S.marker.f+bw/2]; }
+    return null;
+  }
+  function drawFilt(d){
+    var c=$('filtcanvas'),dpr=Math.min(window.devicePixelRatio||1,2),W=Math.max(200,c.clientWidth||300),H=c.clientHeight||150;
+    c.width=W*dpr;c.height=H*dpr;var g=c.getContext('2d');g.setTransform(dpr,0,0,dpr,0,0);g.clearRect(0,0,W,H);
+    if(!d||!d.ok)return; var ys=d.db_before.concat(d.db_after),lo=Math.min.apply(null,ys),hi=Math.max.apply(null,ys); if(hi-lo<1){hi+=1;lo-=1;}
+    var n=d.freqs_mhz.length, px=function(i){return 6+i/(n-1)*(W-12);}, py=function(v){return H-4-(v-lo)/(hi-lo)*(H-10);};
+    // shade the filtered band
+    var fx=function(mhz){return px((mhz-d.freqs_mhz[0])/((d.freqs_mhz[n-1]-d.freqs_mhz[0])||1)*(n-1));};
+    g.fillStyle='rgba(245,185,66,0.10)';g.fillRect(fx(d.f0_mhz),0,Math.max(1,fx(d.f1_mhz)-fx(d.f0_mhz)),H);
+    var line=function(arr,col){g.strokeStyle=col;g.lineWidth=1;g.beginPath();for(var i=0;i<arr.length;i++){var x=px(i),y=py(arr[i]);i?g.lineTo(x,y):g.moveTo(x,y);}g.stroke();};
+    line(d.db_before,'rgba(139,152,171,0.7)'); line(d.db_after,'rgb(56,189,201)');
+    g.fillStyle='rgba(139,152,171,0.9)';g.font='9px monospace';g.textAlign='left';g.fillText('before',6,11);
+    g.fillStyle='rgb(56,189,201)';g.fillText('after',44,11);
+  }
+  $('runfilt').addEventListener('click',function(){
+    if(!S.name)return; var band=filterBand();
+    if(!band){ $('filtout').innerHTML='<span style="color:var(--accent)">Drop A &amp; B cursors around a band (or a marker), then Apply.</span>'; return; }
+    var v=S.view; $('filtout').textContent='filtering…';
+    api('/api/net/rtl/analyze/filter',{name:S.name,kind:fkind,f0:band[0],f1:band[1],t0:v.t0,t1:v.t1}).then(function(d){
+      if(!d||!d.ok){ $('filtout').innerHTML='<span style="color:var(--rose)">⚠ '+esc((d&&d.error)||'filter failed')+'</span>'; return; }
+      $('filtout').innerHTML=(d.kind==='bandpass'?'Band-pass':'Notch')+' '+d.f0_mhz.toFixed(4)+'–'+d.f1_mhz.toFixed(4)+' MHz  ·  '
+        +'<b>'+d.power_kept_pct+'%</b> of power kept';
+      drawFilt(d);
+    }).catch(function(){ $('filtout').textContent='filter request failed'; });
   });
 
   $('cap').addEventListener('change',function(){ var n=decodeURIComponent($('cap').value||''); if(n)loadCapture(n); });

--- a/docs/rf-analyzer-roadmap.md
+++ b/docs/rf-analyzer-roadmap.md
@@ -117,11 +117,16 @@ Turn "here are bits" into "here is what it says."
 - *Left for later:* export a selection as a new SigMF sub-capture; export decoded
   bits / CSV.
 
-## Segment 7 — Advanced DSP
-- **Filter design + apply** (band-pass/notch) with before/after; export/listen.
-- **LoRa / chirp** analysis (de-chirp view); **spectral correlation** (cyclo)
-  display; **multi-signal tracking** across time.
-- Long-capture **tiled waterfall** overview.
+## Segment 7 — Advanced DSP  (in progress)
+- **Filter design + apply** ✅ — band-pass (isolate a signal) / notch (reject an
+  interferer) over the A/B-cursor or marker±BW band, with a **spectrum
+  before-vs-after** plot and a power-kept %. FFT-domain band mask
+  (`_fft_bandmask` / `filter_preview`), route `/analyze/filter`, Filter card on
+  the page. 4 selftests (50/50); on the real garage capture band-pass/notch keep
+  37.5%/62.5% (sum 100%, complementary).
+- *Left for later:* **LoRa / chirp** de-chirp view; **spectral correlation**
+  (cyclostationary) display; **multi-signal tracking**; long-capture **tiled
+  waterfall** overview; filtered-audio export.
 - *Done when:* the analyzer handles chirp-spread and cyclostationary signals a
   plain spectrogram can't characterise.
 

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -22206,6 +22206,13 @@ def register_network_diagnostics(app, logger=None):
     def net_rtl_analyze_instantaneous():
         return _analyze(sigmf_analyzer.instantaneous, **_sel(request.args))
 
+    @app.route('/api/net/rtl/analyze/filter', methods=['GET'])
+    def net_rtl_analyze_filter():
+        a = request.args
+        return _analyze(sigmf_analyzer.filter_preview, name=a.get('name', ''),
+                        kind=a.get('kind', 'bandpass'), f0_hz=_fl(a.get('f0')),
+                        f1_hz=_fl(a.get('f1')), t0=_fl(a.get('t0')), t1=_fl(a.get('t1')))
+
     @app.route('/api/net/rtl/analyze/frames', methods=['GET'])
     def net_rtl_analyze_frames():
         a = request.args

--- a/sigmf_analyzer.py
+++ b/sigmf_analyzer.py
@@ -703,6 +703,58 @@ def classify(name, f_offset_hz=0.0, bw_hz=None, t0=None, t1=None):
 
 
 # --------------------------------------------------------------------------
+# Segment 7 — advanced DSP: apply a band-pass / notch filter to a selection and
+# show the spectrum before vs after (isolate one signal, or reject an
+# interferer). An FFT-domain band mask over absolute frequency — simple, exact
+# and pure, so the selftest can prove a tone survives a band-pass and vanishes
+# under a notch.
+# --------------------------------------------------------------------------
+
+def _fft_bandmask(x, fs, fc, f0_hz, f1_hz, kind):
+    """Zero the FFT bins outside (band-pass) or inside (notch) [f0,f1] Hz (pure)."""
+    import numpy as np
+    n = len(x)
+    X = np.fft.fftshift(np.fft.fft(x))
+    freqs = np.fft.fftshift(np.fft.fftfreq(n, 1.0 / fs)) + fc
+    lo, hi = (f0_hz, f1_hz) if f0_hz <= f1_hz else (f1_hz, f0_hz)
+    inband = (freqs >= lo) & (freqs <= hi)
+    mask = inband if str(kind).lower().startswith("band") else ~inband
+    xf = np.fft.ifft(np.fft.ifftshift(X * mask))
+    return xf.astype(np.complex64)
+
+
+def filter_preview(name, kind="bandpass", f0_hz=None, f1_hz=None, t0=None, t1=None, n=900):
+    """Band-pass/notch the [t0,t1] selection over [f0,f1] Hz; return the spectrum
+    before and after plus the fraction of power kept.  Absolute-frequency
+    filtering (bins mapped through the capture centre), not the mixed-to-DC path."""
+    import numpy as np
+    iq, fs, fc, _ = load(name)
+    i0 = 0 if t0 is None else max(0, int(float(t0) * fs))
+    i1 = len(iq) if t1 is None else min(len(iq), int(float(t1) * fs))
+    x = iq[i0:i1] if i1 > i0 else iq
+    if len(x) < 32:
+        return {"ok": False, "error": "selection too short to filter"}
+    if f0_hz is None or f1_hz is None:
+        return {"ok": False, "error": "give a frequency band (f0_hz, f1_hz)"}
+    f0_hz, f1_hz = float(f0_hz), float(f1_hz)
+    xf = _fft_bandmask(x, fs, fc, f0_hz, f1_hz, kind)
+    fb, db_b = welch_psd(x, fs)
+    fa, db_a = welch_psd(xf, fs)
+    p_in = float(np.mean(np.abs(x) ** 2)); p_out = float(np.mean(np.abs(xf) ** 2))
+    n = int(max(64, min(1600, n)))
+    fr = (fb + fc) / 1e6
+    if len(db_b) > n:
+        idx = np.linspace(0, len(db_b) - 1, n).astype(int)
+        db_b = _pool_max(db_b, n); db_a = _pool_max(db_a, n); fr = fr[idx]
+    return {"ok": True, "kind": ("bandpass" if str(kind).lower().startswith("band") else "notch"),
+            "f0_mhz": round(min(f0_hz, f1_hz) / 1e6, 4), "f1_mhz": round(max(f0_hz, f1_hz) / 1e6, 4),
+            "freqs_mhz": [round(v, 4) for v in fr.tolist()],
+            "db_before": [round(v, 1) for v in db_b.tolist()],
+            "db_after": [round(v, 1) for v in db_a.tolist()],
+            "power_kept_pct": round(100.0 * p_out / (p_in + 1e-12), 1)}
+
+
+# --------------------------------------------------------------------------
 # Segment 4 — protocol framework: line coding, preamble/sync detection,
 # repeated-frame alignment (fixed code vs rolling bits) and a CRC/checksum
 # scanner. All pure string/int math — the demodulator recovers the bits, this
@@ -1401,6 +1453,21 @@ def selftest():
               and mb["channel_power_db"] > mb["mean_db"], str(mb.get("peak_hz")))
         check("list: the synth capture is listed",
               any(c["name"] == "synth" for c in list_captures()["captures"]))
+        # --- Segment 7: band-pass / notch filter before-vs-after ---
+        _pk = 433_900_000 + 150_000                      # the synth CW tone
+        bp = filter_preview("synth", "bandpass", _pk - 40_000, _pk + 40_000, 0, 0.2)
+        bpk = bp["freqs_mhz"].index(min(bp["freqs_mhz"], key=lambda f: abs(f - _pk / 1e6)))
+        check("filter: band-pass keeps the in-band tone",
+              bp["ok"] and bp["db_after"][bpk] > bp["db_before"][bpk] - 3
+              and bp["power_kept_pct"] > 5, str(bp.get("power_kept_pct")))
+        nt = filter_preview("synth", "notch", _pk - 40_000, _pk + 40_000, 0, 0.2)
+        ntk = nt["freqs_mhz"].index(min(nt["freqs_mhz"], key=lambda f: abs(f - _pk / 1e6)))
+        check("filter: notch removes the in-band tone (>=20 dB drop)",
+              nt["db_before"][ntk] - nt["db_after"][ntk] >= 20, str(nt["db_before"][ntk] - nt["db_after"][ntk]))
+        check("filter: complementary masks' kept power sums to ~100%",
+              abs(bp["power_kept_pct"] + nt["power_kept_pct"] - 100.0) < 5.0,
+              str(bp["power_kept_pct"]) + "+" + str(nt["power_kept_pct"]))
+        check("filter: needs a band", filter_preview("synth", "bandpass").get("ok") is False)
         # --- SigMF annotations round-trip ---
         _b = _box_to_annotation(0.08, 0.12, 434_040_000, 434_060_000, "OOK burst", 1_000_000.0)
         check("annot: box -> SigMF annotation (samples + freq edges + label)",


### PR DESCRIPTION
Apply a filter to a selection and see the spectrum change: band-pass to isolate one signal, notch to reject an interferer.

- sigmf_analyzer: _fft_bandmask (zero FFT bins outside/inside an absolute-freq band) + filter_preview (band-pass/notch over [t0,t1]×[f0,f1], returns spectrum before + after + % power kept).
- network_diagnostics: route /analyze/filter.
- rf_analyzer.html: a Filter card — Band-pass/Notch toggle, band taken from the A/B cursors (or marker±BW), Apply draws before (grey) + after (cyan) PSD with the filtered band shaded, and shows power-kept %.

Validated: 4 new selftests (50/50) — band-pass keeps the in-band tone, notch drops it >=20 dB, complementary masks sum to ~100% power, band required. On the real garage capture band-pass/notch keep 37.5%/62.5% (sum 100%). Stacked on the symbol-cursor/stacked-plots branch (both touch the analyzer, not yet in main).