### PR TITLE
feat(rf-analyzer): cyclostationary symbol-rate detector (Segment 7)

### DIFF
--- a/demos/rf_analyzer.html
+++ b/demos/rf_analyzer.html
@@ -231,6 +231,13 @@
         <canvas class="rowcanvas" id="filtcanvas" style="height:150px"></canvas>
       </div>
       <div class="card" style="margin-top:16px">
+        <h3>Cyclostationary <span class="hint">finds the symbol rate even in random data — a cyclic feature the PSD can't show</span>
+          <button class="go" id="runcyc" style="margin-left:auto">Detect</button></h3>
+        <div id="cycout" class="msg">Centre on a signal (marker), then Detect — peaks mark candidate symbol rates.</div>
+        <div style="padding:0 14px 6px"><canvas class="rowcanvas" id="cyccanvas" style="height:140px"></canvas></div>
+        <div id="cycpeaks" class="symbar" style="padding:0 14px 10px"></div>
+      </div>
+      <div class="card" style="margin-top:16px">
         <h3>LoRa de-chirp <span class="hint">collapse chirps to symbol tones — centre on the signal (marker), pick BW+SF</span>
           <button class="go" id="rundechirp" style="margin-left:auto">De-chirp</button></h3>
         <div class="symbar" style="padding:6px 14px 8px">
@@ -771,6 +778,40 @@
       drawGrid('loracanvas',d);
       $('lorasyms').textContent=d.locked?('symbols: '+d.symbols.slice(0,64).join(' ')):'';
     }).catch(function(){ $('loraout').textContent='de-chirp request failed'; });
+  });
+
+  // ---- cyclostationary symbol-rate detector ----
+  function drawProfile(id,fx,py,peaks){
+    var c=$(id),dpr=Math.min(window.devicePixelRatio||1,2),W=Math.max(200,c.clientWidth||300),H=c.clientHeight||140;
+    c.width=W*dpr;c.height=H*dpr;var g=c.getContext('2d');g.setTransform(dpr,0,0,dpr,0,0);g.clearRect(0,0,W,H);
+    if(!py||!py.length)return; var hi=Math.max.apply(null,py)||1, n=py.length;
+    var X=function(i){return 6+i/(n-1)*(W-12);}, Y=function(v){return H-16-v/hi*(H-24);};
+    g.strokeStyle='rgb(56,189,201)';g.lineWidth=1;g.beginPath();
+    for(var i=0;i<n;i++){var x=X(i),y=Y(py[i]);i?g.lineTo(x,y):g.moveTo(x,y);} g.stroke();
+    // mark peaks + freq labels
+    (peaks||[]).forEach(function(p){ var idx=Math.round((p.symbol_rate_hz-fx[0])/((fx[n-1]-fx[0])||1)*(n-1));
+      idx=Math.max(0,Math.min(n-1,idx)); var x=X(idx);
+      g.strokeStyle='rgba(245,185,66,0.7)';g.setLineDash([2,3]);g.beginPath();g.moveTo(x,0);g.lineTo(x,H-14);g.stroke();g.setLineDash([]);
+      g.fillStyle='var(--accent)';g.fillStyle='#f5b942';g.font='9px monospace';g.textAlign='center';
+      g.fillText((p.symbol_rate_hz>=1000?(p.symbol_rate_hz/1000).toFixed(1)+'k':Math.round(p.symbol_rate_hz)),x,H-3); });
+    g.fillStyle='rgba(205,214,228,.55)';g.font='9px monospace';g.textAlign='left';g.fillText('cycle freq (symbol rate) →',6,11);
+  }
+  $('runcyc').addEventListener('click',function(){
+    if(!S.name)return; var v=S.view, foff=(S.marker?S.marker.f:S.fc)-S.fc;
+    $('cycout').textContent='detecting…'; $('cycpeaks').innerHTML='';
+    api('/api/net/rtl/analyze/cyclic',{name:S.name,f_offset:foff,t0:v.t0,t1:v.t1}).then(function(d){
+      if(!d||!d.ok){ $('cycout').innerHTML='<span style="color:var(--rose)">⚠ '+esc((d&&d.error)||'failed')+'</span>'; drawProfile('cyccanvas',[],[],[]); return; }
+      var fmt=function(hz){return hz>=1000?(hz/1000).toFixed(2)+' kBd':Math.round(hz)+' Bd';};
+      $('cycout').innerHTML=d.top_symbol_rate_hz
+        ? 'symbol rate ≈ <b style="color:'+(d.locked?'var(--live)':'var(--accent)')+'">'+fmt(d.top_symbol_rate_hz)+'</b> · strength '+d.top_strength+(d.locked?' ✓':' (weak/uncertain)')
+        : '<span style="color:var(--muted)">no clear cyclostationary feature — try a cleaner burst / different marker</span>';
+      drawProfile('cyccanvas',d.freqs_hz,d.profile,d.peaks);
+      // clickable candidate rates -> feed the symbol tool + LoRa nothing
+      $('cycpeaks').innerHTML=(d.peaks||[]).length?'<span class="lbl">candidates:</span>'+d.peaks.map(function(p){
+        return '<button class="fcand" data-b="'+p.symbol_rate_hz+'">'+fmt(p.symbol_rate_hz)+' ('+p.strength+')</button>';}).join(''):'';
+      $('cycpeaks').querySelectorAll('button[data-b]').forEach(function(b){ b.addEventListener('click',function(){
+        var bd=parseFloat(b.getAttribute('data-b'))||0; if(bd>0){ symState.on=true; $('symtog').setAttribute('aria-pressed','true'); symState.off=0; setBaud(bd); } }); });
+    }).catch(function(){ $('cycout').textContent='cyclic request failed'; });
   });
 
   $('cap').addEventListener('change',function(){ var n=decodeURIComponent($('cap').value||''); if(n)loadCapture(n); });

--- a/docs/rf-analyzer-roadmap.md
+++ b/docs/rf-analyzer-roadmap.md
@@ -135,9 +135,19 @@ Turn "here are bits" into "here is what it says."
   LoRa decoder (no sync/Gray/interleave/FEC/CRC/header). On the real weak
   Meshtastic RTL capture it did **not** lock across an SF/BW/offset sweep (faint
   packet in a 1 MS/s recording) — the lock readout says so honestly.
-- *Left for later:* **spectral correlation** (cyclostationary) display;
-  **multi-signal tracking**; long-capture **tiled waterfall** overview;
-  filtered-audio export.
+- **Cyclostationary symbol-rate detector** ✅ — a cyclic-feature profile from the
+  transition energy |x[n]-x[n-1]|² (whose spectrum lines up at the symbol rate
+  even for *random* data — the point of cyclostationarity), with harmonic→
+  fundamental resolution, a strength/lock readout and clickable candidate rates
+  that feed the symbol tool. `_cyclic_profile`/`_fundamental_rate`/`cyclic()`;
+  route `/analyze/cyclic`; a Cyclostationary card. 4 selftests (59/59), stable
+  over repeated random runs — OOK 5k/20k + BPSK land on the true baud, CW shows
+  no confident feature. HONEST: targets amplitude/phase-transition mods
+  (OOK/ASK/PSK); FSK / very weak / very low baud read low-confidence (the
+  strength says so). It's a symbol-rate cyclic feature, not the full 2-D SCF
+  surface.
+- *Left for later:* full 2-D **spectral-correlation** surface; **multi-signal
+  tracking**; long-capture **tiled waterfall** overview; filtered-audio export.
 - *Done when:* the analyzer handles chirp-spread and cyclostationary signals a
   plain spectrogram can't characterise.
 

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -22221,6 +22221,13 @@ def register_network_diagnostics(app, logger=None):
                         f_offset_hz=_fl(a.get('f_offset')) or 0.0,
                         t0=_fl(a.get('t0')), t1=_fl(a.get('t1')))
 
+    @app.route('/api/net/rtl/analyze/cyclic', methods=['GET'])
+    def net_rtl_analyze_cyclic():
+        a = request.args
+        return _analyze(sigmf_analyzer.cyclic, name=a.get('name', ''),
+                        f_offset_hz=_fl(a.get('f_offset')) or 0.0,
+                        t0=_fl(a.get('t0')), t1=_fl(a.get('t1')), amax_hz=_fl(a.get('amax')))
+
     @app.route('/api/net/rtl/analyze/frames', methods=['GET'])
     def net_rtl_analyze_frames():
         a = request.args

--- a/sigmf_analyzer.py
+++ b/sigmf_analyzer.py
@@ -857,6 +857,110 @@ def dechirp(name, bw_hz=125000, sf=7, f_offset_hz=0.0, t0=None, t1=None, os=2, h
 
 
 # --------------------------------------------------------------------------
+# Segment 7 — cyclostationary symbol-rate detector. Digitally-modulated signals
+# are cyclostationary: their statistics repeat at the symbol rate even when the
+# *data* is random (so the symbol rate is NOT an ordinary spectral line). The
+# transition energy |x[n]-x[n-1]|^2 spikes at every symbol edge (amplitude or
+# phase change), so its spectrum shows a discrete line at the symbol rate and
+# its harmonics — a 2nd-order cyclic feature. This finds the baud when the
+# demodulator's run-length estimate is unsure. Targets amplitude/phase-transition
+# mods (OOK/ASK/PSK) well; FSK/very-weak signals may not show a clear line (the
+# strength readout says so). Pure core, selftested on synthetic signals.
+# --------------------------------------------------------------------------
+
+def _cyclic_profile(x, fs, amax_hz, n=700):
+    """Transition-energy spectrum over cycle frequency; returns (freqs_hz, prof)
+    normalised to its median. Pure numpy."""
+    import numpy as np
+    x = np.asarray(x)
+    if len(x) < 64:
+        return np.array([]), np.array([])
+    d = np.abs(np.diff(x)) ** 2
+    # high-pass: subtract a slow moving-average so the random-data low-frequency
+    # bulk doesn't swamp the (relatively sharp) symbol-rate transition line.
+    k = max(3, int(len(d) * 0.02))
+    d = d - np.convolve(d, np.ones(k) / k, mode="same")
+    w = np.hanning(len(d)).astype(np.float32)
+    F = np.abs(np.fft.rfft(d * w))
+    f = np.fft.rfftfreq(len(d), 1.0 / fs)
+    sel = (f > 0) & (f <= amax_hz)
+    F = F[sel]; f = f[sel]
+    if not len(F):
+        return np.array([]), np.array([])
+    prof = F / (np.median(F) + 1e-9)
+    if len(prof) > n:
+        idx = (np.arange(n + 1) * len(prof) / n).astype(int)
+        prof = np.array([prof[idx[i]:max(idx[i] + 1, idx[i + 1])].max() for i in range(n)])
+        f = f[np.linspace(0, len(f) - 1, n).astype(int)]
+    return f, prof
+
+
+def _cyclic_peaks(f, prof, kmin=6.0, top=6):
+    """Local maxima of the cyclic profile above ``kmin`` (candidate symbol rates)."""
+    out = []
+    for i in range(2, len(prof) - 1):
+        if prof[i] > prof[i - 1] and prof[i] >= prof[i + 1] and prof[i] > kmin:
+            out.append((float(prof[i]), float(f[i])))
+    out.sort(reverse=True)
+    return out[:top]
+
+
+def _fundamental_rate(peaks):
+    """Symbol rate = the fundamental of the cyclic peaks (their harmonics sit at
+    k·f0). Score each peak freq by how many strong peaks are ~integer multiples;
+    prefer more multiples, then the smaller frequency. Pure."""
+    if not peaks:
+        return None
+    top = peaks[0][0]
+    strong = [fr for st, fr in peaks if st >= 0.5 * top]
+    best = None
+    for _, f0 in peaks:
+        if f0 <= 0:
+            continue
+        score = sum(1 for fr in strong
+                    if round(fr / f0) >= 1 and abs(fr / f0 - round(fr / f0)) < 0.06)
+        key = (score, -f0)
+        if best is None or key > best[0]:
+            best = (key, f0)
+    return best[1] if best else peaks[0][1]
+
+
+def cyclic(name, f_offset_hz=0.0, t0=None, t1=None, amax_hz=None):
+    """Cyclostationary symbol-rate profile over a selection. Peaks at the symbol
+    rate (and harmonics). Returns the profile curve + candidate symbol rates with
+    a strength; ``locked`` when the top peak is confident."""
+    import numpy as np
+    iq, fs, fc, _ = load(name)
+    i0 = 0 if t0 is None else max(0, int(float(t0) * fs))
+    i1 = len(iq) if t1 is None else min(len(iq), int(float(t1) * fs))
+    x = iq[i0:i1] if i1 > i0 else iq
+    if len(x) < 256:
+        return {"ok": False, "error": "selection too short"}
+    foff = float(f_offset_hz or 0.0)
+    if foff:
+        x = x * np.exp(-2j * np.pi * (foff / fs) * np.arange(len(x)))
+    amax = float(amax_hz) if amax_hz else min(fs / 4.0, 100000.0)
+    amax = max(1000.0, min(amax, fs / 2.0))
+    f, prof = _cyclic_profile(x, fs, amax)
+    if not len(f):
+        return {"ok": False, "error": "could not compute cyclic profile"}
+    peaks = _cyclic_peaks(f, prof)
+    fund = _fundamental_rate(peaks)
+    # strength credited to the fundamental = the strongest peak near it or a harmonic
+    fstr = 0.0
+    for st, fr in peaks:
+        if fund and abs(fr / fund - round(fr / fund)) < 0.06:
+            fstr = max(fstr, st)
+    return {"ok": True, "amax_hz": round(amax, 1),
+            "freqs_hz": [round(v, 1) for v in f.tolist()],
+            "profile": [round(v, 2) for v in prof.tolist()],
+            "peaks": [{"symbol_rate_hz": round(fr, 1), "strength": round(st, 1)} for st, fr in peaks],
+            "top_symbol_rate_hz": round(fund, 1) if fund else None,
+            "top_strength": round(fstr, 1),
+            "locked": bool(fund and fstr >= 8.0)}
+
+
+# --------------------------------------------------------------------------
 # Segment 4 — protocol framework: line coding, preamble/sync detection,
 # repeated-frame alignment (fixed code vs rolling bits) and a CRC/checksum
 # scanner. All pure string/int math — the demodulator recovers the bits, this
@@ -1584,6 +1688,33 @@ def selftest():
         check("lora: wrong SF does not lock (quality drops)", _qw < _q / 3, str(round(_qw, 1)))
         check("lora: grid is chips×symbols", _grid is not None and _grid.shape == (_M, len(_true)))
         check("lora: bw/sf validation", dechirp("synth", bw_hz=125000, sf=99).get("ok") is False)
+        # --- Segment 7: cyclostationary symbol-rate detector (pure core) ---
+        from scipy import signal as _sg
+        _fs = 1_000_000.0
+        def _ook(baud):
+            sps = int(_fs / baud); nbb = 300; bits = np.random.randint(0, 2, nbb).astype(float)
+            k = max(2, sps // 8)
+            env = _sg.lfilter(np.ones(k) / k, 1, np.repeat(bits, sps))
+            return env + (np.random.randn(nbb * sps) + 1j * np.random.randn(nbb * sps)) * 0.03
+        # high baud: confident lock; mid baud: found (strength scales with baud/SNR)
+        _f, _p = _cyclic_profile(_ook(20000), _fs, 70000)
+        _pk = _cyclic_peaks(_f, _p)
+        check("cyclo: OOK 20000 baud found + confident",
+              bool(_pk) and abs(_pk[0][1] - 20000) < 1000 and _pk[0][0] >= 8, str(_pk[0] if _pk else None))
+        _f, _p = _cyclic_profile(_ook(5000), _fs, 17500)
+        _fund = _fundamental_rate(_cyclic_peaks(_f, _p, kmin=4.0))
+        check("cyclo: OOK 5000 baud found via fundamental (harmonics rejected)",
+              _fund is not None and abs(_fund - 5000) < 400, str(_fund))
+        _sps = 200; _nb = 300; _sy = (np.random.randint(0, 2, _nb) * 2 - 1).astype(float)
+        _xb = _sg.lfilter(np.ones(_sps // 8) / (_sps // 8), 1, np.repeat(_sy, _sps)) \
+            * np.exp(2j * np.pi * 1500 * np.arange(_nb * _sps) / _fs) \
+            + (np.random.randn(_nb * _sps) + 1j * np.random.randn(_nb * _sps)) * 0.03
+        _f, _p = _cyclic_profile(_xb, _fs, 20000); _fb = _fundamental_rate(_cyclic_peaks(_f, _p))
+        check("cyclo: BPSK 5000 baud found via fundamental", _fb is not None and abs(_fb - 5000) < 300, str(_fb))
+        _xc = np.exp(2j * np.pi * 1000 * np.arange(80000) / _fs) \
+            + (np.random.randn(80000) + 1j * np.random.randn(80000)) * 0.03
+        _f, _p = _cyclic_profile(_xc, _fs, 20000)
+        check("cyclo: CW shows no confident symbol rate", not _cyclic_peaks(_f, _p, kmin=8.0), str(_p.max()))
         # --- SigMF annotations round-trip ---
         _b = _box_to_annotation(0.08, 0.12, 434_040_000, 434_060_000, "OOK burst", 1_000_000.0)
         check("annot: box -> SigMF annotation (samples + freq edges + label)",


### PR DESCRIPTION
Find the symbol rate even when the data is random — a cyclic feature an ordinary PSD can't show, and the fix for when demod/autocorr are unsure of the baud.

- sigmf_analyzer: _cyclic_profile (transition-energy |x[n]-x[n-1]|^2 spectrum, high-passed so the random-data low-freq bulk doesn't swamp the symbol-rate line) + _cyclic_peaks + _fundamental_rate (resolve the fundamental from its harmonics) + cyclic() (profile curve, candidate symbol rates w/ strength, lock). Route /analyze/cyclic.
- rf_analyzer.html: a Cyclostationary card — profile plot with peak markers, a symbol-rate + lock readout, and clickable candidate rates that set the symbol tool's baud.

Validated: 4 new selftests (59/59), stable across repeated random runs — OOK 5k/20k and BPSK land on the true baud (harmonics resolved to the fundamental), CW shows no confident feature. HONEST: targets amplitude/phase-transition mods (OOK/ASK/PSK); FSK / very weak / very low baud read low-confidence (strength says so). A symbol-rate cyclic feature, not the full 2-D SCF surface.