### PR TITLE
feat(rf-analyzer): upload/import recordings (Flipper .sub, raw IQ, Si…

### DIFF
--- a/demos/rf_analyzer.html
+++ b/demos/rf_analyzer.html
@@ -129,6 +129,7 @@
     <span class="lbl">Capture</span>
     <select id="cap"><option value="">— loading… —</option></select>
     <button id="reload" title="Refresh the capture list">&#8635;</button>
+    <button id="uploadbtn" title="Import a recording — Flipper .sub, raw IQ, or a SigMF pair">⤴ Upload</button>
     <span class="lbl">Palette</span>
     <div class="seg" id="palette"></div>
     <span class="spacer"></span>
@@ -139,6 +140,19 @@
   <div id="kbdpop" class="kbdpop" hidden>
     <b>Keyboard shortcuts</b>
     <div><kbd>R</kbd> reset zoom · <kbd>B</kbd> back · <kbd>[</kbd>/<kbd>]</kbd> palette · <kbd>Z</kbd>/<kbd>X</kbd>/<kbd>C</kbd> zoom/measure/annotate · <kbd>D</kbd> demodulate · <kbd>L</kbd> copy link · <kbd>?</kbd> this help</div>
+  </div>
+  <div id="uploadpop" class="kbdpop" hidden>
+    <b>Import a recording</b>
+    <div style="margin-top:6px"><input type="file" id="upfile" multiple></div>
+    <div id="uprawopts" class="symbar" style="margin-top:8px" hidden>
+      <span class="lbl">Raw IQ</span>
+      <span class="lbl">datatype</span>
+      <select id="updtype"><option>cu8</option><option>cs8</option><option>cs16</option><option>cf32</option></select>
+      <span class="lbl">sample rate</span><input id="uprate" size="9" placeholder="Hz e.g. 2000000">
+      <span class="lbl">centre</span><input id="upfreq" size="7" placeholder="MHz">
+    </div>
+    <div style="margin-top:8px"><button id="updo" class="go">Import</button> <span id="upstat" class="symout"></span></div>
+    <div style="margin-top:6px;color:var(--muted)"><b>Flipper .sub</b> (RAW → synthesised OOK) · <b>SigMF</b> (select both the .sigmf-meta and .sigmf-data) · <b>raw IQ</b> (.cu8/.cs8/.cs16/.cf32 — set datatype + sample rate + centre). Keep files under ~50&nbsp;MB on a 512&nbsp;MB Pi.</div>
   </div>
 
   <div class="stats" id="stats"></div>
@@ -1008,6 +1022,40 @@
     else { try{ var ta=document.createElement('textarea'); ta.value=url; document.body.appendChild(ta); ta.select(); document.execCommand('copy'); ta.remove(); done(true); }catch(e){ done(false); } }
   });
   $('kbdhelp').addEventListener('click',function(){ $('kbdpop').hidden=!$('kbdpop').hidden; });
+
+  // ---- upload / import (Flipper .sub · raw IQ · SigMF pair) ----
+  $('uploadbtn').addEventListener('click',function(){ $('uploadpop').hidden=!$('uploadpop').hidden; });
+  $('upfile').addEventListener('change',function(){
+    var fs=Array.prototype.slice.call($('upfile').files||[]);
+    // raw-IQ params only matter when a file isn't a .sub or SigMF sidecar
+    var needsRaw=fs.some(function(f){ return !/\.(sub|sigmf-meta|sigmf-data)$/i.test(f.name); });
+    $('uprawopts').hidden=!needsRaw;
+  });
+  $('updo').addEventListener('click',function(){
+    var fs=Array.prototype.slice.call($('upfile').files||[]);
+    if(!fs.length){ $('upstat').textContent='pick a file first'; return; }
+    var subs=fs.filter(function(f){return /\.sub$/i.test(f.name);});
+    var metas=fs.filter(function(f){return /\.sigmf-meta$/i.test(f.name);});
+    var datas=fs.filter(function(f){return /\.sigmf-data$/i.test(f.name);});
+    var others=fs.filter(function(f){return !/\.(sub|sigmf-meta|sigmf-data)$/i.test(f.name);});
+    var jobs=[];
+    subs.forEach(function(f){ var fd=new FormData(); fd.append('file',f); jobs.push(fd); });
+    if(metas.length&&datas.length){ var fd=new FormData(); fd.append('file',datas[0]); fd.append('meta',metas[0]); jobs.push(fd); }
+    else if(metas.length||datas.length){ $('upstat').textContent='SigMF needs BOTH the .sigmf-meta and .sigmf-data'; return; }
+    others.forEach(function(f){ var fd=new FormData(); fd.append('file',f);
+      fd.append('datatype',$('updtype').value); fd.append('sample_rate',($('uprate').value||'').trim());
+      fd.append('frequency',String((parseFloat($('upfreq').value)||0)*1e6)); jobs.push(fd); });
+    if(!jobs.length){ $('upstat').textContent='nothing to import'; return; }
+    $('upstat').textContent='importing…';
+    var last=null, msgs=[];
+    jobs.reduce(function(p,fd){ return p.then(function(){
+      return fetch('/api/net/rtl/analyze/upload',{method:'POST',body:fd}).then(function(r){return r.json();}).then(function(r){
+        if(r&&r.ok){ last=r.name; msgs.push('✓ '+esc(r.name)); } else { msgs.push('⚠ '+esc((r&&r.error)||'failed')); } });
+    }); }, Promise.resolve()).then(function(){
+      $('upstat').innerHTML=msgs.join(' · ');
+      if(last){ loadList(last); setTimeout(function(){ $('uploadpop').hidden=true; $('upfile').value=''; },1200); }
+    }).catch(function(){ $('upstat').textContent='upload request failed'; });
+  });
 
   // ---- keyboard shortcuts (ignored while typing in a field) ----
   function palStep(dir){ var i=ORDER.indexOf(pal); if(i<0)i=0; var next=ORDER[(i+dir+ORDER.length)%ORDER.length];

--- a/docs/rf-analyzer-roadmap.md
+++ b/docs/rf-analyzer-roadmap.md
@@ -191,6 +191,20 @@ Turn "here are bits" into "here is what it says."
   filter), absolute-phase ambiguity resolved only by the differential decode; it's
   a constellation demod, not a full frame decoder — pair it with Frames / CRC.
 
+## Upload / import ✅ shipped (out-of-band, user-requested)
+Bring recordings from other tools into the capture list (an **⤴ Upload** button):
+- **Flipper Zero `.sub` (RAW)** → not IQ but an OOK pulse-timing list, so a
+  baseband IQ waveform is **synthesised** (carrier on/off at the file's frequency)
+  and it opens as a real burst — spectrogram/demod/frames/CRC all work.
+- **Raw IQ** (`.cu8/.cs8/.cs16/.cf32`) → a SigMF meta wrapper is written from the
+  datatype / sample-rate / centre-freq you give.
+- **SigMF** (meta + data) recorded elsewhere → stored as-is.
+`load()` was extended to decode cf32/cs16/cu16 alongside cu8/cs8. Pure helpers
+(`parse_flipper_sub` / `flipper_raw_to_cu8` / `import_*`) selftested (77/77 incl.
+a Flipper .sub → loadable OOK capture → bursts); route `POST /analyze/upload`
+(size-capped, names sanitised, bytes read as data only). *Left for later:*
+WAV-IQ, decoded (protocol) `.sub` re-synthesis, `.sigmf` tar archives.
+
 ## Segment 10 — Multi-signal & long captures  (next)
 - **Tiled / decimated spectrogram overview** for long or large captures — pan/zoom
   without loading the whole file (Pi-Zero-safe; overlaps the skipped Segment 5).

--- a/docs/rf-waterfall.md
+++ b/docs/rf-waterfall.md
@@ -230,6 +230,19 @@ that requests windows:
   read and a scatter plot, plus rotation-invariant differential bits. PSK only,
   no QAM — see the [roadmap](rf-analyzer-roadmap.md) (Segment 9) for the honest
   scope.
+- **Upload / import** — an **⤴ Upload** button brings recordings from other
+  tools into the capture list so every analyzer tool works on them:
+  - **Flipper Zero `.sub` (RAW)** — a `.sub` isn't IQ, it's an OOK pulse-timing
+    list, so Ragnar **synthesises a baseband IQ waveform** from it (carrier
+    on/off at the file's frequency, +40 kHz off DC). It then opens as a real
+    burst — spectrogram, demod, frames/CRC all work. (Decoded *protocol* `.sub`
+    files have no RAW data; re-record as **Read RAW** on the Flipper.)
+  - **Raw IQ** (`.cu8`/`.cs8`/`.cs16`/`.cf32`) — you supply the datatype, sample
+    rate and centre frequency, and a SigMF `.sigmf-meta` wrapper is written.
+  - **SigMF** (`.sigmf-meta` + `.sigmf-data`) recorded on another SDR/box —
+    stored as-is (any datatype the loader understands: cu8/cs8/cs16/cu16/cf32).
+  Untrusted input is sanitised, size-capped (keep under ~50 MB on a 512 MB Pi),
+  and read only as data. Route `POST /analyze/upload`.
 
 - **Ask the RF analyst (AI)** — when Ragnar's AI service is enabled (Settings ›
   AI), the analyzer shows an assistant card that reuses that service

--- a/network_diagnostics.py
+++ b/network_diagnostics.py
@@ -22236,6 +22236,52 @@ def register_network_diagnostics(app, logger=None):
                         baud_hz=_fl(a.get('baud')),
                         order=int(_order) if _order else None)
 
+    @app.route('/api/net/rtl/analyze/upload', methods=['POST'])
+    def net_rtl_analyze_upload():
+        # Import a recording from another tool as a capture: Flipper .sub RAW,
+        # raw IQ (+ datatype/rate/freq), or a SigMF pair. Untrusted bytes — read
+        # as data only, size-capped so a small board can't OOM.
+        _MAX = 80 * 1024 * 1024
+        files = request.files
+        main = files.get('file')
+        if not main or not main.filename:
+            return jsonify({"ok": False, "error": "no file uploaded"})
+        fname = main.filename
+        data = main.read()
+        if len(data) > _MAX:
+            return jsonify({"ok": False, "error": "file too large (%d MB) — keep uploads under 80 MB for on-box analysis"
+                            % (len(data) // (1024 * 1024))})
+        low = fname.lower()
+        try:
+            if low.endswith('.sub'):
+                r = sigmf_analyzer.import_flipper_sub(data.decode('utf-8', 'replace'), fname)
+            elif (low.endswith('.sigmf-meta') or low.endswith('.sigmf-data')
+                  or files.get('meta') or files.get('data')):
+                metaf, dataf = files.get('meta'), files.get('data')
+                if low.endswith('.sigmf-meta'):
+                    meta_text = data.decode('utf-8', 'replace')
+                    db = dataf.read() if dataf else b''
+                    dn = dataf.filename if dataf else fname
+                elif low.endswith('.sigmf-data'):
+                    db, dn = data, fname
+                    meta_text = metaf.read().decode('utf-8', 'replace') if metaf else ''
+                else:
+                    meta_text = metaf.read().decode('utf-8', 'replace') if metaf else ''
+                    db = dataf.read() if dataf else b''
+                    dn = dataf.filename if dataf else fname
+                if not meta_text or not db:
+                    return jsonify({"ok": False, "error": "SigMF needs both the .sigmf-meta and .sigmf-data files"})
+                if len(db) > _MAX:
+                    return jsonify({"ok": False, "error": "the .sigmf-data is too large — keep under 80 MB"})
+                r = sigmf_analyzer.import_sigmf(meta_text, db, dn)
+            else:
+                r = sigmf_analyzer.import_raw_iq(data, fname, request.form.get('datatype', 'cu8'),
+                                                 _fl(request.form.get('sample_rate')),
+                                                 _fl(request.form.get('frequency')))
+        except Exception as exc:                     # never leak a stack to the page
+            return jsonify({"ok": False, "error": "import failed: " + str(exc)})
+        return jsonify(r)
+
     @app.route('/api/net/rtl/analyze/frames', methods=['GET'])
     def net_rtl_analyze_frames():
         a = request.args

--- a/sigmf_analyzer.py
+++ b/sigmf_analyzer.py
@@ -72,12 +72,25 @@ def load(name):
     fs = float(g.get("core:sample_rate") or 0) or 1.0
     fc = float(cap0.get("core:frequency") or 0)
     dtype = (g.get("core:datatype") or "cu8").lower()
-    raw = np.fromfile(data_p, dtype=np.uint8)
-    raw = raw[: (raw.size // 2) * 2]                 # whole I/Q pairs only
-    if dtype.startswith("cs8"):                       # signed 8-bit
+    # Decode the common SigMF/SDR interleaved-IQ datatypes to normalised complex64.
+    if dtype.startswith("cf64"):                      # complex float64
+        a = np.fromfile(data_p, dtype="<f8"); a = a[: (a.size // 2) * 2].astype(np.float32)
+        iq = a[0::2] + 1j * a[1::2]
+    elif dtype.startswith("cf32"):                    # complex float32 (GNU Radio, IQEngine)
+        a = np.fromfile(data_p, dtype="<f4"); a = a[: (a.size // 2) * 2]
+        iq = a[0::2] + 1j * a[1::2]
+    elif dtype.startswith("ci16") or dtype.startswith("cs16"):   # signed 16-bit
+        a = np.fromfile(data_p, dtype="<i2").astype(np.float32); a = a[: (a.size // 2) * 2]
+        iq = (a[0::2] + 1j * a[1::2]) / 32768.0
+    elif dtype.startswith("cu16"):                    # unsigned 16-bit
+        a = np.fromfile(data_p, dtype="<u2").astype(np.float32) - 32768.0; a = a[: (a.size // 2) * 2]
+        iq = (a[0::2] + 1j * a[1::2]) / 32768.0
+    elif dtype.startswith("cs8") or dtype.startswith("ci8"):     # signed 8-bit
+        raw = np.fromfile(data_p, dtype=np.uint8); raw = raw[: (raw.size // 2) * 2]
         s = raw.astype(np.int8).astype(np.float32)
         iq = (s[0::2] + 1j * s[1::2]) / 128.0
     else:                                             # cu8 (default): unsigned 8-bit
+        raw = np.fromfile(data_p, dtype=np.uint8); raw = raw[: (raw.size // 2) * 2]
         f = raw.astype(np.float32) - 127.5
         iq = (f[0::2] + 1j * f[1::2]) / 127.5
     iq = iq.astype(np.complex64)
@@ -1607,6 +1620,203 @@ def parse_ai_actions(text):
 
 
 # --------------------------------------------------------------------------
+# Upload / import — bring recordings from OTHER tools into the capture list so
+# every analyzer tool works on them. Three kinds:
+#   * SigMF (.sigmf-meta + .sigmf-data)  -> stored as-is (any datatype load()
+#     understands).
+#   * Raw IQ (.cu8/.cs8/.cs16/.cf32/…)   -> a .sigmf-meta wrapper is written from
+#     the sample-rate / centre-freq / datatype the user supplies.
+#   * Flipper Zero .sub RAW              -> it isn't IQ, it's an OOK pulse-timing
+#     list, so a baseband IQ waveform is SYNTHESISED from it (carrier on/off) and
+#     it opens as a real burst (spectrogram + demod + frames/CRC all work).
+# Untrusted input: names are sanitised, size is capped by the caller, and the
+# bytes are only ever read as data (numpy), never executed. Pure parse/synth
+# helpers are selftested.
+# --------------------------------------------------------------------------
+
+# datatypes load() can decode (so an uploaded raw file / SigMF actually opens)
+_IMPORT_DTYPES = ("cu8", "cs8", "ci8", "cs16", "ci16", "ci16_le", "cu16",
+                  "cu16_le", "cf32", "cf32_le", "cf64", "cf64_le")
+
+
+def _unique_name(stem):
+    """A capture name (sanitised) that doesn't clash with an existing capture."""
+    base = _safe(stem) or "upload"
+    d = _cap_dir()
+    name, i = base, 1
+    while os.path.exists(os.path.join(d, name + ".sigmf-meta")):
+        name = base + "-" + str(i); i += 1
+    return name
+
+
+def _write_capture(name, data_bytes, fs, fc, datatype, description=None):
+    """Write a .sigmf-data + .sigmf-meta pair into the capture dir. Returns name."""
+    from datetime import datetime, timezone
+    os.makedirs(_cap_dir(), exist_ok=True)
+    data_p, meta_p = _paths(name)
+    with open(data_p, "wb") as fh:
+        fh.write(data_bytes)
+    g = {"core:datatype": datatype, "core:sample_rate": float(fs), "core:version": "1.0.0"}
+    if description:
+        g["core:description"] = description
+    meta = {"global": g,
+            "captures": [{"core:sample_start": 0, "core:frequency": float(fc or 0),
+                          "core:datetime": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")}],
+            "annotations": []}
+    with open(meta_p, "w") as fh:
+        json.dump(meta, fh)
+    return name
+
+
+def parse_flipper_sub(text):
+    """Parse a Flipper Zero Sub-GHz .sub file (pure).
+
+    RAW captures carry ``RAW_Data:`` lines of signed µs durations (+ = carrier
+    on, − = off). Returns {ok, kind:'raw', freq_hz, preset, modulation, pulses,
+    n_pulses, total_us}. Decoded (protocol) .sub files have no RAW_Data — those
+    return {ok:False, kind:'protocol', …} with a helpful message.
+    """
+    freq = None; preset = None; proto = None; pulses = []; kv = {}
+    for line in (text or "").splitlines():
+        line = line.strip()
+        if not line or ":" not in line:
+            continue
+        k, v = line.split(":", 1); k = k.strip(); v = v.strip()
+        if k == "Frequency":
+            try: freq = int(float(v))
+            except ValueError: pass
+        elif k == "Preset":
+            preset = v
+        elif k == "Protocol":
+            proto = v
+        elif k == "RAW_Data":
+            for tok in v.split():
+                try: pulses.append(int(tok))
+                except ValueError: pass
+        else:
+            kv[k] = v
+    mod = "OOK" if (preset and "ook" in preset.lower()) else \
+          ("FSK" if (preset and "fsk" in preset.lower()) else "OOK")
+    if pulses:
+        return {"ok": True, "kind": "raw", "freq_hz": freq, "preset": preset,
+                "protocol": proto, "modulation": mod, "pulses": pulses,
+                "n_pulses": len(pulses), "total_us": sum(abs(p) for p in pulses)}
+    return {"ok": False, "kind": "protocol", "freq_hz": freq, "preset": preset,
+            "protocol": proto, "fields": kv,
+            "error": "This is a decoded (protocol) .sub, not a RAW capture. On the "
+                     "Flipper use Read RAW (or Sub-GHz → Read RAW) and import that .sub."}
+
+
+def flipper_raw_to_cu8(pulses, fs=250000.0, off_hz=40000.0, amp=0.6, noise=0.02,
+                       max_samples=12_000_000):
+    """Synthesise a baseband cu8 IQ waveform from Flipper RAW pulses (pure).
+
+    OOK: +duration → carrier on, −duration → off. The carrier sits at +off_hz so
+    it isn't glued to DC. Returns (interleaved-cu8 bytes, actual fs) — fs is
+    reduced if the run would exceed max_samples so a small board can't OOM.
+    """
+    import numpy as np
+    total_us = sum(abs(int(p)) for p in pulses)
+    if total_us <= 0:
+        return b"", fs
+    n = int(total_us * 1e-6 * fs)
+    if n > max_samples:                    # keep it Pi-safe: stretch the sample period to fit
+        fs = fs * max_samples / n; n = max_samples
+    env = np.zeros(n, dtype=np.float32); idx = 0
+    for p in pulses:
+        ns = int(round(abs(int(p)) * 1e-6 * fs))
+        if ns <= 0:
+            continue
+        end = idx + ns
+        if end > n: end = n
+        if int(p) > 0:
+            env[idx:end] = 1.0
+        idx = end
+        if idx >= n:
+            break
+    t = np.arange(n)
+    iq = (env * amp) * np.exp(2j * np.pi * (off_hz / fs) * t)
+    iq = iq + (np.random.randn(n) + 1j * np.random.randn(n)).astype(np.complex64) * noise
+    I = np.clip(np.round(iq.real * 127.5 + 127.5), 0, 255).astype(np.uint8)
+    Q = np.clip(np.round(iq.imag * 127.5 + 127.5), 0, 255).astype(np.uint8)
+    inter = np.empty(2 * n, dtype=np.uint8); inter[0::2] = I; inter[1::2] = Q
+    return inter.tobytes(), fs
+
+
+def import_flipper_sub(text, filename="flipper.sub"):
+    """Import a Flipper .sub RAW capture: synthesise IQ, write it, return {ok,name,…}."""
+    p = parse_flipper_sub(text)
+    if not p.get("ok"):
+        return p
+    freq = p.get("freq_hz") or 433_920_000
+    off = 40000.0
+    data, fs = flipper_raw_to_cu8(p["pulses"], off_hz=off)
+    if not data:
+        return {"ok": False, "error": "no usable pulses in the .sub RAW data"}
+    stem = os.path.splitext(os.path.basename(filename))[0]
+    name = _unique_name("flipper-" + stem)
+    desc = ("Imported from Flipper .sub RAW"
+            + (" (" + p["preset"] + ")" if p.get("preset") else "")
+            + " — " + (p.get("modulation") or "OOK") + " envelope synthesised at +"
+            + str(int(off / 1000)) + " kHz")
+    _write_capture(name, data, fs, freq - off, "cu8", desc)   # centre offset so the signal sits at the .sub frequency
+    return {"ok": True, "name": name, "kind": "flipper", "freq_hz": freq,
+            "preset": p.get("preset"), "modulation": p.get("modulation"),
+            "n_pulses": p["n_pulses"], "sample_rate_hz": round(fs, 1),
+            "samples": len(data) // 2}
+
+
+def import_raw_iq(data_bytes, filename, datatype="cu8", sample_rate=0, frequency=0):
+    """Import a raw interleaved-IQ file by writing a SigMF meta wrapper for it."""
+    dt = (datatype or "cu8").lower()
+    if dt not in _IMPORT_DTYPES:
+        return {"ok": False, "error": "unsupported datatype '" + dt + "'"}
+    try:
+        fs = float(sample_rate or 0)
+    except (TypeError, ValueError):
+        fs = 0.0
+    if fs <= 0:
+        return {"ok": False, "error": "a sample rate is required for raw IQ"}
+    if not data_bytes:
+        return {"ok": False, "error": "empty file"}
+    stem = os.path.splitext(os.path.basename(filename or "rawiq"))[0]
+    name = _unique_name(stem)
+    _write_capture(name, data_bytes, fs, frequency or 0, dt, "Imported raw IQ (" + dt + ")")
+    return {"ok": True, "name": name, "kind": "raw_iq", "datatype": dt,
+            "sample_rate_hz": fs, "bytes": len(data_bytes)}
+
+
+def import_sigmf(meta_text, data_bytes, filename="capture"):
+    """Import a SigMF pair (meta JSON text + data bytes), stored as-is."""
+    try:
+        meta = json.loads(meta_text)
+    except (ValueError, TypeError):
+        return {"ok": False, "error": "invalid .sigmf-meta JSON"}
+    g = meta.get("global", {}) if isinstance(meta, dict) else {}
+    dt = (g.get("core:datatype") or "").lower()
+    if not dt:
+        return {"ok": False, "error": ".sigmf-meta is missing core:datatype"}
+    if not any(dt.startswith(x) for x in ("cu8", "cs8", "ci8", "cs16", "ci16",
+                                          "cu16", "cf32", "cf64")):
+        return {"ok": False, "error": "unsupported SigMF datatype '" + dt + "'"}
+    if not data_bytes:
+        return {"ok": False, "error": "empty .sigmf-data"}
+    stem = os.path.basename(filename or "capture")
+    for suf in (".sigmf-data", ".sigmf-meta", ".sigmf"):
+        if stem.endswith(suf):
+            stem = stem[:-len(suf)]; break
+    stem = os.path.splitext(stem)[0]
+    name = _unique_name(stem or "sigmf")
+    os.makedirs(_cap_dir(), exist_ok=True)
+    data_p, meta_p = _paths(name)
+    with open(data_p, "wb") as fh:
+        fh.write(data_bytes)
+    with open(meta_p, "w") as fh:
+        json.dump(meta, fh)
+    return {"ok": True, "name": name, "kind": "sigmf", "datatype": dt}
+
+
+# --------------------------------------------------------------------------
 # Self-test — synthesise a cu8 capture (tone + OOK burst) and check the DSP
 # --------------------------------------------------------------------------
 
@@ -1917,6 +2127,54 @@ def selftest():
         d433 = decode433("synth")     # a tone+OOK synth won't match a real protocol
         check("rtl433: runs on a capture, returns a clean (empty) device list",
               d433.get("ok") is True and isinstance(d433.get("devices"), list), str(d433)[:120])
+        # --- Upload / import: Flipper .sub RAW, raw IQ, SigMF, extended datatypes ---
+        import numpy as np
+        # a Flipper RAW .sub: repeated OOK bursts (500us on / 500us off) at 433.92 MHz
+        _pulses = " ".join((["500 -500"] * 20 + ["-4000"]) * 3)
+        _sub = ("Filetype: Flipper SubGhz RAW File\nVersion: 1\nFrequency: 433920000\n"
+                "Preset: FuriHalSubGhzPresetOok650Async\nProtocol: RAW\nRAW_Data: " + _pulses + "\n")
+        _pf = parse_flipper_sub(_sub)
+        check("import: Flipper .sub RAW parsed (freq + pulses)",
+              _pf["ok"] and _pf["freq_hz"] == 433_920_000 and _pf["n_pulses"] > 100
+              and _pf["modulation"] == "OOK", str({k: _pf.get(k) for k in ("ok", "freq_hz", "n_pulses")}))
+        _fr = import_flipper_sub(_sub, "garage.sub")
+        check("import: Flipper .sub -> a loadable OOK capture at the right freq",
+              _fr["ok"] and abs(load(_fr["name"])[2] - (433_920_000 - 40000)) < 1, str(_fr)[:120])
+        _fb = bursts(_fr["name"])
+        check("import: synthesised Flipper capture shows OOK bursts",
+              _fb["ok"] and _fb["count"] >= 1, str(_fb.get("count")))
+        _fp = parse_flipper_sub("Filetype: Flipper SubGhz RAW File\nFrequency: 433920000\n"
+                                "Protocol: Princeton\nKey: 00 00 00 00 12 34 56\nBit: 24\nTE: 400\n")
+        check("import: decoded (protocol) .sub is rejected with guidance",
+              _fp["ok"] is False and _fp["kind"] == "protocol" and "RAW" in _fp["error"])
+        # raw IQ (cf32) round-trips: write a tone, import, load it back
+        _n = 20000; _tt = np.arange(_n) / 1_000_000.0
+        _tone = np.exp(2j * np.pi * 120000 * _tt).astype(np.complex64)
+        _cf32 = np.empty(_n * 2, dtype=np.float32); _cf32[0::2] = _tone.real; _cf32[1::2] = _tone.imag
+        _ri = import_raw_iq(_cf32.tobytes(), "tone.cf32", "cf32", 1_000_000, 433_000_000)
+        check("import: raw cf32 IQ imported + wrapped as SigMF", _ri["ok"], str(_ri)[:120])
+        _sm = summary(_ri["name"])
+        check("import: cf32 capture loads + peak near +120 kHz",
+              _sm["ok"] and abs(_sm["peak_offset_hz"] - 120000) < 6000, str(_sm.get("peak_offset_hz")))
+        check("import: raw IQ needs a sample rate",
+              import_raw_iq(b"\x00\x01", "x.cu8", "cu8", 0, 0).get("ok") is False)
+        check("import: unknown datatype rejected",
+              import_raw_iq(b"\x00", "x.zzz", "zzz", 1e6, 0).get("ok") is False)
+        # cs16 datatype decodes through the extended load()
+        _i16 = np.empty(_n * 2, dtype="<i2")
+        _i16[0::2] = (_tone.real * 20000).astype("<i2"); _i16[1::2] = (_tone.imag * 20000).astype("<i2")
+        _r16 = import_raw_iq(_i16.tobytes(), "tone16.cs16", "cs16", 1_000_000, 433_000_000)
+        check("import: cs16 raw IQ loads (extended datatypes)",
+              _r16["ok"] and summary(_r16["name"])["ok"], str(_r16)[:80])
+        # SigMF pair passthrough
+        _sd = (np.random.randint(0, 256, 4000, dtype=np.uint8)).tobytes()
+        _meta = json.dumps({"global": {"core:datatype": "cu8", "core:sample_rate": 1_000_000, "core:version": "1.0.0"},
+                            "captures": [{"core:sample_start": 0, "core:frequency": 868_000_000}], "annotations": []})
+        _si = import_sigmf(_meta, _sd, "elsewhere.sigmf-meta")
+        check("import: SigMF pair stored + listed",
+              _si["ok"] and any(c["name"] == _si["name"] for c in list_captures()["captures"]), str(_si)[:80])
+        check("import: SigMF meta without datatype rejected",
+              import_sigmf('{"global":{}}', b"\x00", "x").get("ok") is False)
     finally:
         globals()["_cap_dir"] = saved
         import shutil


### PR DESCRIPTION
An Upload button on the analyzer brings recordings from other tools into the capture list, so every existing tool (spectrogram/demod/frames/CRC/ constellation/…) works on them:

- Flipper Zero .sub (RAW): it's not IQ, it's an OOK pulse-timing list, so a baseband IQ waveform is SYNTHESISED from it (carrier on/off at the file's frequency, +40 kHz off DC) and opens as a real burst. Decoded (protocol) .sub files are rejected with guidance to Read RAW instead.
- Raw IQ (.cu8/.cs8/.cs16/.cf32): a SigMF meta wrapper is written from the datatype/sample-rate/centre-freq the user supplies.
- SigMF (.sigmf-meta + .sigmf-data) recorded elsewhere: stored as-is.

load() extended to decode cf32/cs16/cu16 alongside cu8/cs8. Pure helpers parse_flipper_sub / flipper_raw_to_cu8 / import_flipper_sub / import_raw_iq / import_sigmf; route POST /api/net/rtl/analyze/upload (untrusted bytes: names sanitised, 80 MB cap, read as data only). Uploads land in data/iq_captures so they appear in the analyzer dropdown and the RF Waterfall Sessions list.

77/77 selftests (incl. Flipper .sub -> loadable OOK capture -> bursts, cf32/cs16 round-trip, SigMF passthrough, error paths). Proven on-box: a garage-style .sub imported and demodulated to its exact 2500-baud bits.