### PR TITLE
Make the SPI TFT kiosk mode-aware (Ragnar + Pwnagotchi)

### DIFF
--- a/docs/PWNAGOTCHI.md
+++ b/docs/PWNAGOTCHI.md
@@ -274,6 +274,71 @@ The one-shot flags are what Pwnagotchi's own web UI MANU/AUTO buttons write, so 
 
 ---
 
+## 🖥️ All-in-one SPI TFT kiosk (both modes on one screen)
+
+If you run Ragnar + Pwnagotchi as an all-in-one box (e.g. a Pi 5 with a 3.5"
+MPI3501/ILI9486 SPI TFT and ADS7846 touch), you can have the little screen mirror
+the web UI of whichever mode is active:
+
+```bash
+sudo bash scripts/install_tft35_kiosk.sh
+sudo reboot
+```
+
+The kiosk is **mode-aware**. Because Ragnar and Pwnagotchi never run at the same
+time — switching to Pwnagotchi stops `ragnar.service` (and `:8000`) and serves the
+Pwnagotchi web UI on `:8080` — a fixed-URL kiosk would show a dead page for the
+whole time you were hunting. Instead the runner (`scripts/ragnar_tft_kiosk.sh`)
+points Chromium at whichever UI answers and relaunches it when you swap:
+
+| Active mode | On-screen |
+|-------------|-----------|
+| Ragnar      | `http://localhost:8000/?kiosk=1` |
+| Pwnagotchi  | `http://localhost:8080/` |
+
+Per-mode Chromium zoom is tunable via the service environment
+(`RAGNAR_TFT_RAGNAR_SCALE`, default `0.5` for the dense dashboard;
+`RAGNAR_TFT_PWN_SCALE`, default `1.0`).
+
+### Touch calibration
+
+The panel shows up as `ADS7846 Touchscreen`. The tap position depends on the
+display **rotation** you set on the overlay (`dtoverlay=tft35a:rotate=…`), so the
+touch axes have to be transformed to match. Test a matrix live (applies instantly,
+no restart) and, once taps land where you press, persist it:
+
+```bash
+# find the device + test live (drag a finger and watch the cursor track it)
+export DISPLAY=:1   # kiosk-tft runs X on :1
+xinput set-prop "ADS7846 Touchscreen" "Coordinate Transformation Matrix" <9 values>
+```
+
+Known-good transformation matrices by rotation (portrait 320×480 is `rotate=0`):
+
+| Overlay rotate | Orientation      | `Coordinate Transformation Matrix` |
+|----------------|------------------|------------------------------------|
+| `0`            | portrait         | `1 0 0 0 1 0 0 0 1` (identity; the installer adds a small `1 0 0.003 0 1 0.048 0 0 1` offset for the MPI3501) |
+| `90`           | landscape        | `0 -1 1 1 0 0 0 0 1` (verified on a Pi 5 + MPI3501) |
+| `180`          | portrait flipped | `-1 0 1 0 -1 1 0 0 1` |
+| `270`          | landscape flipped| `0 1 0 -1 0 1 0 0 1` |
+
+To make it permanent, drop it into an `xorg.conf.d` rule (matches by product name,
+so it's independent of the `/dev/input/eventN` number):
+
+```
+# /etc/X11/xorg.conf.d/98-touch-calibration.conf
+Section "InputClass"
+    Identifier "ADS7846 touch calibration"
+    MatchProduct "ADS7846 Touchscreen"
+    Option "TransformationMatrix" "0 -1 1 1 0 0 0 0 1"
+EndSection
+```
+
+Resistive panels tap most reliably with a stylus. If you only want a status
+display, disable touch entirely with `Option "Ignore" "on"` in the same block.
+
+---
+
 ## 🌐 API Endpoints
 
 | Method | Endpoint | Description |

--- a/scripts/install_tft35_kiosk.sh
+++ b/scripts/install_tft35_kiosk.sh
@@ -2,6 +2,13 @@
 # Ragnar SPI TFT kiosk installer — MPI3501 / ILI9486 3.5" display with ADS7846 touch.
 # Idempotent: safe to re-run; only installs what's missing.
 #
+# MODE-AWARE: the on-screen kiosk follows the active mode. Ragnar and its built-in
+# Pwnagotchi mode never run together (switching to Pwnagotchi stops ragnar.service
+# and :8000, and serves the Pwnagotchi web UI on :8080). The kiosk therefore points
+# Chromium at whichever UI is live — Ragnar (:8000) or Pwnagotchi (:8080) — and
+# relaunches on a mode switch, via scripts/ragnar_tft_kiosk.sh. This makes an
+# all-in-one box (Ragnar + Pwnagotchi + SPI TFT) show the right screen at all times.
+#
 # Supported displays (ILI9486 + ADS7846, standard GPIO pinout):
 #   - MPI3501 Display-F 3.5" 480x320 (tested)
 #   - Waveshare 3.5" (A)
@@ -246,38 +253,33 @@ echo "[tft35-kiosk] ragnar service drop-in written -> $RAGNAR_DROPIN"
 # ---------------------------------------------------------------------------
 # kiosk-tft systemd service
 # ---------------------------------------------------------------------------
+# Install the mode-aware kiosk runner (picks :8000 vs :8080 live, relaunches on switch)
+install -m 0755 "$REPO_ROOT/scripts/ragnar_tft_kiosk.sh" /usr/local/bin/ragnar-tft-kiosk
+echo "[tft35-kiosk] mode-aware runner installed -> /usr/local/bin/ragnar-tft-kiosk"
+
 cat > "$SERVICE_FILE" <<EOF
 [Unit]
-Description=Ragnar TFT Kiosk — Chromium on 3.5" SPI display (MPI3501/ILI9486)
+Description=Ragnar TFT Kiosk — Chromium on 3.5" SPI display (MPI3501/ILI9486), mode-aware
+# Ordered after ragnar.service but NOT Requires= it: in Pwnagotchi mode ragnar.service
+# is stopped, and the kiosk must keep running to show the Pwnagotchi UI on :8080.
 After=ragnar.service network.target
-Requires=ragnar.service
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
 [Service]
 User=$KIOSK_USER
-# Wait for Ragnar web server to be ready (up to 60s)
-ExecStartPre=/bin/bash -c 'for i in \$(seq 1 30); do curl -s http://localhost:8000 >/dev/null 2>&1 && break; sleep 2; done'
+# Wait for EITHER Ragnar (:8000) or Pwnagotchi (:8080) to answer — the box may boot
+# straight into Pwnagotchi mode, where :8000 never comes up.
+ExecStartPre=/bin/bash -c 'for i in \$(seq 1 30); do curl -s http://localhost:8000 >/dev/null 2>&1 && break; curl -s http://localhost:8080 >/dev/null 2>&1 && break; sleep 2; done'
+# Start X + touch calibration + hide cursor, then hand off to the mode-aware runner,
+# which points Chromium at whichever UI is live and relaunches it on a mode switch.
 ExecStart=/bin/bash -c '\\
     sudo Xorg :1 -nolisten tcp vt7 & \\
-    sleep 4 && \\
-    DISPLAY=:1 xinput set-prop "ADS7846 Touchscreen" "Coordinate Transformation Matrix" 1 0 0.003 0 1 0.048 0 0 1 && \\
+    sleep 4 ; \\
+    DISPLAY=:1 xinput set-prop "ADS7846 Touchscreen" "Coordinate Transformation Matrix" 1 0 0.003 0 1 0.048 0 0 1 ; \\
     DISPLAY=:1 unclutter -idle 0 -root & \\
-    exec DISPLAY=:1 $BROWSER_BIN \\
-        --no-sandbox \\
-        --kiosk \\
-        --noerrdialogs \\
-        --disable-infobars \\
-        --disable-session-crashed-bubble \\
-        --disable-restore-session-state \\
-        --disable-features=TranslateUI \\
-        --disable-pinch \\
-        --overscroll-history-navigation=0 \\
-        --disable-gpu \\
-        --force-device-scale-factor=0.5 \\
-        --touch-events=enabled \\
-        http://localhost:8000'
-ExecStop=/bin/bash -c 'pkill -f "$BROWSER_BIN.*localhost:8000"; pkill -f "Xorg :1"'
+    exec env DISPLAY=:1 RAGNAR_BROWSER=$BROWSER_BIN /usr/local/bin/ragnar-tft-kiosk'
+ExecStop=/bin/bash -c 'pkill -f ragnar-tft-kiosk; pkill -f "$BROWSER_BIN.*user-data-dir"; pkill -f "Xorg :1"'
 Restart=on-failure
 RestartSec=10
 

--- a/scripts/ragnar_tft_kiosk.sh
+++ b/scripts/ragnar_tft_kiosk.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Ragnar TFT kiosk runner — MODE-AWARE.
+#
+# Ragnar and its built-in Pwnagotchi mode never run at the same time: switching
+# to Pwnagotchi stops ragnar.service (so :8000 goes down) and brings up the
+# Pwnagotchi web UI on :8080, and switching back does the reverse. A kiosk hard-
+# wired to http://localhost:8000 therefore shows a dead "can't connect" page the
+# whole time you're in Pwnagotchi mode.
+#
+# This runner points Chromium at whichever UI is actually serving right now and
+# relaunches it when you switch modes, so the on-screen display always mirrors
+# the active mode with no manual intervention:
+#     Ragnar mode      -> http://localhost:8000/?kiosk=1
+#     Pwnagotchi mode  -> http://localhost:8080/
+#
+# It expects an X server to already be running (DISPLAY set) and a touch matrix /
+# unclutter already applied — the kiosk-tft.service ExecStart does that, then
+# execs this script. Runs as the kiosk user.
+#
+# Tunables (env, all optional):
+#   RAGNAR_BROWSER            chromium binary (default: autodetect chromium/chromium-browser)
+#   RAGNAR_TFT_RAGNAR_URL     default http://localhost:8000
+#   RAGNAR_TFT_PWN_URL        default http://localhost:8080
+#   RAGNAR_TFT_RAGNAR_SCALE   Chromium device scale for Ragnar (default 0.5 — dense dashboard)
+#   RAGNAR_TFT_PWN_SCALE      Chromium device scale for Pwnagotchi (default 1.0 — mostly the face)
+#   RAGNAR_TFT_POLL           seconds between mode checks (default 5)
+
+set -u
+
+: "${DISPLAY:=:1}"
+export DISPLAY
+
+BROWSER="${RAGNAR_BROWSER:-}"
+if [ -z "$BROWSER" ]; then
+    for b in chromium chromium-browser; do
+        command -v "$b" >/dev/null 2>&1 && { BROWSER="$b"; break; }
+    done
+fi
+if [ -z "$BROWSER" ]; then
+    echo "[tft-kiosk] FATAL: no chromium binary found" >&2
+    exit 1
+fi
+
+RAGNAR_URL="${RAGNAR_TFT_RAGNAR_URL:-http://localhost:8000}"
+PWN_URL="${RAGNAR_TFT_PWN_URL:-http://localhost:8080}"
+RAGNAR_SCALE="${RAGNAR_TFT_RAGNAR_SCALE:-0.5}"
+PWN_SCALE="${RAGNAR_TFT_PWN_SCALE:-1.0}"
+POLL="${RAGNAR_TFT_POLL:-5}"
+
+PROFILE="${HOME:-/home/ragnar}/.config/ragnar-tft-chromium"
+mkdir -p "$PROFILE" 2>/dev/null || true
+
+# Same hardened flags the TFT kiosk has always used, minus the fixed URL/scale
+# (those are chosen per mode below).
+BASE_ARGS=(
+    --no-sandbox
+    --kiosk
+    --noerrdialogs
+    --disable-infobars
+    --disable-session-crashed-bubble
+    --disable-restore-session-state
+    --disable-features=TranslateUI,Translate
+    --disable-pinch
+    --overscroll-history-navigation=0
+    --disable-gpu
+    --touch-events=enabled
+    --no-first-run
+    --check-for-update-interval=31536000
+    --disable-dev-shm-usage
+    --password-store=basic
+    --user-data-dir="$PROFILE"
+)
+
+# Which UI is live right now? Prefer Ragnar; fall back to Pwnagotchi. Prints
+# "<url>|<scale>", or "|" when neither answers (mid-switch — keep the last view).
+pick_target() {
+    if curl -fsS --max-time 2 -o /dev/null "${RAGNAR_URL}/" 2>/dev/null; then
+        echo "${RAGNAR_URL}/?kiosk=1|${RAGNAR_SCALE}"
+    elif curl -fsS --max-time 2 -o /dev/null "${PWN_URL}/" 2>/dev/null; then
+        echo "${PWN_URL}/|${PWN_SCALE}"
+    else
+        echo "|"
+    fi
+}
+
+launch() {
+    local url="$1" scale="$2"
+    # A crash/kill leaves the "restore pages?" state + a singleton lock behind;
+    # clearing both keeps a relaunch from stalling or nagging over the kiosk.
+    local prefs="$PROFILE/Default/Preferences"
+    [ -f "$prefs" ] && sed -i \
+        's/"exit_type":"[^"]*"/"exit_type":"Normal"/;s/"exited_cleanly":false/"exited_cleanly":true/' \
+        "$prefs" 2>/dev/null || true
+    rm -f "$PROFILE"/SingletonLock "$PROFILE"/SingletonSocket "$PROFILE"/SingletonCookie 2>/dev/null || true
+    "$BROWSER" "${BASE_ARGS[@]}" --force-device-scale-factor="$scale" --app="$url" >/dev/null 2>&1 &
+}
+
+_term() { pkill -f "user-data-dir=$PROFILE" 2>/dev/null || true; exit 0; }
+trap _term TERM INT
+
+echo "[tft-kiosk] mode-aware runner: DISPLAY=$DISPLAY browser=$BROWSER ragnar=$RAGNAR_URL pwn=$PWN_URL"
+
+CUR=""
+while true; do
+    sel="$(pick_target)"
+    url="${sel%|*}"
+    scale="${sel#*|}"
+    if [ -n "$url" ] && [ "$sel" != "$CUR" ]; then
+        echo "[tft-kiosk] $(date -Iseconds) -> $url (scale $scale)"
+        pkill -f "user-data-dir=$PROFILE" 2>/dev/null || true
+        sleep 1
+        launch "$url" "$scale"
+        CUR="$sel"
+    fi
+    sleep "$POLL"
+done

--- a/scripts/uninstall_tft35_kiosk.sh
+++ b/scripts/uninstall_tft35_kiosk.sh
@@ -20,6 +20,10 @@ fi
 rm -f /etc/systemd/system/kiosk-tft.service
 systemctl daemon-reload
 
+# Remove the mode-aware kiosk runner
+rm -f /usr/local/bin/ragnar-tft-kiosk
+echo "[tft35-kiosk-uninstall] removed /usr/local/bin/ragnar-tft-kiosk"
+
 # Remove ragnar service drop-in (restore wipe_epd pre-start)
 rm -f /etc/systemd/system/ragnar.service.d/tft.conf
 rmdir --ignore-fail-on-non-empty /etc/systemd/system/ragnar.service.d 2>/dev/null || true


### PR DESCRIPTION
The tft35 kiosk was hardwired to Ragnar's :8000 and hard-required ragnar.service, so in Pwnagotchi mode — where ragnar.service is stopped and the Pwnagotchi web UI serves on :8080 — the panel showed a dead "can't connect" page the whole time you were hunting.

Add scripts/ragnar_tft_kiosk.sh, a mode-aware runner that points Chromium at whichever UI is actually serving (:8000 Ragnar / :8080 Pwnagotchi) and relaunches it on a mode switch, with per-mode Chromium zoom. install_tft35_kiosk.sh now installs the runner, drops the hard Requires=ragnar.service (so the kiosk survives ragnar.service stopping in pwn mode), and waits for EITHER port before starting. Document the all-in-one setup plus ADS7846 touch calibration (transformation matrices per display rotation).

Verified on a Pi 5 + MPI3501/ILI9486 3.5" panel: the kiosk follows the active mode and switches both directions on the screen itself.